### PR TITLE
fix(web): pin package.json to a sentinel version instead of a stale one

### DIFF
--- a/changelog.d/1897-web-package-version-sentinel.md
+++ b/changelog.d/1897-web-package-version-sentinel.md
@@ -1,0 +1,13 @@
+### Fixed
+- **The frontend package version no longer poses as a release version**
+  ([#1897](https://github.com/vavallee/bindery/issues/1897)) — `web/package.json`
+  had been frozen at `1.22.3` since that release while the app shipped 1.30.x,
+  because nothing in the release pipeline bumps it. This is metadata only, with
+  no user-visible effect: the version shown in the UI comes from the API
+  (`/system/status`), which reports the Go build's stamped version, so the app
+  never displayed the stale number. The risk was in tooling that reads the file
+  — npm banners, the vitest header, an SBOM generated from the frontend tree —
+  where `1.22.3` looked like a real, current answer. Rather than adding release
+  machinery to bump a number nothing consumes, the field is now pinned to the
+  `0.0.0` sentinel, which reads unmistakably as "not a version" and cannot drift
+  again. A test keeps it pinned.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindery-web",
-  "version": "1.22.3",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindery-web",
-      "version": "1.22.3",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "i18next": "^26.3.6",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.22.3",
+  "version": "0.0.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/web/src/packageVersion.test.ts
+++ b/web/src/packageVersion.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import pkg from '../package.json'
+
+// `web/package.json` is a private, never-published package, and the version the
+// UI shows comes from the API (`/system/status` → `main.version`, which the Go
+// build stamps from `git describe`), not from this file. A real-looking number
+// here is therefore a second, unmaintained copy of the release version: it sat
+// at 1.22.3 while the app shipped 1.30.x, because nothing in the release
+// pipeline bumps it (#1897).
+//
+// So it is pinned to the 0.0.0 sentinel — obviously a placeholder, so an SBOM
+// or an npm banner generated from this tree cannot quietly report a stale
+// version as if it were real. package.json has no comment syntax to say that
+// in place, which is what this test is for: if someone "helpfully" sets it to
+// the current release, this fails and points them here.
+describe('web package version', () => {
+  it('stays pinned to the 0.0.0 sentinel', () => {
+    expect(pkg.version).toBe('0.0.0')
+  })
+
+  it('is a private package, so npm never publishes the sentinel', () => {
+    expect(pkg.private).toBe(true)
+  })
+})

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
Closes #1897. Internal only — no user-visible effect.

`web/package.json` read `"version": "1.22.3"` while the app was on 1.30.1. Nothing reads it: the UI version comes from `/system/status`, which the Go build stamps from `git describe --tags --match 'v*'`.

There is also a **fourth** copy the issue didn't mention — `web/package-lock.json` carries the root version in two places, also at 1.22.3.

## Decision, and why it diverges from the Helm fix

The Helm `appVersion` fix (#1826) auto-bumps in `deploy-prod`. This deliberately does **not** mirror that:

- `appVersion` has a real consumer — `helm show chart` publishes it to operators. The npm version of a `private: true`, never-published package has none.
- Auto-bumping would need to touch two files, or immediately create a fresh disagreement with the lockfile.
- A release-time bump is only correct *at the tag*; every checkout in between still carries the previous version, which is the same drift in a slower form.

So it's pinned to the `0.0.0` sentinel in both files. It reads as a placeholder rather than a plausible-but-wrong number — which is the SBOM/banner failure mode the issue is actually about — and it cannot drift, because it is no longer tracking anything.

Bumping it by hand to 1.30.1 was the option I rejected: that recreates the identical problem at the next release.

## Verification

`web/src/packageVersion.test.ts` asserts the pin and the `private` flag. package.json has no comment syntax, so the test is where the reasoning is recorded for whoever next wonders why it says 0.0.0.

Mutation: setting the field to `1.30.1` fails with `expected '1.30.1' to be '0.0.0'` at `packageVersion.test.ts:18`.

Separately verified in a scratch package that `npm ci` does **not** enforce the root version against the lockfile — it tolerates both a mismatch and a removed field. So the lockfile edit is for consistency, not to avoid a break; I made it because the next `npm install` would rewrite it anyway.

Backend untouched and green. `tsc --noEmit` clean, eslint clean, 56 files / 532 tests. `.github/workflows/` not touched at all — no action pins or permissions changed.

## Noted, not fixed

`charts/bindery/Chart.yaml`'s own `version: 0.9.12` (the chart version, distinct from `appVersion`) is also hand-maintained and untouched by CI. Arguably correct for a chart version, but it's another number nobody bumps.

## Uncertainty

If some external SBOM tool treats `0.0.0` as an error rather than a placeholder, this is a behaviour change for it. The release SBOMs are syft over the Go archives, not the frontend tree, so nothing in the release path is affected — but I can't rule out a consumer outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)