### PR TITLE
fix(hardcover): carry the contribution role through search results

### DIFF
--- a/changelog.d/1892-typesense-contribution-roles.md
+++ b/changelog.d/1892-typesense-contribution-roles.md
@@ -1,0 +1,12 @@
+### Fixed
+- **Hardcover search results no longer file a book under its narrator**
+  ([#1892](https://github.com/vavallee/bindery/issues/1892)) — #1733 added a
+  contribution-role filter so an audiobook's narrator stops being treated as its
+  author, but it covered only the GraphQL book queries. The Typesense search
+  documents carry the same `contribution` field and it was never decoded, so
+  every search-sourced credit arrived with an empty role, which the filter reads
+  as "this is the author", and the first credit won. Hardcover lists the narrator
+  first on plenty of audiobook-bearing works, so anything resolved through search
+  rather than through a book query kept the pre-#1733 behaviour. The field name
+  was confirmed against the live API rather than guessed — a wrong guess would
+  have decoded to empty and silently preserved the bug while looking fixed.

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -813,6 +813,20 @@ type hcBookSearchDocument struct {
 
 type hcSearchContribution struct {
 	Author hcAuthorSearchDocument `json:"author"`
+	// Contribution is the credit role, the same free-text field the GraphQL
+	// book queries carry. #1733 filtered on it there but not here, because the
+	// Typesense document shape is not published and guessing a field name that
+	// decodes to empty would have silently kept the old behaviour while looking
+	// like coverage.
+	//
+	// Confirmed against api.hardcover.app: the field is `contribution`, and on
+	// the primary author it is either absent or explicit null — never the string
+	// "Author" — which is exactly what isAuthorContributionRole already treats as
+	// an author. Both shapes decode to "" here. The role IS spelled out for
+	// non-authors ("Narrator"). A parallel top-level `contribution_types` array
+	// does name the primary author explicitly, but it is a separate list that has
+	// to be index-matched to this one, so the per-entry field is the safer source.
+	Contribution string `json:"contribution"`
 }
 
 func parseAuthorSearchResults(raw json.RawMessage) []hcAuthor {
@@ -934,7 +948,15 @@ func bookSearchDocumentToBook(doc hcBookSearchDocument) (hcBook, bool) {
 	for _, contribution := range doc.Contributions {
 		author, ok := authorSearchDocumentToAuthor(contribution.Author)
 		if ok {
-			book.Contributions = append(book.Contributions, hcContribution{Author: author})
+			// Carry the role through. Dropping it left every search-sourced
+			// contribution with an empty role, which authorContribution reads as
+			// "is an author", so the first credit won — and Hardcover lists the
+			// narrator first on plenty of audiobook-bearing works. That is the
+			// pre-#1733 behaviour surviving on the search path (#1892).
+			book.Contributions = append(book.Contributions, hcContribution{
+				Author:       author,
+				Contribution: contribution.Contribution,
+			})
 		}
 	}
 	return book, true

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -2754,3 +2754,91 @@ func TestToBook_ContributionRoleSelection(t *testing.T) {
 		})
 	}
 }
+
+// TestSearchBooks_SkipsNarratorCreditedFirst is the #1892 regression test.
+//
+// #1733 stopped Hardcover filing books under their narrator, but only on the
+// GraphQL book queries. hcSearchContribution carried no `contribution` field, so
+// every search-sourced credit decoded with an empty role — which
+// isAuthorContributionRole reads as "this is the author" — and the first entry
+// won. Hardcover lists the narrator first on plenty of audiobook-bearing works,
+// so the pre-#1733 behaviour survived on the search path.
+//
+// The document below is the real shape, captured from api.hardcover.app for
+// "Blackflame" (the case #1879 verified): Travis Baldree carries
+// `"contribution": "Narrator"` and is listed FIRST, while Will Wight, the actual
+// author, has no `contribution` key at all. Sampling three more works
+// (Project Hail Mary, God Emperor of Dune, The Way of Kings) showed the primary
+// author's field either absent or explicit null, never the string "Author" —
+// both decode to "" here, which is what isAuthorContributionRole already accepts.
+func TestSearchBooks_SkipsNarratorCreditedFirst(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		assertSearchRequest(t, r, "Book", "Blackflame")
+		data := map[string]interface{}{
+			"search": map[string]interface{}{
+				"results": map[string]interface{}{
+					"found": 1,
+					"hits": []map[string]interface{}{
+						{
+							"document": map[string]interface{}{
+								"id":    260147,
+								"title": "Blackflame",
+								"slug":  "blackflame",
+								"contributions": []map[string]interface{}{
+									{
+										"author":       map[string]interface{}{"id": 254153, "name": "Travis Baldree", "slug": "travis-baldree"},
+										"contribution": "Narrator",
+									},
+									// No "contribution" key, exactly as the API returns it.
+									{"author": map[string]interface{}{"id": 235980, "name": "Will Wight", "slug": "will-wight"}},
+								},
+								"contribution_types": []string{"Narrator", "Author"},
+								"author_names":       []string{"Travis Baldree", "Will Wight"},
+							},
+						},
+					},
+				},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	books, err := c.SearchBooks(context.Background(), "Blackflame")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	if books[0].Author == nil {
+		t.Fatal("book has no author")
+	}
+	if got := books[0].Author.Name; got != "Will Wight" {
+		t.Errorf("Author = %q, want %q — the narrator is credited first and won", got, "Will Wight")
+	}
+}
+
+// TestSearchBooks_ExplicitNullContributionIsAnAuthor covers the other primary-author
+// shape the live API returns: `"contribution": null` rather than the key being
+// absent. Both must decode to the empty role, or a single-author book resolved
+// through search would end up with no author at all.
+func TestSearchBooks_ExplicitNullContributionIsAnAuthor(t *testing.T) {
+	encoded := `{"found":1,"hits":[{"document":{"id":"312460","title":"God Emperor of Dune","slug":"god-emperor-of-dune",` +
+		`"contributions":[{"author":{"id":9,"name":"Frank Herbert","slug":"frank-herbert"},"contribution":null}],` +
+		`"contribution_types":["Author"],"author_names":["Frank Herbert"]}}]}`
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		data := map[string]interface{}{"search": map[string]interface{}{"results": encoded}}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	books, err := c.SearchBooks(context.Background(), "Dune")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	if books[0].Author == nil || books[0].Author.Name != "Frank Herbert" {
+		t.Errorf("Author = %+v, want Frank Herbert — a null role is the author, not a rejected credit", books[0].Author)
+	}
+}


### PR DESCRIPTION
Closes #1892. Verified against the live Hardcover API rather than guessed.

#1733 stopped Hardcover filing books under their narrator, but only on the GraphQL book queries. `hcSearchContribution` carried no `contribution` field and `bookSearchDocumentToBook` dropped the role when building `hcContribution`, so every search-sourced credit arrived with an empty role — which `isAuthorContributionRole` reads as "this is the author" — and the first credit won.

Hardcover lists the narrator first on plenty of audiobook-bearing works, so anything resolved through search rather than through a book query kept the pre-#1733 behaviour.

## Why this needed a live token

#1733 deliberately left it out: the Typesense document shape is not published, and a wrong field name decodes to empty, which is the same outcome as not trying but with a false sense of coverage. So it was settled against `api.hardcover.app` instead of guessed. Captured for **Blackflame**, the case #1879 used:

```json
"contributions": [
  {"author": {"name": "Travis Baldree"}, "contribution": "Narrator"},
  {"author": {"name": "Will Wight"}}
],
"contribution_types": ["Narrator", "Author"],
"author_names": ["Travis Baldree", "Will Wight"]
```

The field is `contribution` — the same name as the GraphQL path. On the primary author it is **absent or explicit null, never the string "Author"**, across all four works sampled (Blackflame, Project Hail Mary, God Emperor of Dune, The Way of Kings). Both shapes decode to `""` in Go, which `isAuthorContributionRole` already accepts — so no filter change was needed. The role only had to survive the trip.

`contribution_types` *does* name the primary author explicitly, but it is a parallel top-level array that has to be index-matched to `contributions`, so the per-entry field is the safer source.

## Verification

Mutation — dropping the pass-through:

```
client_test.go:2817: Author = "Travis Baldree", want "Will Wight" — the narrator is
  credited first and won
```

Two tests: the Blackflame shape (narrator first, author key absent) and the explicit-`null` shape, because a single-author book would otherwise end up with no author at all.

`go build`, `go test ./... -count=1`, `golangci-lint` all clean.

Token was read from the cluster secret into a 600-mode file, never printed, and shredded along with every captured response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)