### PR TITLE
feat(web): sortable Authors columns, and a Books count that exists

### DIFF
--- a/changelog.d/1349-authors-column-sort.md
+++ b/changelog.d/1349-authors-column-sort.md
@@ -1,0 +1,17 @@
+### Added
+- **Sortable column headers on the Authors page**
+  ([#1349](https://github.com/vavallee/bindery/issues/1349)) — Name, Books,
+  Rating and Monitored are now clickable, ascending on the first click and
+  descending on a second, matching the Books page. This completes #1349, whose
+  Books half shipped in v1.28.0 while the Authors half never did. Sort keys are
+  whitelisted server-side and every new sort carries a name tiebreaker, so ties
+  cannot shuffle rows between pages of a paginated list.
+
+### Fixed
+- **The Books column on the Authors page shows a real count** — it rendered `—`
+  for every author, in every version that has had the column. The list query
+  selected no count and nothing on that path ever set the author's statistics,
+  so the field was omitted from the API response entirely and the UI fell back
+  to its placeholder. The count is now computed per author and scoped to the
+  books the requesting user can see, so it cannot report rows that belong to
+  another user.

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -112,8 +112,10 @@ type AuthorListFilter struct {
 	Search string
 	// Monitored, when non-nil, restricts to authors with that monitored flag.
 	Monitored *bool
-	// Sort is one of "az" (sort_name asc, default), "za" (sort_name desc), or
-	// "recent" (created_at desc). Unknown values fall back to "az".
+	// Sort is one of "az" (sort_name asc, default), "za" (sort_name desc),
+	// "recent" (created_at desc), or one of the column-header sorts added for
+	// #1349: "books-asc"/"books-desc", "rating-asc"/"rating-desc",
+	// "monitored-asc"/"monitored-desc". Unknown values fall back to "az".
 	Sort string
 }
 
@@ -132,12 +134,28 @@ func escapeLike(s string) string {
 // Ø…) sorting after "Z" (#1347). sort_name is the tiebreaker for a stable order
 // when two folded keys collide. The "recent" sort keys on created_at (a
 // timestamp) and is unaffected.
+// The column-header sorts (#1349) all carry `sort_key ASC` as a tiebreaker:
+// book counts, ratings and the monitored flag are heavily non-unique, and
+// without a stable secondary key SQLite is free to return ties in any order,
+// which makes a paginated list drop and repeat rows between pages.
 func authorSortOrder(sort string) string {
 	switch sort {
 	case "za":
 		return "sort_key DESC, sort_name COLLATE NOCASE DESC"
 	case "recent":
 		return "created_at DESC, id DESC"
+	case "books-asc":
+		return "book_count ASC, sort_key ASC"
+	case "books-desc":
+		return "book_count DESC, sort_key ASC"
+	case "rating-asc":
+		return "average_rating ASC, sort_key ASC"
+	case "rating-desc":
+		return "average_rating DESC, sort_key ASC"
+	case "monitored-asc":
+		return "monitored ASC, sort_key ASC"
+	case "monitored-desc":
+		return "monitored DESC, sort_key ASC"
 	default:
 		return "sort_key ASC, sort_name COLLATE NOCASE ASC"
 	}
@@ -196,10 +214,30 @@ func (r *AuthorRepo) ListPageFiltered(ctx context.Context, f AuthorListFilter, l
 		return nil, 0, fmt.Errorf("count authors: %w", err)
 	}
 
+	// book_count is a correlated subquery rather than a stored column so it
+	// cannot drift from the books table. It serves two purposes: the Authors
+	// list renders it as the Books column (which showed "—" for every author
+	// before this, because nothing ever populated Author.Statistics on a row
+	// read back from the database), and "books-asc"/"books-desc" order by it.
+	//
+	// Scoped to the same rows the caller may see. An unscoped COUNT would let a
+	// user infer how many books another user's author has — a small leak, but
+	// the same class as the one #1872 closed, and free to avoid here. NULL-owned
+	// books stay visible to everyone, matching listAuthorsByUser.
+	bookCountExpr := "(SELECT COUNT(*) FROM books b WHERE b.author_id = authors.id) AS book_count"
+	var selectArgs []any
+	if f.UserID != 0 {
+		bookCountExpr = "(SELECT COUNT(*) FROM books b WHERE b.author_id = authors.id" +
+			" AND (b.owner_user_id = ? OR b.owner_user_id IS NULL)) AS book_count"
+		selectArgs = append(selectArgs, f.UserID)
+	}
+
 	//nolint:gosec // query is built only from static columns, a parameterised WHERE, and a whitelisted ORDER BY (authorSortOrder); all user values are bound via args
-	listQuery := "SELECT " + authorSelectCols + " FROM authors" + where +
+	listQuery := "SELECT " + authorSelectCols + ", " + bookCountExpr + " FROM authors" + where +
 		" ORDER BY " + authorSortOrder(f.Sort) + " LIMIT ? OFFSET ?"
-	pageArgs := append(append([]any{}, args...), limit, offset)
+	// Order matters: the subquery's placeholder sits in the SELECT list, ahead
+	// of every WHERE placeholder.
+	pageArgs := append(append(append([]any{}, selectArgs...), args...), limit, offset)
 
 	rows, err := r.db.QueryContext(ctx, listQuery, pageArgs...)
 	if err != nil {
@@ -209,10 +247,12 @@ func (r *AuthorRepo) ListPageFiltered(ctx context.Context, f AuthorListFilter, l
 
 	var authors []models.Author
 	for rows.Next() {
-		a, err := scanAuthor(rows)
+		var bookCount int
+		a, err := scanAuthorFrom(trailingScanner{s: rows, extra: []any{&bookCount}})
 		if err != nil {
 			return nil, 0, err
 		}
+		a.Statistics = &models.AuthorStats{BookCount: bookCount}
 		authors = append(authors, a)
 	}
 	if err := rows.Err(); err != nil {
@@ -775,6 +815,18 @@ func scanAuthor(rows *sql.Rows) (models.Author, error) {
 
 func scanAuthorRow(row *sql.Row) (models.Author, error) {
 	return scanAuthorFrom(row)
+}
+
+// trailingScanner lets a query select the standard author columns plus extra
+// derived ones without duplicating scanAuthorFrom's 22-destination list, which
+// would then be free to drift from authorSelectCols on the next column added.
+type trailingScanner struct {
+	s     rowScanner
+	extra []any
+}
+
+func (t trailingScanner) Scan(dest ...any) error {
+	return t.s.Scan(append(dest, t.extra...)...)
 }
 
 func scanAuthorFrom(s rowScanner) (models.Author, error) {

--- a/internal/db/authors_test.go
+++ b/internal/db/authors_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -829,5 +831,242 @@ func TestMigration074_BackfillsBookOwnerFromAuthor(t *testing.T) {
 	}
 	if got, ok := ownerOf("B_ALREADY"); !ok || got != bob.ID {
 		t.Errorf("already-owned book owner = %d (set=%v), want bob %d untouched", got, ok, bob.ID)
+	}
+}
+
+// TestListPageFiltered_PopulatesBookCount pins the Books column on the Authors
+// page, which rendered "—" for every author before #1349's second half.
+//
+// The frontend reads `author.statistics?.bookCount`, but ListPageFiltered
+// selected only authorSelectCols — which has no count — and nothing else on the
+// list path ever set Author.Statistics. It is a `*AuthorStats` with
+// `json:"statistics,omitempty"`, so a nil pointer is simply omitted from the
+// response and the column falls back to its em dash. The column has been inert
+// for as long as it has existed.
+func TestListPageFiltered_PopulatesBookCount(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authors := NewAuthorRepo(database)
+	books := NewBookRepo(database)
+
+	prolific := &models.Author{ForeignID: "OL_P", Name: "Prolific", SortName: "Prolific"}
+	if err := authors.Create(ctx, prolific); err != nil {
+		t.Fatal(err)
+	}
+	silent := &models.Author{ForeignID: "OL_S", Name: "Silent", SortName: "Silent"}
+	if err := authors.Create(ctx, silent); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 3 {
+		b := &models.Book{
+			ForeignID: fmt.Sprintf("OL_P_B%d", i), AuthorID: prolific.ID,
+			Title: fmt.Sprintf("Book %d", i), SortTitle: fmt.Sprintf("book %d", i),
+			Status: models.BookStatusWanted,
+		}
+		if err := books.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page, _, err := authors.ListPageFiltered(ctx, AuthorListFilter{}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := map[string]int{}
+	for _, a := range page {
+		if a.Statistics == nil {
+			t.Fatalf("author %q has nil Statistics — the Books column renders an em dash for this row", a.Name)
+		}
+		counts[a.Name] = a.Statistics.BookCount
+	}
+	if counts["Prolific"] != 3 {
+		t.Errorf("Prolific book count = %d, want 3", counts["Prolific"])
+	}
+	// An author with no books must report 0, not a missing Statistics pointer —
+	// "0" and "unknown" are different things on screen.
+	if counts["Silent"] != 0 {
+		t.Errorf("Silent book count = %d, want 0", counts["Silent"])
+	}
+}
+
+// TestListPageFiltered_BookCountIsOwnerScoped keeps the derived count inside the
+// same tenancy boundary as the rows it decorates. An unscoped COUNT would let
+// one user infer how much another user's author holds — the same class of leak
+// as #1872, and free to avoid since the predicate is already known here.
+func TestListPageFiltered_BookCountIsOwnerScoped(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	users := NewUserRepo(database)
+	alice, err := users.Create(ctx, "alice", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := users.Create(ctx, "bob", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authors := NewAuthorRepo(database)
+	// A shared (NULL-owned) author, the pre-multi-user shape, visible to both.
+	shared := &models.Author{ForeignID: "OL_SH", Name: "Shared", SortName: "Shared"}
+	if err := authors.Create(ctx, shared); err != nil {
+		t.Fatal(err)
+	}
+
+	insertBook := func(foreignID string, owner any) {
+		t.Helper()
+		if _, err := database.ExecContext(ctx,
+			`INSERT INTO books (foreign_id, author_id, title, sort_title, status, owner_user_id, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, 'wanted', ?, datetime('now'), datetime('now'))`,
+			foreignID, shared.ID, foreignID, foreignID, owner); err != nil {
+			t.Fatal(err)
+		}
+	}
+	insertBook("B_ALICE", alice.ID)
+	insertBook("B_BOB", bob.ID)
+	insertBook("B_SHARED", nil)
+
+	countFor := func(userID int64) int {
+		t.Helper()
+		page, _, err := authors.ListPageFiltered(ctx, AuthorListFilter{UserID: userID}, 50, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(page) != 1 || page[0].Statistics == nil {
+			t.Fatalf("expected one author with statistics, got %d", len(page))
+		}
+		return page[0].Statistics.BookCount
+	}
+
+	// Own book + the shared one; never the other user's.
+	if got := countFor(alice.ID); got != 2 {
+		t.Errorf("alice sees %d books, want 2 (hers + the shared one)", got)
+	}
+	if got := countFor(bob.ID); got != 2 {
+		t.Errorf("bob sees %d books, want 2 (his + the shared one)", got)
+	}
+	// Unscoped (admin / API key) sees everything.
+	if got := countFor(0); got != 3 {
+		t.Errorf("unscoped count = %d, want 3", got)
+	}
+}
+
+// TestListPageFiltered_ColumnHeaderSorts covers the Authors half of #1349: the
+// Books, Rating and Monitored columns had no sort at all, in either direction.
+func TestListPageFiltered_ColumnHeaderSorts(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authors := NewAuthorRepo(database)
+	books := NewBookRepo(database)
+
+	seed := func(name string, rating float64, monitored bool, bookCount int) {
+		t.Helper()
+		a := &models.Author{
+			ForeignID: "OL_" + name, Name: name, SortName: name,
+			AverageRating: rating, Monitored: monitored,
+		}
+		if err := authors.Create(ctx, a); err != nil {
+			t.Fatal(err)
+		}
+		for i := range bookCount {
+			b := &models.Book{
+				ForeignID: fmt.Sprintf("OL_%s_B%d", name, i), AuthorID: a.ID,
+				Title: fmt.Sprintf("%s %d", name, i), SortTitle: fmt.Sprintf("%s %d", name, i),
+				Status: models.BookStatusWanted,
+			}
+			if err := books.Create(ctx, b); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	seed("Ann", 4.5, true, 1)
+	seed("Bea", 2.0, false, 3)
+	seed("Cal", 3.0, true, 2)
+
+	names := func(sort string) []string {
+		t.Helper()
+		page, _, err := authors.ListPageFiltered(ctx, AuthorListFilter{Sort: sort}, 50, 0)
+		if err != nil {
+			t.Fatalf("sort %q: %v", sort, err)
+		}
+		out := make([]string, 0, len(page))
+		for _, a := range page {
+			out = append(out, a.Name)
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		sort string
+		want []string
+	}{
+		{"books-asc", []string{"Ann", "Cal", "Bea"}},
+		{"books-desc", []string{"Bea", "Cal", "Ann"}},
+		{"rating-asc", []string{"Bea", "Cal", "Ann"}},
+		{"rating-desc", []string{"Ann", "Cal", "Bea"}},
+		// Ties on the monitored flag fall back to sort_key, so Ann precedes Cal.
+		{"monitored-asc", []string{"Bea", "Ann", "Cal"}},
+		{"monitored-desc", []string{"Ann", "Cal", "Bea"}},
+		// Unknown keys must not error or reorder unpredictably.
+		{"nonsense", []string{"Ann", "Bea", "Cal"}},
+	} {
+		if got := names(tc.sort); !slices.Equal(got, tc.want) {
+			t.Errorf("sort %q = %v, want %v", tc.sort, got, tc.want)
+		}
+	}
+}
+
+// TestListPageFiltered_TiedSortIsStableAcrossPages guards the tiebreaker on the
+// new sorts. Book counts and the monitored flag are heavily non-unique; without
+// a stable secondary key SQLite may return ties in any order, and a paginated
+// list then drops and repeats rows between pages.
+func TestListPageFiltered_TiedSortIsStableAcrossPages(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authors := NewAuthorRepo(database)
+	// Six authors, all monitored, all with zero books: every sort key ties.
+	for _, n := range []string{"Fay", "Eve", "Dot", "Cal", "Bea", "Ann"} {
+		if err := authors.Create(ctx, &models.Author{
+			ForeignID: "OL_" + n, Name: n, SortName: n, Monitored: true,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, sort := range []string{"books-asc", "monitored-desc", "rating-asc"} {
+		var paged []string
+		for offset := 0; offset < 6; offset += 2 {
+			page, _, err := authors.ListPageFiltered(ctx, AuthorListFilter{Sort: sort}, 2, offset)
+			if err != nil {
+				t.Fatalf("sort %q offset %d: %v", sort, offset, err)
+			}
+			for _, a := range page {
+				paged = append(paged, a.Name)
+			}
+		}
+		want := []string{"Ann", "Bea", "Cal", "Dot", "Eve", "Fay"}
+		if !slices.Equal(paged, want) {
+			t.Errorf("sort %q paged 2-at-a-time = %v, want %v (a repeat or a gap here is a lost author)", sort, paged, want)
+		}
 	}
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -104,7 +104,8 @@
     "unmonitored": "Nicht überwacht",
     "deleteConfirm": "Diesen Autor und alle seine Bücher löschen?",
     "deleteWithFilesConfirm": "Diesen Autor, {{total}} Buch/Bücher UND {{withFiles}} Datei(en)/Ordner auf der Festplatte löschen?\n\nDies kann nicht rückgängig gemacht werden.",
-    "bulkDeleteConfirm": "{{count}} Autor(en) und alle ihre Bücher löschen?"
+    "bulkDeleteConfirm": "{{count}} Autor(en) und alle ihre Bücher löschen?",
+    "sortByColumn": "Nach {{column}} sortieren"
   },
   "books": {
     "title": "Bücher",
@@ -135,7 +136,8 @@
     "setAudiobook": "🎧 Als Hörbuch setzen",
     "mediaEbook": "📖 E-Book",
     "mediaAudiobook": "🎧 Hörbuch",
-    "mediaBoth": "📖🎧 Beides"
+    "mediaBoth": "📖🎧 Beides",
+    "sortByColumn": "Nach {{column}} sortieren"
   },
   "wanted": {
     "title": "Gesucht",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -194,7 +194,8 @@
     "bulkApplyMonitorModeToExistingHint": "Otherwise this only affects books discovered in future refreshes.",
     "bulkSetMonitorModeApply": "Apply monitor mode",
     "bulkSetMonitorModeFailed": "Bulk monitor mode update failed",
-    "bulkSetMonitorModePartial": "Monitor mode was not updated for author {{id}}: {{error}}"
+    "bulkSetMonitorModePartial": "Monitor mode was not updated for author {{id}}: {{error}}",
+    "sortByColumn": "Sort by {{column}}"
   },
   "authorDetail": {
     "description": {
@@ -300,7 +301,8 @@
     "exclude": "Exclude",
     "unexclude": "Un-exclude",
     "excluded": "Excluded",
-    "showExcluded": "Show excluded"
+    "showExcluded": "Show excluded",
+    "sortByColumn": "Sort by {{column}}"
   },
   "wanted": {
     "title": "Wanted",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -116,7 +116,8 @@
     "unmonitored": "No monitorizado",
     "deleteConfirm": "¿Eliminar este autor y todos sus libros?",
     "deleteWithFilesConfirm": "¿Eliminar este autor, {{total}} libro(s) Y {{withFiles}} archivo(s)/carpeta(s) del disco?\n\nEsta acción no se puede deshacer.",
-    "bulkDeleteConfirm": "¿Eliminar {{count}} autor(es) y todos sus libros?"
+    "bulkDeleteConfirm": "¿Eliminar {{count}} autor(es) y todos sus libros?",
+    "sortByColumn": "Ordenar por {{column}}"
   },
   "books": {
     "title": "Libros",
@@ -152,7 +153,8 @@
     "exclude": "Excluir",
     "unexclude": "Incluir",
     "excluded": "Excluido",
-    "showExcluded": "Mostrar excluidos"
+    "showExcluded": "Mostrar excluidos",
+    "sortByColumn": "Ordenar por {{column}}"
   },
   "wanted": {
     "title": "Buscados",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -104,7 +104,8 @@
     "unmonitored": "Non surveillé",
     "deleteConfirm": "Supprimer cet auteur et tous ses livres ?",
     "deleteWithFilesConfirm": "Supprimer cet auteur, {{total}} livre(s) ET {{withFiles}} fichier(s)/dossier(s) sur le disque ?\n\nCette action est irréversible.",
-    "bulkDeleteConfirm": "Supprimer {{count}} auteur(s) et tous leurs livres ?"
+    "bulkDeleteConfirm": "Supprimer {{count}} auteur(s) et tous leurs livres ?",
+    "sortByColumn": "Trier par {{column}}"
   },
   "books": {
     "title": "Livres",
@@ -135,7 +136,8 @@
     "setAudiobook": "🎧 Définir livre audio",
     "mediaEbook": "📖 Livre numérique",
     "mediaAudiobook": "🎧 Livre audio",
-    "mediaBoth": "📖🎧 Les deux"
+    "mediaBoth": "📖🎧 Les deux",
+    "sortByColumn": "Trier par {{column}}"
   },
   "wanted": {
     "title": "Recherchés",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -116,7 +116,8 @@
     "unmonitored": "Tidak dipantau",
     "deleteConfirm": "Hapus penulis ini beserta semua bukunya?",
     "deleteWithFilesConfirm": "Hapus penulis ini, {{total}} buku, DAN {{withFiles}} berkas/folder di disk?\n\nTindakan ini tidak dapat dibatalkan.",
-    "bulkDeleteConfirm": "Hapus {{count}} penulis beserta semua bukunya?"
+    "bulkDeleteConfirm": "Hapus {{count}} penulis beserta semua bukunya?",
+    "sortByColumn": "Urutkan menurut {{column}}"
   },
   "books": {
     "title": "Buku",
@@ -152,7 +153,8 @@
     "exclude": "Kecualikan",
     "unexclude": "Batalkan kecualikan",
     "excluded": "Dikecualikan",
-    "showExcluded": "Tampilkan yang dikecualikan"
+    "showExcluded": "Tampilkan yang dikecualikan",
+    "sortByColumn": "Urutkan menurut {{column}}"
   },
   "wanted": {
     "title": "Dicari",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -144,7 +144,8 @@
     "deleteConfirm": "이 저자와 모든 도서를 삭제할까요?",
     "deleteWithFilesConfirm": "이 저자, {{total}}권의 도서, 그리고 디스크의 {{withFiles}}개 파일/폴더를 삭제할까요?\n\n이 작업은 되돌릴 수 없습니다.",
     "bulkDeleteConfirm": "{{count}}명의 저자와 모든 도서를 삭제할까요?",
-    "bulkRefreshMetadata": "메타데이터 새로고침"
+    "bulkRefreshMetadata": "메타데이터 새로고침",
+    "sortByColumn": "{{column}} 기준 정렬"
   },
   "authorDetail": {
     "description": {
@@ -204,7 +205,8 @@
     "exclude": "제외",
     "unexclude": "제외 해제",
     "excluded": "제외됨",
-    "showExcluded": "제외된 항목 보기"
+    "showExcluded": "제외된 항목 보기",
+    "sortByColumn": "{{column}} 기준 정렬"
   },
   "wanted": {
     "title": "찾는 중",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -104,7 +104,8 @@
     "unmonitored": "Niet gemonitord",
     "deleteConfirm": "Deze auteur en al zijn/haar boeken verwijderen?",
     "deleteWithFilesConfirm": "Deze auteur, {{total}} boek(en) EN {{withFiles}} bestand(en)/map(pen) op schijf verwijderen?\n\nDit kan niet ongedaan worden gemaakt.",
-    "bulkDeleteConfirm": "{{count}} auteur(s) en al hun boeken verwijderen?"
+    "bulkDeleteConfirm": "{{count}} auteur(s) en al hun boeken verwijderen?",
+    "sortByColumn": "Sorteren op {{column}}"
   },
   "books": {
     "title": "Boeken",
@@ -135,7 +136,8 @@
     "setAudiobook": "🎧 Instellen als luisterboek",
     "mediaEbook": "📖 E-boek",
     "mediaAudiobook": "🎧 Luisterboek",
-    "mediaBoth": "📖🎧 Beide"
+    "mediaBoth": "📖🎧 Beide",
+    "sortByColumn": "Sorteren op {{column}}"
   },
   "wanted": {
     "title": "Gewenst",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -116,7 +116,8 @@
     "unmonitored": "Hindi binabantayan",
     "deleteConfirm": "Tanggalin ang may-akdang ito at lahat ng kanilang mga libro?",
     "deleteWithFilesConfirm": "Tanggalin ang may-akdang ito, {{total}} (na) libro, AT {{withFiles}} (na) file/folder sa disk?\n\nHindi na ito maibabalik.",
-    "bulkDeleteConfirm": "Tanggalin ang {{count}} (na) may-akda at lahat ng kanilang mga libro?"
+    "bulkDeleteConfirm": "Tanggalin ang {{count}} (na) may-akda at lahat ng kanilang mga libro?",
+    "sortByColumn": "Ayusin ayon sa {{column}}"
   },
   "books": {
     "title": "Mga Libro",
@@ -152,7 +153,8 @@
     "exclude": "Ibukod",
     "unexclude": "Alisin sa pagbukod",
     "excluded": "Ibinukod",
-    "showExcluded": "Ipakita ang mga ibinukod"
+    "showExcluded": "Ipakita ang mga ibinukod",
+    "sortByColumn": "Ayusin ayon sa {{column}}"
   },
   "wanted": {
     "title": "Hinahangad",

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import AuthorsPage from './AuthorsPage'
@@ -42,6 +42,10 @@ vi.mock('react-i18next', () => ({
         'authors.sortAZ': 'A-Z',
         'authors.sortZA': 'Z-A',
         'authors.sortRecent': 'Recent',
+        'authors.colName': 'Name',
+        'authors.colBooks': 'Books',
+        'authors.colRating': 'Rating',
+        'authors.colMonitored': 'Monitored',
         'authors.filterMonitored': 'Monitored:',
         'authors.filterAll': 'All',
         'authors.filterMonitoredOnly': 'Monitored',
@@ -379,5 +383,89 @@ describe('AuthorsPage', () => {
     // checkmark is visible instead of white-on-white.
     expect(checkbox).toBeChecked()
     expect(checkbox.className).not.toContain('bg-white/80')
+  })
+})
+
+// The Authors half of #1349. The issue is "Sortable column headers +
+// unmonitored/unwanted filter in Books & Authors views"; the Books half shipped
+// in v1.28.0 and this side never did. Name, Books, Rating and Monitored were
+// plain <th> elements, and the backend accepted only az/za/recent, so there was
+// no way to order the list by anything but name or recency.
+describe('AuthorsPage — sortable column headers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // The table (and therefore its headers) only renders with rows; an empty
+    // list shows the empty state instead.
+    vi.mocked(api.listAuthors).mockResolvedValue({
+      items: [
+        {
+          id: 1, authorName: 'Ann', foreignAuthorId: 'OL_A', monitored: true,
+          averageRating: 4, imageUrl: '', statistics: { bookCount: 2, availableBookCount: 0, wantedBookCount: 0 },
+        },
+      ] as never,
+      total: 1, limit: 100, offset: 0,
+    })
+    localStorage.setItem('bindery.view.authors', 'table')
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('sends the whitelisted sort key for each column, and flips on a second click', async () => {
+    render(
+      <MemoryRouter>
+        <AuthorsPage />
+      </MemoryRouter>,
+    )
+    await screen.findByRole('columnheader', { name: 'Books' })
+
+    // Scope to the column header: "Monitored" is also the label of a filter
+    // chip, so a bare role+name lookup is ambiguous. Re-query before each click
+    // too — SortableHeader is declared in the component body, so React remounts
+    // the header cells on every render and a captured node goes stale.
+    const click = (name: string) =>
+      fireEvent.click(within(screen.getByRole('columnheader', { name })).getByRole('button'))
+    const sorts = () =>
+      vi.mocked(api.listAuthors).mock.calls.map(c => (c[0] as { sort?: string }).sort)
+
+    click('Books')
+    await waitFor(() => expect(sorts()).toContain('books-asc'))
+    click('Books')
+    await waitFor(() => expect(sorts()).toContain('books-desc'))
+
+    click('Rating')
+    await waitFor(() => expect(sorts()).toContain('rating-asc'))
+
+    click('Monitored')
+    await waitFor(() => expect(sorts()).toContain('monitored-asc'))
+
+    // Name reuses the keys the existing toolbar buttons already send, so the
+    // header and the A-Z / Z-A buttons cannot disagree.
+    click('Name')
+    await waitFor(() => expect(sorts()).toContain('az'))
+  })
+
+  it('renders the book count from the server instead of an em dash', async () => {
+    vi.mocked(api.listAuthors).mockResolvedValue({
+      items: [
+        {
+          id: 1, authorName: 'Prolific', foreignAuthorId: 'OL_P', monitored: true,
+          averageRating: 4, imageUrl: '', statistics: { bookCount: 12, availableBookCount: 0, wantedBookCount: 0 },
+        },
+      ] as never,
+      total: 1, limit: 100, offset: 0,
+    })
+
+    render(
+      <MemoryRouter>
+        <AuthorsPage />
+      </MemoryRouter>,
+    )
+
+    // Before the backend populated Statistics on the list path this cell was
+    // always "—", because the field is `json:"statistics,omitempty"` and no
+    // code ever set it on a row read back from SQLite.
+    expect(await screen.findByText('12')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -15,7 +15,14 @@ import SetupChecklist from '../components/SetupChecklist'
 import { btn, btnSize } from '../components/buttons'
 import Switch from '../components/Switch'
 
-type SortMode = 'az' | 'za' | 'recent'
+// 'az' | 'za' sort by name and back the existing toolbar buttons; the rest are
+// the column-header sorts (#1349), whitelisted server-side by authorSortOrder.
+type SortMode =
+  | 'az' | 'za'
+  | 'recent'
+  | 'books-asc' | 'books-desc'
+  | 'rating-asc' | 'rating-desc'
+  | 'monitored-asc' | 'monitored-desc'
 type MonitoredFilter = '' | 'monitored' | 'unmonitored'
 
 export default function AuthorsPage() {
@@ -279,6 +286,33 @@ export default function AuthorsPage() {
   const sortBtnCls = (active: boolean) =>
     `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
 
+  // Column-header sorting, mirroring BooksPage: first click ascending, a second
+  // click on the same column flips to descending. Both keys are whitelisted
+  // server-side, so an unknown value can only ever fall back to the name sort.
+  const toggleSort = (asc: SortMode, desc: SortMode) =>
+    setSort(prev => (prev === asc ? desc : asc))
+
+  const SortableHeader = ({ label, asc, desc }: { label: string; asc: SortMode; desc: SortMode }) => {
+    const active = sort === asc || sort === desc
+    const arrow = sort === asc ? '▲' : '▼'
+    return (
+      <th className="text-left px-3 py-2 text-xs font-medium uppercase">
+        <button
+          type="button"
+          onClick={() => toggleSort(asc, desc)}
+          aria-label={label}
+          title={t('authors.sortByColumn', { column: label, defaultValue: 'Sort by {{column}}' })}
+          className={`inline-flex items-center gap-0.5 uppercase transition-colors cursor-pointer select-none ${active ? 'text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'}`}
+        >
+          {label}
+          {active
+            ? <span aria-hidden="true">{arrow}</span>
+            : <span aria-hidden="true" className="opacity-40">↕</span>}
+        </button>
+      </th>
+    )
+  }
+
   return (
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       <div className="flex items-center justify-between mb-4">
@@ -395,10 +429,10 @@ export default function AuthorsPage() {
                       title="Select all on this page"
                     />
                   </th>
-                  <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">{t('authors.colName')}</th>
-                  <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">{t('authors.colBooks')}</th>
-                  <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">{t('authors.colRating')}</th>
-                  <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">{t('authors.colMonitored')}</th>
+                  <SortableHeader label={t('authors.colName')} asc="az" desc="za" />
+                  <SortableHeader label={t('authors.colBooks')} asc="books-asc" desc="books-desc" />
+                  <SortableHeader label={t('authors.colRating')} asc="rating-asc" desc="rating-desc" />
+                  <SortableHeader label={t('authors.colMonitored')} asc="monitored-asc" desc="monitored-desc" />
                   <th className="px-3 py-2" />
                 </tr>
               </thead>


### PR DESCRIPTION
Completes **#1349**, whose title is "Sortable column headers + unmonitored/unwanted filter in Books **& Authors** views". The Books half shipped in v1.28.0; the Authors half never did. Stacked conceptually on #1905 (the Books-side affordance fix) but independent of it.

## Sortable Authors columns

Name, Books, Rating and Monitored are now clickable headers — ascending on the first click, descending on a second, matching `BooksPage`. `authorSortOrder` gains `books-asc/desc`, `rating-asc/desc`, `monitored-asc/desc` alongside `az/za/recent`, all whitelisted server-side.

Name reuses the same `az`/`za` keys the existing toolbar buttons send, so the header and the A–Z / Z–A buttons can't disagree.

**Every new sort carries `sort_key` as a tiebreaker.** Book counts, ratings and the monitored flag are heavily non-unique, and without a stable secondary key SQLite may return ties in any order — a paginated list then drops and repeats rows between pages. The test paginates six all-tied authors two at a time; dropping the tiebreakers returns them in reverse (rowid) order and fails.

## The Books column has never worked

Found while wiring the sort. The frontend reads `author.statistics?.bookCount` (`AuthorsPage.tsx:431`), but `ListPageFiltered` selected only `authorSelectCols` — which has no count — and nothing on the list path ever set `Author.Statistics`. It's a `*AuthorStats` with `json:"statistics,omitempty"`, so the nil pointer is omitted from the response entirely and the cell falls back to its em dash.

**Every author, in every version that has had the column.** Sorting by a column that always reads `—` would have been pointless, so this is fixed here rather than filed.

It's now a correlated subquery — so it can't drift from the books table — and **scoped to the rows the caller may see**:

```sql
(SELECT COUNT(*) FROM books b WHERE b.author_id = authors.id
   AND (b.owner_user_id = ? OR b.owner_user_id IS NULL)) AS book_count
```

An unscoped `COUNT` would let one user infer how many books another user's author holds. Small, but the same class as the leak #1872 closed, and free to avoid when the predicate is already in hand. NULL-owned books stay visible to everyone, matching `listAuthorsByUser`.

`trailingScanner` lets the list query select derived columns without duplicating `scanAuthorFrom`'s 22-destination list, which would otherwise be free to drift from `authorSelectCols` the next time a column is added.

## Verification

Every behaviour mutation-tested — reverted, test confirmed failing, restored:

| Mutation | Result |
|---|---|
| drop the `Statistics` assignment | `author "Prolific" has nil Statistics — the Books column renders an em dash` |
| unscope the book count | `alice sees 3 books, want 2 (hers + the shared one)` |
| remove the sort tiebreakers | `paged 2-at-a-time = [Fay Eve Dot Cal Bea Ann], want [Ann Bea Cal Dot Eve Fay]` |
| revert a header to a plain `<th>` | frontend sort-key test fails |

Backend `go test ./... -count=1` clean, `golangci-lint` 0 issues. Frontend 55 files / 526 tests, `tsc --noEmit` clean. `sortByColumn` added to all 8 locales.

## Note

`SortableHeader` is declared inside the component body on both pages, so React remounts the header cells on every render. Harmless, but it detaches nodes between clicks — the tests re-query before each one rather than caching a reference. Left as-is; changing it is unrelated to #1349.

closes #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)