### PR TITLE
feat(authors): surface what an author sync skipped

### DIFF
--- a/changelog.d/1889-language-skip-visibility.md
+++ b/changelog.d/1889-language-skip-visibility.md
@@ -1,0 +1,18 @@
+### Fixed
+- **An author refresh now says which books it skipped, and why**
+  ([#1889](https://github.com/vavallee/bindery/issues/1889)) — the catalogue
+  sync already counted the works it dropped, but the counts only ever reached a
+  Debug log line per book plus one Info summary, so an author whose catalogue
+  had been filtered down to a handful looked exactly like an author who only
+  wrote a handful. One reporter lost 65 books from a single author to the
+  allowed-languages filter and found out only by going looking in the logs,
+  which a rootless container does not hand them. The author detail response now
+  carries a `lastSync` summary — works returned, books added, and how many each
+  filter dropped — and the author page shows a note above the book list naming
+  the language set that was applied, whether the profile also rejects works with
+  no reported language, and a few of the dropped titles. The run's summary log
+  line moves from `INFO` to `WARN` when anything was skipped, so it also shows
+  up in Settings → Logs at the default level. Nothing about the filtering
+  changed: a metadata profile set to reject unknown languages still rejects
+  them, it just no longer does it silently. The summary is kept in memory, so it
+  reports syncs this process has run rather than surviving a restart.

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,6 +46,31 @@ GET    /api/v1/author/{id}/aliases                list merged-in alias rows
 POST   /api/v1/author/{id}/merge                  merge another author into this one
 ```
 
+`GET /api/v1/author/{id}` includes a `lastSync` object when this Bindery process
+has synced the author's catalogue since it started — what the provider returned
+and what each filter dropped, so a catalogue that was filtered down is
+distinguishable from an author who wrote that few books:
+
+```json
+{
+  "lastSync": {
+    "completedAt": "2026-08-11T12:00:00Z",
+    "total": 66,
+    "added": 1,
+    "skippedLanguage": 65,
+    "skippedJunk": 0,
+    "skippedMediaType": 0,
+    "allowedLanguages": ["eng"],
+    "unknownLanguageFail": true,
+    "skippedLanguageSample": [{ "title": "Les Ours", "language": "fre" }]
+  }
+}
+```
+
+It is held in memory, not stored, so it is absent after a restart until the
+author is synced again. `skippedLanguageSample` is capped at a few titles; the
+counts are exact.
+
 `POST /api/v1/author/{id}/relink-upstream` may be called without a body for
 automatic upstream matching. Manual relink can send:
 

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -92,3 +92,14 @@ The metadata button on an author's page only appears when Bindery thinks the aut
 - **"Find better metadata"** — the author *is* linked, but the stored record is **sparse**: no description, no image, no disambiguation, and no ratings. The button searches the providers for a richer match to relink to.
 
 An author that already has a filled-in record (a description, an image, ratings) hides the button, because there's nothing obviously better to fetch. So a missing button means that author already has good metadata. If an author looks well populated but still shows the button, the stored description/image/ratings are likely empty even though the page renders other fields — relink and pick the best match to fill them in.
+
+## An author has far fewer books than they should after a refresh
+
+The catalogue sync filters the works the metadata provider returns before creating book rows, so a refresh can legitimately end with far fewer books than the author has written. After the refresh finishes, the author's page shows a note above the book list saying how many works were skipped and by which filter — reload the page if the refresh was still running when you last looked.
+
+The usual culprit is the **allowed languages** list on the author's metadata profile (`Settings → Metadata`). Two halves of that setting drop books:
+
+- **The language list itself.** A work whose language is outside the list is skipped. Foreign-language editions of an English author are the common case.
+- **"When book language is unknown".** OpenLibrary carries no language on many *work* records, so a large tail of an author's catalogue arrives with no language at all. Set to **fail**, every one of those is skipped too — which is what turns "a few translations were dropped" into "most of this author is missing". Setting it to **pass** and refreshing again brings them back.
+
+The skip counts are also in the log (`Settings → Logs`): the `author books synced` line carries `added`, `skipped_language`, `skipped_junk` and `skipped_media_type`, and is logged at WARN whenever anything was skipped. Per-book detail (which title, which language) is at DEBUG.

--- a/internal/api/author_sync_summary.go
+++ b/internal/api/author_sync_summary.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"sync"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// authorSyncSkippedSampleLimit caps how many rejected titles a summary carries.
+// The point is to let the user recognise WHAT is being dropped, not to mirror
+// the whole rejected tail into the author payload — a prolific author can have
+// hundreds of foreign-language works.
+const authorSyncSkippedSampleLimit = 5
+
+// authorSyncSummaries remembers the outcome of the last catalogue sync per
+// author so the author detail endpoint can report it (#1889).
+//
+// Deliberately in-process rather than a table: the counts are diagnostic
+// output about a run, not library state, and the moment they matter is right
+// after the refresh the user just triggered. That keeps the fix free of a
+// schema change, at the cost of the summary disappearing on restart — which is
+// the same lifetime the log ring buffer behind Settings → Logs has.
+type authorSyncSummaries struct {
+	mu       sync.Mutex
+	byAuthor map[int64]models.AuthorSyncSummary
+}
+
+// record stores the summary for authorID, replacing any earlier one. Only the
+// most recent sync is kept; an older run's counts describe a catalogue that no
+// longer exists.
+func (s *authorSyncSummaries) record(authorID int64, summary models.AuthorSyncSummary) {
+	if authorID == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byAuthor == nil {
+		s.byAuthor = make(map[int64]models.AuthorSyncSummary)
+	}
+	s.byAuthor[authorID] = summary
+}
+
+// get returns a copy of the last recorded summary for authorID, or nil when
+// this process hasn't synced that author. A copy so a caller attaching it to a
+// response can't mutate the stored record.
+func (s *authorSyncSummaries) get(authorID int64) *models.AuthorSyncSummary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	summary, ok := s.byAuthor[authorID]
+	if !ok {
+		return nil
+	}
+	summary.AllowedLanguages = append([]string(nil), summary.AllowedLanguages...)
+	summary.SkippedLanguageSample = append([]models.AuthorSyncSkippedBook(nil), summary.SkippedLanguageSample...)
+	return &summary
+}
+
+// forget drops the recorded summary for authorID. Called when the author row
+// goes away so a re-added author can't inherit the deleted one's counts.
+func (s *authorSyncSummaries) forget(authorID int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.byAuthor, authorID)
+}

--- a/internal/api/author_sync_summary_test.go
+++ b/internal/api/author_sync_summary_test.go
@@ -1,0 +1,339 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// languageSkipFixture seeds an author on a profile that allows English only and
+// rejects unknown languages, plus a provider catalogue that the filters chew
+// through: one keeper, three language rejects (two French, one with no language
+// at all), and one junk-titled work. Mirrors the reported shape in #1889, where
+// an author refresh dropped 65 of one author's books.
+type languageSkipFixture struct {
+	handler *AuthorHandler
+	author  *models.Author
+	books   *db.BookRepo
+}
+
+func newLanguageSkipFixture(t *testing.T) languageSkipFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	profile := &models.MetadataProfile{
+		Name:                    "English only",
+		AllowedLanguages:        "eng",
+		UnknownLanguageBehavior: models.UnknownLanguageFail,
+	}
+	if err := profileRepo.Create(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID: "OL1889A", Name: "Terry Bisson", SortName: "Bisson, Terry",
+		MetadataProvider: "openlibrary", MetadataProfileID: &profile.ID,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	works := []models.Book{
+		{ForeignID: "OL1W", Title: "Bears Discover Fire", SortTitle: "bears discover fire", Language: "eng",
+			Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{}},
+		{ForeignID: "OL2W", Title: "Les Ours", SortTitle: "les ours", Language: "fre",
+			Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{}},
+		{ForeignID: "OL3W", Title: "Le Feu", SortTitle: "le feu", Language: "fre",
+			Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{}},
+		{ForeignID: "OL4W", Title: "Untitled Work", SortTitle: "untitled work",
+			Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{}},
+		{ForeignID: "OL5W", Title: "Terry Bisson", SortTitle: "terry bisson", Language: "eng",
+			Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{}},
+	}
+	agg := metadata.NewAggregator(&stubMetaProvider{works: works})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, nil)
+	return languageSkipFixture{handler: h, author: author, books: bookRepo}
+}
+
+// getAuthorJSON runs the detail handler as userID/role and returns the decoded
+// body. Goes through the handler rather than the summary store directly so the
+// ownership guard the summary rides on is part of what's asserted.
+func getAuthorJSON(t *testing.T, h *AuthorHandler, id, userID int64, role string) (*httptest.ResponseRecorder, models.Author) {
+	t.Helper()
+	ctx := withAuthCtx(context.Background(), userID, role)
+	req := newRequestForID(http.MethodGet, "/api/v1/author/"+strconv.FormatInt(id, 10), id, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	var got models.Author
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode author body: %v (%s)", err, rec.Body.String())
+		}
+	}
+	return rec, got
+}
+
+// #1889: the counts the sync already tallies must reach the author detail
+// response. Before this, a refresh that dropped most of an author's catalogue
+// left a Debug line per book and one Info summary — invisible to anyone who
+// can't read the container's stdout.
+func TestAuthorGet_ReportsLastSyncSkipCounts(t *testing.T) {
+	f := newLanguageSkipFixture(t)
+	f.handler.FetchAuthorBooks(f.author, false, "")
+
+	rec, got := getAuthorJSON(t, f.handler, f.author.ID, 1, "admin")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("author Get = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got.LastSync == nil {
+		t.Fatal("author detail carries no lastSync: the catalogue sync's outcome is still invisible (#1889)")
+	}
+	sync := got.LastSync
+	if sync.Total != 5 {
+		t.Errorf("lastSync.total = %d, want 5 (works the provider returned)", sync.Total)
+	}
+	if sync.Added != 1 {
+		t.Errorf("lastSync.added = %d, want 1", sync.Added)
+	}
+	// Two French works plus one the provider gave no language for, which the
+	// profile's unknown_language_behavior=fail rejects.
+	if sync.SkippedLanguage != 3 {
+		t.Errorf("lastSync.skippedLanguage = %d, want 3", sync.SkippedLanguage)
+	}
+	if sync.SkippedJunk != 1 {
+		t.Errorf("lastSync.skippedJunk = %d, want 1 (the author-name-titled work)", sync.SkippedJunk)
+	}
+	if sync.SkippedTotal() != 4 {
+		t.Errorf("lastSync skipped total = %d, want 4", sync.SkippedTotal())
+	}
+	if !sync.UnknownLanguageFail {
+		t.Error("lastSync.unknownLanguageFail = false, want true: the user can't tell which half of the filter dropped the untitled-language works")
+	}
+	if len(sync.AllowedLanguages) != 1 || sync.AllowedLanguages[0] != "eng" {
+		t.Errorf("lastSync.allowedLanguages = %v, want [eng]", sync.AllowedLanguages)
+	}
+	if sync.CompletedAt.IsZero() {
+		t.Error("lastSync.completedAt is zero; the UI can't tell a fresh summary from a stale one")
+	}
+
+	// The sample names what was dropped, which is what tells the user whether
+	// the profile is set the way they meant.
+	sampled := map[string]string{}
+	for _, s := range sync.SkippedLanguageSample {
+		sampled[s.Title] = s.Language
+	}
+	if len(sampled) != 3 {
+		t.Fatalf("lastSync.skippedLanguageSample = %+v, want 3 entries", sync.SkippedLanguageSample)
+	}
+	if lang, ok := sampled["Les Ours"]; !ok || lang != "fre" {
+		t.Errorf("sample missing the French reject with its language: %+v", sync.SkippedLanguageSample)
+	}
+	if lang, ok := sampled["Untitled Work"]; !ok || lang != "" {
+		t.Errorf("sample missing the unknown-language reject: %+v", sync.SkippedLanguageSample)
+	}
+}
+
+// The sample is capped so a prolific author's rejected tail can't bloat every
+// author detail response — the counts stay exact, only the named titles are cut.
+func TestAuthorGet_LastSyncSampleIsCapped(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	profile := &models.MetadataProfile{Name: "English only", AllowedLanguages: "eng"}
+	if err := profileRepo.Create(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{ForeignID: "OL1889B", Name: "Prolific", SortName: "Prolific",
+		MetadataProvider: "openlibrary", MetadataProfileID: &profile.ID}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	works := make([]models.Book, 0, 20)
+	for i := range 20 {
+		works = append(works, models.Book{
+			ForeignID: "OLX" + strconv.Itoa(i), Title: "Roman " + strconv.Itoa(i),
+			SortTitle: "roman", Language: "fre", Status: models.BookStatusWanted,
+			MetadataProvider: "openlibrary", Genres: []string{},
+		})
+	}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(&stubMetaProvider{works: works}), nil, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, "")
+
+	rec, got := getAuthorJSON(t, h, author.ID, 1, "admin")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("author Get = %d, want 200", rec.Code)
+	}
+	if got.LastSync == nil {
+		t.Fatal("author detail carries no lastSync")
+	}
+	if got.LastSync.SkippedLanguage != 20 {
+		t.Errorf("lastSync.skippedLanguage = %d, want 20 (the count is not sampled)", got.LastSync.SkippedLanguage)
+	}
+	if len(got.LastSync.SkippedLanguageSample) != authorSyncSkippedSampleLimit {
+		t.Errorf("sample length = %d, want %d", len(got.LastSync.SkippedLanguageSample), authorSyncSkippedSampleLimit)
+	}
+}
+
+// A sync that dropped nothing still reports, so "nothing was filtered" is an
+// answer the user can get rather than an absence they have to interpret.
+func TestAuthorGet_LastSyncReportsCleanRun(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	author := &models.Author{ForeignID: "OL1889C", Name: "Clean Run", SortName: "Clean Run",
+		MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	works := []models.Book{{ForeignID: "OLC1", Title: "Only Book", SortTitle: "only book", Language: "eng",
+		Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{}}}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(&stubMetaProvider{works: works}), nil, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, "")
+
+	_, got := getAuthorJSON(t, h, author.ID, 1, "admin")
+	if got.LastSync == nil {
+		t.Fatal("author detail carries no lastSync after a clean sync")
+	}
+	if got.LastSync.SkippedTotal() != 0 || got.LastSync.Added != 1 {
+		t.Errorf("clean sync summary = %+v, want added=1 and nothing skipped", got.LastSync)
+	}
+}
+
+// The summary is diagnostic output about another user's library, so it must not
+// escape the ownership guard the rest of the author payload sits behind.
+func TestAuthorGet_LastSyncNotVisibleCrossUser(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserAuthors(t)
+	h := NewAuthorHandler(f.authors, nil, f.books, nil, nil, nil, f.profiles, nil)
+	h.syncSummaries.record(f.a1.ID, models.AuthorSyncSummary{
+		Total: 66, Added: 1, SkippedLanguage: 65,
+		SkippedLanguageSample: []models.AuthorSyncSkippedBook{{Title: "Les Ours", Language: "fre"}},
+	})
+
+	rec, _ := getAuthorJSON(t, h, f.a1.ID, f.u2, "user")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user author Get = %d, want 404", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "skippedLanguage") || strings.Contains(rec.Body.String(), "Les Ours") {
+		t.Errorf("cross-user 404 body leaked the sync summary: %s", rec.Body.String())
+	}
+
+	rec, got := getAuthorJSON(t, h, f.a1.ID, f.u1, "user")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("owner author Get = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got.LastSync == nil || got.LastSync.SkippedLanguage != 65 {
+		t.Errorf("owner must still see the summary; got %+v", got.LastSync)
+	}
+}
+
+// A sync that dropped books logs its summary at WARN, not INFO: INFO is the
+// level the in-app log view captures by default, and the reporter in #1889 was
+// running rootless with no way to reach the Debug per-book lines.
+func TestFetchAuthorBooks_SkippedBooksLogAtWarn(t *testing.T) {
+	f := newLanguageSkipFixture(t)
+	logs := captureSlog(t)
+	f.handler.FetchAuthorBooks(f.author, false, "")
+
+	var summaryLine string
+	for _, line := range strings.Split(logs.String(), "\n") {
+		if strings.Contains(line, "author books synced") {
+			summaryLine = line
+		}
+	}
+	if summaryLine == "" {
+		t.Fatal("no 'author books synced' summary line was logged")
+	}
+	if !strings.Contains(summaryLine, "level=WARN") {
+		t.Errorf("summary logged at the wrong level for a run that skipped books: %s", summaryLine)
+	}
+	if !strings.Contains(summaryLine, "skipped_language=3") {
+		t.Errorf("summary line lost its breakdown: %s", summaryLine)
+	}
+}
+
+// A run with nothing skipped stays at INFO — raising every sync to WARN would
+// make the level meaningless.
+func TestFetchAuthorBooks_CleanSyncLogsAtInfo(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	author := &models.Author{ForeignID: "OL1889D", Name: "Quiet Author", SortName: "Quiet Author",
+		MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	works := []models.Book{{ForeignID: "OLQ1", Title: "A Book", SortTitle: "a book", Language: "eng",
+		Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{}}}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(&stubMetaProvider{works: works}), nil, profileRepo, nil)
+
+	logs := captureSlog(t)
+	h.FetchAuthorBooks(author, false, "")
+	for _, line := range strings.Split(logs.String(), "\n") {
+		if strings.Contains(line, "author books synced") && !strings.Contains(line, "level=INFO") {
+			t.Errorf("clean sync summary must stay INFO: %s", line)
+		}
+	}
+}
+
+// Author ids come from SQLite's rowid allocation and get reused, so a deleted
+// author's counts must not reappear on whatever author lands on that id next.
+func TestAuthorDelete_ForgetsSyncSummary(t *testing.T) {
+	f := newLanguageSkipFixture(t)
+	f.handler.FetchAuthorBooks(f.author, false, "")
+	if f.handler.syncSummaries.get(f.author.ID) == nil {
+		t.Fatal("precondition: sync should have recorded a summary")
+	}
+
+	req := newRequestForID(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(f.author.ID, 10), f.author.ID, context.Background())
+	rec := httptest.NewRecorder()
+	f.handler.Delete(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("author Delete = %d, want 204: %s", rec.Code, rec.Body.String())
+	}
+	if got := f.handler.syncSummaries.get(f.author.ID); got != nil {
+		t.Errorf("summary survived the author delete: %+v", got)
+	}
+}

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -56,6 +56,11 @@ type AuthorHandler struct {
 	// goroutines do not outlive the process. Falls back to
 	// context.Background() when not set; see #846 and recommendations.go.
 	lifetimeCtx context.Context
+
+	// syncSummaries records what each catalogue sync added and dropped so the
+	// detail endpoint can report it instead of leaving the drops to a Debug
+	// log line nobody reads (#1889).
+	syncSummaries authorSyncSummaries
 }
 
 func NewAuthorHandler(authors *db.AuthorRepo, aliases *db.AuthorAliasRepo, books *db.BookRepo, series *db.SeriesRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo, searcher BookSearcher) *AuthorHandler {
@@ -273,6 +278,11 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 			author.MonitoredSeriesIDs = ids
 		}
 	}
+
+	// Attach the last catalogue sync's outcome (#1889). No extra scoping is
+	// needed: this hangs off the author the ownership guard above already
+	// cleared, so a non-owner gets the 404 and never reaches the counts.
+	author.LastSync = h.syncSummaries.get(id)
 
 	proxyAuthorImages(author)
 	cleanAuthorDescription(author)
@@ -1183,6 +1193,10 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeServerError(w, r, err)
 		return
 	}
+	// Drop the sync accounting with the row (#1889) — author ids are reused by
+	// SQLite's rowid allocation, and a re-added author must not inherit the
+	// deleted one's skip counts.
+	h.syncSummaries.forget(id)
 
 	// The author's books (and their book_files rows) were cascade-deleted above,
 	// so excludeBookID=0 makes the ownership guard skip any path still tracked by
@@ -1599,6 +1613,11 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 	strictMediaType := h.resolveDefaultMediaTypeStrict(ctx)
 
 	var added, skippedLang, skippedJunk, skippedMediaType int
+	// Names of the first few language-rejected works, reported to the user
+	// alongside the count (#1889): "65 books skipped" is alarming, but it is
+	// the titles and their language codes that tell them whether the profile
+	// is set the way they meant.
+	var skippedLangSample []models.AuthorSyncSkippedBook
 	for _, b := range books {
 		b.AuthorID = author.ID
 		// Apply the caller-provided default media type when the provider
@@ -1647,6 +1666,9 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 		// unknown_language_behavior (pass by default; see #232).
 		if !models.IsLanguageAllowed(b.Language, allowedLangs, unknownFail) {
 			skippedLang++
+			if len(skippedLangSample) < authorSyncSkippedSampleLimit {
+				skippedLangSample = append(skippedLangSample, models.AuthorSyncSkippedBook{Title: b.Title, Language: b.Language})
+			}
 			slog.Debug("skipping non-allowed-language book", "title", b.Title, "language", b.Language, "allowed", allowedLangs, "edition_sampled", langSampled)
 			continue
 		}
@@ -1829,7 +1851,38 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 		}
 	}
 	runBookSearches(ctx, h.searcher, searchQueue, authorAutoSearchConcurrency)
-	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "skipped_media_type", skippedMediaType, "total", len(books))
+
+	// Publish the run's accounting so the author page can say what happened to
+	// the works that never became books (#1889). Recorded for every sync, not
+	// just ones that dropped something: "nothing was filtered out" is the
+	// answer to "where are my books?" as often as a count is.
+	summary := models.AuthorSyncSummary{
+		CompletedAt:           time.Now().UTC(),
+		Total:                 len(books),
+		Added:                 added,
+		SkippedLanguage:       skippedLang,
+		SkippedJunk:           skippedJunk,
+		SkippedMediaType:      skippedMediaType,
+		AllowedLanguages:      allowedLangs,
+		UnknownLanguageFail:   unknownFail,
+		SkippedLanguageSample: skippedLangSample,
+	}
+	h.syncSummaries.record(author.ID, summary)
+
+	// Same line, louder when the run dropped something. A refresh that quietly
+	// discards most of an author's catalogue is not routine Info-level news,
+	// and Info is the default level the in-app log view captures — a reporter
+	// running rootless couldn't reach the Debug per-book lines at all.
+	logArgs := []any{
+		"author", author.Name, "added", added,
+		"skipped_language", skippedLang, "skipped_junk", skippedJunk, "skipped_media_type", skippedMediaType,
+		"total", len(books),
+	}
+	if summary.SkippedTotal() > 0 {
+		slog.Warn("author books synced", logArgs...)
+		return
+	}
+	slog.Info("author books synced", logArgs...)
 }
 
 // reparentMisattachedBook re-links existing to the author being synced when

--- a/internal/models/author.go
+++ b/internal/models/author.go
@@ -57,10 +57,65 @@ type Author struct {
 	// pinned to when MonitorMode == AuthorMonitorModeSeries (#810). Populated
 	// by the author Get handler so the edit modal can preselect chips.
 	MonitoredSeriesIDs []int64 `json:"monitoredSeriesIds,omitempty"`
+	// LastSync reports what the most recent catalogue sync did with the works
+	// the provider returned (#1889). Populated by the author Get handler from
+	// an in-process record, so it is absent until this process has synced the
+	// author at least once.
+	LastSync *AuthorSyncSummary `json:"lastSync,omitempty"`
 
 	// Transient: populated from the metadata provider during add/refresh; not stored in DB.
 	// Used to seed author_aliases so non-latin primary names get latin-script alternates.
 	AlternateNames []string `json:"-"`
+}
+
+// AuthorSyncSummary is the outcome of one catalogue sync: how many of the
+// provider's works became books, and how many were dropped by which filter.
+//
+// It exists because the drops were invisible (#1889). The allowed-languages
+// filter logged one Debug line per rejected work and the run's totals landed in
+// a single Info line, so an author whose catalogue was mostly filtered away
+// looked exactly like an author who only ever wrote a few books — one reporter
+// lost 65 books from a single author and only found out by going looking in the
+// logs, which a rootless container does not even hand them.
+type AuthorSyncSummary struct {
+	CompletedAt time.Time `json:"completedAt"`
+	// Total is the number of works the providers returned, before filtering.
+	Total            int `json:"total"`
+	Added            int `json:"added"`
+	SkippedLanguage  int `json:"skippedLanguage"`
+	SkippedJunk      int `json:"skippedJunk"`
+	SkippedMediaType int `json:"skippedMediaType"`
+	// AllowedLanguages is the language set the run actually applied, so the UI
+	// can name the setting that did the dropping rather than making the user
+	// guess which profile the author is on. Empty means "no language filter".
+	AllowedLanguages []string `json:"allowedLanguages,omitempty"`
+	// UnknownLanguageFail records the profile's unknown_language_behavior, the
+	// half of the filter that surprises people: with it on, every work the
+	// provider gave no language for is dropped too.
+	UnknownLanguageFail bool `json:"unknownLanguageFail,omitempty"`
+	// SkippedLanguageSample is the first few titles the language filter
+	// dropped, capped so a prolific author's rejected tail can't bloat the
+	// author payload. Enough to recognise whether the profile is set the way
+	// the user meant.
+	SkippedLanguageSample []AuthorSyncSkippedBook `json:"skippedLanguageSample,omitempty"`
+}
+
+// AuthorSyncSkippedBook is one dropped work, named so the user can tell a
+// mis-set filter from a correctly-set one.
+type AuthorSyncSkippedBook struct {
+	Title string `json:"title"`
+	// Language is the code the provider reported, empty when it reported none
+	// (the unknown-language case).
+	Language string `json:"language"`
+}
+
+// SkippedTotal is the number of provider works this sync dropped for any
+// reason. Zero means nothing was filtered out.
+func (s *AuthorSyncSummary) SkippedTotal() int {
+	if s == nil {
+		return 0
+	}
+	return s.SkippedLanguage + s.SkippedJunk + s.SkippedMediaType
 }
 
 // AuthorProviderFromForeignID returns the metadata provider implied by a

--- a/web/src/api/authors.ts
+++ b/web/src/api/authors.ts
@@ -30,6 +30,35 @@ export interface Author {
   // Populated by the author Get response when monitorMode === 'series' (#810).
   // The Update endpoint accepts an updated array via UpdateAuthorRequest.
   monitoredSeriesIds?: number[]
+  // What the last catalogue sync did with the provider's works (#1889).
+  // Absent until the server has synced this author since it last started.
+  lastSync?: AuthorSyncSummary
+}
+
+// AuthorSyncSummary reports how many provider works became books on the last
+// refresh and how many each filter dropped. Books removed by the
+// allowed-languages filter used to leave no trace outside a Debug log line, so
+// a catalogue that had been filtered down to a handful looked identical to an
+// author who only wrote a handful (#1889).
+export interface AuthorSyncSummary {
+  completedAt: string
+  total: number
+  added: number
+  skippedLanguage: number
+  skippedJunk: number
+  skippedMediaType: number
+  // The language set the run applied, and whether it also rejected works the
+  // provider reported no language for. Empty means no language filter.
+  allowedLanguages?: string[]
+  unknownLanguageFail?: boolean
+  // The first few dropped titles, capped server-side.
+  skippedLanguageSample?: AuthorSyncSkippedBook[]
+}
+
+export interface AuthorSyncSkippedBook {
+  title: string
+  // Empty when the provider reported no language for the work.
+  language: string
 }
 
 export interface AuthorAlias {

--- a/web/src/components/AuthorSyncNotice.tsx
+++ b/web/src/components/AuthorSyncNotice.tsx
@@ -1,0 +1,94 @@
+import { Link } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import type { AuthorSyncSummary } from '../api/client'
+
+// The catalogue sync's filters used to drop books in silence: one Debug log
+// line per rejected work and a single Info summary at the end, nothing in the
+// API and nothing on the page. A reporter lost 65 books from one author to the
+// allowed-languages filter and only found out by going looking in the logs,
+// which a rootless container does not hand them (#1889).
+//
+// This is the same information the sync already had, put where the missing
+// books are. It is informational rather than an error — the filter did what it
+// was configured to do — so it reads as a note, not a failure.
+export default function AuthorSyncNotice({ sync }: { sync?: AuthorSyncSummary }) {
+  const { t } = useTranslation()
+  if (!sync) return null
+
+  const skipped = sync.skippedLanguage + sync.skippedJunk + sync.skippedMediaType
+  // A sync that dropped nothing has nothing to explain; the book list already
+  // says what happened.
+  if (skipped <= 0) return null
+
+  const languages = sync.allowedLanguages?.length
+    ? sync.allowedLanguages.join(', ')
+    : t('authorDetail.lastSync.anyLanguage', 'any')
+  const sample = (sync.skippedLanguageSample ?? []).map(b =>
+    b.language
+      ? `${b.title} (${b.language})`
+      : t('authorDetail.lastSync.sampleUnknownLanguage', '{{title}} (no language)', { title: b.title }),
+  )
+
+  return (
+    <div
+      data-testid="author-sync-notice"
+      className="mb-4 px-3 py-2 rounded border text-sm border-amber-300 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/30 text-amber-900 dark:text-amber-200"
+    >
+      <div className="font-medium">
+        {t('authorDetail.lastSync.heading', {
+          count: skipped,
+          defaultValue: 'Last refresh skipped {{count}} of this author’s {{total}} works',
+          total: sync.total,
+        })}
+      </div>
+      <ul className="mt-1 list-disc list-inside space-y-0.5">
+        {sync.skippedLanguage > 0 && (
+          <li>
+            {t('authorDetail.lastSync.language', {
+              count: sync.skippedLanguage,
+              defaultValue: '{{count}} skipped by the language filter (allowed: {{languages}})',
+              languages,
+            })}
+            {sync.unknownLanguageFail
+              ? ' ' +
+                t(
+                  'authorDetail.lastSync.unknownFail',
+                  'Works the metadata provider reported no language for were skipped too, because this author’s metadata profile is set to reject unknown languages.',
+                )
+              : ''}
+          </li>
+        )}
+        {sync.skippedJunk > 0 && (
+          <li>
+            {t('authorDetail.lastSync.junk', {
+              count: sync.skippedJunk,
+              defaultValue: '{{count}} skipped as untitled provider records',
+            })}
+          </li>
+        )}
+        {sync.skippedMediaType > 0 && (
+          <li>
+            {t('authorDetail.lastSync.mediaType', {
+              count: sync.skippedMediaType,
+              defaultValue: '{{count}} skipped as the wrong format for your default media type',
+            })}
+          </li>
+        )}
+      </ul>
+      {sample.length > 0 && (
+        <div className="mt-1">
+          {t('authorDetail.lastSync.examples', 'For example: {{titles}}', { titles: sample.join(', ') })}
+        </div>
+      )}
+      <div className="mt-1 text-xs">
+        <Link to="/settings?tab=metadata" className="underline">
+          {t('authorDetail.lastSync.settingsLink', 'Metadata profile settings')}
+        </Link>
+        {' · '}
+        {t('authorDetail.lastSync.completedAt', 'Refreshed {{when}}', {
+          when: new Date(sync.completedAt).toLocaleString(),
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -220,6 +220,18 @@
       "selectAll": "Select all",
       "deselectAll": "Deselect all"
     },
+    "lastSync": {
+      "heading": "Last refresh skipped {{count}} of this author’s {{total}} works",
+      "language": "{{count}} skipped by the language filter (allowed: {{languages}})",
+      "unknownFail": "Works the metadata provider reported no language for were skipped too, because this author’s metadata profile is set to reject unknown languages.",
+      "junk": "{{count}} skipped as untitled provider records",
+      "mediaType": "{{count}} skipped as the wrong format for your default media type",
+      "examples": "For example: {{titles}}",
+      "sampleUnknownLanguage": "{{title}} (no language)",
+      "anyLanguage": "any",
+      "settingsLink": "Metadata profile settings",
+      "completedAt": "Refreshed {{when}}"
+    },
     "booksHeading": "Books",
     "filteredCount": "{{shown}} of {{total}}",
     "groupBySeries": "Group by series",

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -807,3 +807,67 @@ describe('AuthorDetailPage — toolbar and stats', () => {
     await waitFor(() => expect(seen).toBe('/book/7'))
   })
 })
+
+// #1889: books dropped by the metadata-profile filters were invisible — a Debug
+// log line per book, nothing on the page. An author whose catalogue was mostly
+// filtered away looked exactly like an author who wrote three books.
+describe('AuthorDetailPage — last sync outcome', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    installLocalStorageMock()
+    vi.mocked(api.listAuthorSeries).mockResolvedValue([])
+  })
+
+  it('reports the books the last refresh skipped, and why', async () => {
+    renderAuthorDetailPage([makeBook({ id: 1, title: 'Bears Discover Fire', status: 'imported' })], 'grid', {
+      lastSync: {
+        completedAt: '2026-08-11T12:00:00Z',
+        total: 66,
+        added: 1,
+        skippedLanguage: 65,
+        skippedJunk: 0,
+        skippedMediaType: 0,
+        allowedLanguages: ['eng'],
+        unknownLanguageFail: true,
+        skippedLanguageSample: [
+          { title: 'Les Ours', language: 'fre' },
+          { title: 'Untitled Work', language: '' },
+        ],
+      },
+    })
+
+    const notice = await screen.findByTestId('author-sync-notice')
+    expect(notice).toHaveTextContent('Last refresh skipped 65 of this author’s 66 works')
+    expect(notice).toHaveTextContent('65 skipped by the language filter (allowed: eng)')
+    // The unknown-language half of the filter is the part that surprises
+    // people, so it is named rather than folded into the count.
+    expect(notice).toHaveTextContent(/reject unknown languages/)
+    expect(notice).toHaveTextContent('Les Ours (fre)')
+    expect(notice).toHaveTextContent('Untitled Work (no language)')
+    expect(within(notice).getByRole('link', { name: 'Metadata profile settings' })).toHaveAttribute(
+      'href',
+      '/settings?tab=metadata',
+    )
+  })
+
+  it('stays silent when the last refresh skipped nothing', async () => {
+    renderAuthorDetailPage([makeBook({ id: 1, title: 'Only Book', status: 'imported' })], 'grid', {
+      lastSync: {
+        completedAt: '2026-08-11T12:00:00Z',
+        total: 1,
+        added: 1,
+        skippedLanguage: 0,
+        skippedJunk: 0,
+        skippedMediaType: 0,
+      },
+    })
+    await screen.findByRole('heading', { name: 'Only Book' })
+    expect(screen.queryByTestId('author-sync-notice')).toBeNull()
+  })
+
+  it('stays silent when the server reports no sync at all', async () => {
+    renderAuthorDetailPage([makeBook({ id: 1, title: 'Only Book', status: 'imported' })])
+    await screen.findByRole('heading', { name: 'Only Book' })
+    expect(screen.queryByTestId('author-sync-notice')).toBeNull()
+  })
+})

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -18,6 +18,7 @@ import Switch from '../components/Switch'
 import CoverPlaceholder from '../components/CoverPlaceholder'
 import MoreMenu from '../components/MoreMenu'
 import Section from '../components/Section'
+import AuthorSyncNotice from '../components/AuthorSyncNotice'
 
 type MediaFilter = '' | 'ebook' | 'audiobook'
 // 'excluded' folds in what used to be a separate "Show excluded" checkbox. It
@@ -875,6 +876,10 @@ export default function AuthorDetailPage() {
           {error}
         </div>
       )}
+
+      {/* Books the last sync dropped, right above the list they are missing
+          from (#1889). Renders nothing when nothing was filtered out. */}
+      <AuthorSyncNotice sync={author.lastSync} />
 
       <Section
         bare


### PR DESCRIPTION
Closes #1889.

A user (Eric, v1.30.1) lost **65 books from a single author** to the allowed-languages filter and only found out because he happened to know the Debug log line existed — and he cannot reach stdout at all, because his container is rootless (#1903). The filter was doing exactly what `unknown_language_behavior=fail` promises. The bug is that the outcome was invisible.

**This does not change what gets filtered.** Only what you can see afterwards.

## Change

`Author.LastSync` — the per-run outcome (totals, per-filter counts, the allowed-language set, whether unknown-language is set to fail, and up to 5 example dropped titles) attached to author detail. It follows the existing joined-data pattern (`Books`, `Aliases`, `omitempty`) and is attached **after** the existing `auth.CheckOwnership` guard, so tenancy scoping is inherited rather than reinvented.

The summary line also moves from INFO to **WARN when anything was skipped** — INFO is the level the in-app log ring captures by default, so this reaches Settings → Logs without the operator having to reproduce at Debug.

Frontend: a note above the book list saying how many were skipped of how many works, the breakdown, the allowed languages, an explicit sentence about the `fail` setting, example titles, and a link straight to `/settings?tab=metadata`. Renders nothing on a clean run.

No new endpoint, no migration.

## Storage: in-process, deliberately

The store is a mutex-guarded per-author map, deep-copying slices on read and forgetting on author delete (SQLite reuses rowids). It is diagnostic output about a run, not library state, and the moment it matters is right after the refresh you just triggered — the same lifetime as the log ring buffer it complements.

Cost: lost on restart. Bounded by author count, roughly a few hundred bytes each.

## Verification

Five mutations, each reverted after:

```
1. dropped the LastSync attach   → author detail carries no lastSync: the catalogue sync's
                                    outcome is still invisible (#1889)   [+3 more tests]
2. removed the WARN branch       → summary logged at the wrong level: level=INFO
                                    added=1 skipped_language=3 skipped_junk=1 total=5
3. removed the sample cap        → sample length = 20, want 5
4. removed forget-on-delete      → summary survived the author delete
5. forced skipped=0 in the UI    → Unable to find [data-testid="author-sync-notice"]
```

Backend clean (`go build`, `go test ./... -count=1`, `golangci-lint` 0 issues); frontend `tsc --noEmit` clean, 55 files / 533 tests.

Docs: `docs/API.md` documents the object; `docs/Troubleshooting-Wiki.md` gains "An author has far fewer books than they should after a refresh", naming both halves of the language setting.

## Known limits, stated

- **The refresh is async and there is no polling.** `POST /author/{id}/refresh` returns 202, so immediately after clicking Refresh the note still shows the *previous* run — hence the visible timestamp. The new summary appears on the next page load. Given #1888 says a large author takes ~an hour, that is the realistic path anyway; a "running" state plus a poll was judged past proportionate for a patch.
- **5 sample titles, not all of them.** A user with 65 drops sees 5. One constant if you want more.
- **Does not touch #1888.** This makes the drop visible; it does nothing about the sync being slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)