### PR TITLE
test(metadata): guard mockProvider's call recorders against the #1888 fan-out

### DIFF
--- a/internal/metadata/aggregator_test_helpers_test.go
+++ b/internal/metadata/aggregator_test_helpers_test.go
@@ -2,12 +2,30 @@ package metadata
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
 )
 
 type mockProvider struct {
+	// mu guards only the call-recording fields below (searchAuthorQueries,
+	// searchBookQueries, getBookCalls, gotBookIDs, getByISBNCalls, gotISBNs).
+	//
+	// The aggregator used to call every provider method from one goroutine, so
+	// the recorders needed no synchronisation. #1888 gave the author-works
+	// enrichment passes a bounded fan-out, and enrichBook reaches SearchBooks
+	// from each worker — so the bare `append` at SearchBooks became a genuine
+	// data race, caught by the `race (non-api)` shard.
+	//
+	// Only the writers lock. Every assertion reads these fields from the test
+	// body after the pass has returned, and concurrency.RunBounded waits on its
+	// WaitGroup before returning, which establishes the happens-before those
+	// reads need. That keeps the ~110 existing read sites untouched.
+	//
+	// The configuration fields are written once during setup and only read
+	// afterwards, so they stay unguarded.
+	mu                   sync.Mutex
 	name                 string
 	searchBooks          []models.Book
 	searchBooksByQuery   map[string][]models.Book
@@ -38,7 +56,9 @@ type mockProvider struct {
 
 func (m *mockProvider) Name() string { return m.name }
 func (m *mockProvider) SearchAuthors(_ context.Context, query string) ([]models.Author, error) {
+	m.mu.Lock()
 	m.searchAuthorQueries = append(m.searchAuthorQueries, query)
+	m.mu.Unlock()
 	if m.searchAuthorsByQuery != nil {
 		if authors, ok := m.searchAuthorsByQuery[query]; ok {
 			return authors, m.searchAuthErr
@@ -47,7 +67,9 @@ func (m *mockProvider) SearchAuthors(_ context.Context, query string) ([]models.
 	return m.searchAuthors, m.searchAuthErr
 }
 func (m *mockProvider) SearchBooks(_ context.Context, query string) ([]models.Book, error) {
+	m.mu.Lock()
 	m.searchBookQueries = append(m.searchBookQueries, query)
+	m.mu.Unlock()
 	if m.searchBooksByQuery != nil {
 		if books, ok := m.searchBooksByQuery[query]; ok {
 			return books, m.searchBookErr
@@ -59,8 +81,10 @@ func (m *mockProvider) GetAuthor(_ context.Context, _ string) (*models.Author, e
 	return m.getAuthor, m.getAuthorErr
 }
 func (m *mockProvider) GetBook(_ context.Context, foreignID string) (*models.Book, error) {
+	m.mu.Lock()
 	m.getBookCalls++
 	m.gotBookIDs = append(m.gotBookIDs, foreignID)
+	m.mu.Unlock()
 	if m.getBookByID != nil {
 		return m.getBookByID[foreignID], m.getBookErr
 	}
@@ -70,8 +94,10 @@ func (m *mockProvider) GetEditions(_ context.Context, _ string) ([]models.Editio
 	return m.getEditions, m.getEditionsErr
 }
 func (m *mockProvider) GetBookByISBN(_ context.Context, isbn string) (*models.Book, error) {
+	m.mu.Lock()
 	m.getByISBNCalls++
 	m.gotISBNs = append(m.gotISBNs, isbn)
+	m.mu.Unlock()
 	if m.getByISBNByISBN != nil {
 		return m.getByISBNByISBN[isbn], m.getByISBNErr
 	}


### PR DESCRIPTION
Fixes the red `race (non-api)` shard on the v1.30.2 tag.

## The race is in the test stub, not in shipped code

`mockProvider` records every call by appending to a plain slice. That was safe while the aggregator called each provider method from one goroutine. #1888 gave the author-works enrichment passes a bounded fan-out, and `enrichBook` reaches `SearchBooks` from each worker:

```
aggregator_author_works.go:285      RunBounded
aggregator_enrichment.go:276        enrichBook -> enricher.SearchBooks
aggregator_test_helpers_test.go:50  append, unsynchronised   <-- both sides of the race
```

**Production code on that path was checked, not assumed:**

- `RunBounded` hands each index to exactly one goroutine, so `&books[i]` is never shared between workers.
- `a.enrichers` is read-only after construction.
- The enrichment cache is a `ttlCache` whose `get`/`set` are both guarded by a `sync.RWMutex`.

**Nothing in the shipped v1.30.2 binary races.** The tag stands; this is a broken CI signal, not a broken release.

## Change

A `sync.Mutex` on `mockProvider`, taken by the four recording methods only (`SearchAuthors`, `SearchBooks`, `GetBookByID`, `GetByISBN`).

Writers lock; readers don't. Every assertion reads these fields from the test body after the pass has returned, and `RunBounded` waits on its `WaitGroup` before returning, which establishes the happens-before those reads need. That keeps the **~110 existing read sites** untouched. Configuration fields are written once during setup and only read afterwards, so they stay unguarded.

## Verification

Reproduced on `origin/main` before fixing, with a stack matching the CI failure exactly. Clean with the fix.

Mutation — removing just the `SearchBooks` lock:

| runs | GOMAXPROCS | races detected |
|---|---|---|
| 5 | default | 0 |
| 40 | default | 0 |
| 30 | 8 | **2** |

**Roughly 7% per run.** That is the part worth remembering: a local `go test -race` on the #1888 branch came back clean and only the CI shard caught it. A single clean `-race` run is not evidence of absence — this needs `-count` and load to surface.

Full `-race` sweep of the non-api packages (`metadata/...`, `notifier/...`, `indexer/...`, `importer/...`) is clean. `golangci-lint` 0 issues.

No changelog fragment — test-only, no user-visible behaviour.

refs #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)