### PR TITLE
perf(importer): walk the library once per author sync, not once per book

### DIFF
--- a/changelog.d/1888-library-walk-per-book.md
+++ b/changelog.d/1888-library-walk-per-book.md
@@ -1,0 +1,21 @@
+### Fixed
+- **An author sync no longer walks the entire library once per new book**
+  ([#1888](https://github.com/vavallee/bindery/issues/1888),
+  [#1929](https://github.com/vavallee/bindery/issues/1929)) — before queuing a
+  search for each book it creates, the sync checks whether the file already
+  exists on disk, and that check did a full recursive walk of every library
+  root, per book. A sync that added 65 books walked the whole library 65 times.
+  On local disk the OS caches the directory tree and the cost hides; on an NFS
+  or SMB mount every walk is real network round trips per directory entry, and
+  at a few dozen seconds per walk this alone accounts for the reported
+  hour-long refresh. The sync now takes one snapshot of the library per
+  refresh: each root is walked once, on first use, and every per-book check is
+  answered from memory with the same matching rules as before — same root
+  selection per media type, same author-folder pre-filter, same title and
+  author comparison, in the same order. The walk also now honours cancellation,
+  which it previously ignored, so deleting an author mid-refresh stops the
+  filesystem work instead of letting it run to completion. One-off checks
+  (adding a single book, series add, recommendations) keep their per-call walk
+  and see the library exactly as it is at that moment; only files copied in by
+  hand while a refresh is mid-flight are invisible to that refresh's snapshot,
+  and the next refresh sees them.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1607,6 +1607,18 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 	searchQueue := make([]models.Book, 0)
 	autoSearchEnabled := autoSearch && h.searcher != nil && author.Monitored && h.isAutoGrabEnabled(ctx)
 
+	// One library snapshot for the whole create loop (#1888, #1929). The loop
+	// below calls handleNewWantedBook once per new book, and its FindExisting
+	// used to re-walk every library root per call — a 65-book sync did 65 full
+	// walks of the library, which on network storage is minutes to an hour of
+	// pure stat traffic. The snapshot walks each root once, on first use.
+	//
+	// The staleness this buys is deliberate and near-vacuous here: a file that
+	// can match a book this loop is creating was on disk before the sync began,
+	// because auto-search for these books only runs after the loop. See the
+	// LibrarySnapshot contract for the full argument.
+	finder := snapshotFinder(h.finder)
+
 	// Strict media-type policy (#1575). When on and the default is a single
 	// format, catalogue population is narrowed to that format so an ebook-only
 	// (or audiobook-only) user never accumulates rows they can't grab.
@@ -1840,7 +1852,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 		h.hydrateHardcoverEditions(ctx, &b)
 		added++
 
-		if fileFound := handleNewWantedBook(ctx, h.books, h.series, h.finder, b, author.Name); fileFound {
+		if fileFound := handleNewWantedBook(ctx, h.books, h.series, finder, b, author.Name); fileFound {
 			continue // don't auto-search for a book we already have
 		}
 

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -5505,5 +5506,96 @@ func TestFetchAuthorBooks_AdoptsPersistedOwnerOverStaleSnapshot(t *testing.T) {
 	}
 	if got.OwnerUserID != owner.ID {
 		t.Fatalf("book owner = %d, want the author row's persisted owner %d", got.OwnerUserID, owner.ID)
+	}
+}
+
+// snapshottingStubFinder implements the librarySnapshotter capability so the
+// sync-side seam can be pinned: FetchAuthorBooks must take ONE snapshot before
+// its create loop and route every per-book lookup through it, never through
+// the finder's own per-call FindExisting. If the loop regressed to h.finder
+// directly, perCallQueries would record the lookups and the assertion below
+// names the regression.
+type snapshottingStubFinder struct {
+	snapshot       *importer.LibrarySnapshot
+	snapshotsTaken int
+	perCallQueries []string
+}
+
+func (f *snapshottingStubFinder) FindExisting(_ context.Context, title, _, _ string) string {
+	f.perCallQueries = append(f.perCallQueries, title)
+	return ""
+}
+
+func (f *snapshottingStubFinder) SnapshotFinder() *importer.LibrarySnapshot {
+	f.snapshotsTaken++
+	return f.snapshot
+}
+
+// TestFetchAuthorBooks_UsesOneLibrarySnapshotForTheLoop is the api half of
+// #1888/#1929: the create loop calls FindExisting once per new book, and each
+// call used to walk the whole library. The fix is one snapshot per sync, so
+// this pins three things at once — the snapshot is taken exactly once, the
+// per-book lookups all go through it (the on-disk book gets its file path from
+// the snapshot's temp library), and the finder's per-call path is never used.
+func TestFetchAuthorBooks_UsesOneLibrarySnapshotForTheLoop(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	libDir := t.TempDir()
+	ownedPath := filepath.Join(libDir, "Snapshot Author", "Owned Book - Snapshot Author.epub")
+	if err := os.MkdirAll(filepath.Dir(ownedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ownedPath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL900A", Name: "Snapshot Author", SortName: "Author, Snapshot",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubMetaProvider{
+		works: []models.Book{
+			{ForeignID: "OL901W", Title: "Owned Book", SortTitle: "owned book", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary", MediaType: models.MediaTypeEbook},
+			{ForeignID: "OL902W", Title: "Missing Book", SortTitle: "missing book", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary", MediaType: models.MediaTypeEbook},
+		},
+	}
+	finder := &snapshottingStubFinder{snapshot: importer.NewLibrarySnapshot(libDir, "")}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(stub), nil, profileRepo, nil).WithFinder(finder)
+
+	h.FetchAuthorBooks(author, false, "")
+
+	if finder.snapshotsTaken != 1 {
+		t.Errorf("snapshots taken = %d, want exactly 1 per sync", finder.snapshotsTaken)
+	}
+	if len(finder.perCallQueries) != 0 {
+		t.Errorf("per-call FindExisting ran for %v — the loop bypassed the snapshot and paid a library walk per book", finder.perCallQueries)
+	}
+	owned, err := bookRepo.GetByForeignID(ctx, "OL901W")
+	if err != nil || owned == nil {
+		t.Fatalf("owned book not created: err=%v", err)
+	}
+	if owned.FilePath != ownedPath {
+		t.Errorf("owned book file path = %q, want %q from the snapshot's library", owned.FilePath, ownedPath)
+	}
+	missing, err := bookRepo.GetByForeignID(ctx, "OL902W")
+	if err != nil || missing == nil {
+		t.Fatalf("missing book not created: err=%v", err)
+	}
+	if missing.FilePath != "" {
+		t.Errorf("missing book unexpectedly got a file path %q", missing.FilePath)
 	}
 }

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/textutil"
 )
@@ -32,6 +33,28 @@ type BookMetaLookup interface {
 // mis-attributed to a book of the opposite media type.
 type LibraryFinder interface {
 	FindExisting(ctx context.Context, title, authorName, mediaType string) string
+}
+
+// librarySnapshotter is the optional capability behind LibraryFinder: a finder
+// that can hand out a snapshot answering many FindExisting queries from one
+// walk of each library root. The author sync asserts for it before its create
+// loop, because that loop calls FindExisting once per new book and each call
+// used to re-walk the entire library — 65 full walks for a 65-book author,
+// which on network storage is the right order of magnitude for the reported
+// hour-long refresh (#1888, #1929). Implemented by *importer.Scanner; a finder
+// without the capability keeps its per-call behaviour.
+type librarySnapshotter interface {
+	SnapshotFinder() *importer.LibrarySnapshot
+}
+
+// snapshotFinder returns a batch-friendly view of finder when it offers one,
+// and finder itself otherwise (including nil, which callers already treat as a
+// no-op).
+func snapshotFinder(finder LibraryFinder) LibraryFinder {
+	if sn, ok := finder.(librarySnapshotter); ok {
+		return sn.SnapshotFinder()
+	}
+	return finder
 }
 
 // parseID extracts the `{id}` URL parameter as an int64. If the value is

--- a/internal/importer/library_snapshot.go
+++ b/internal/importer/library_snapshot.go
@@ -1,0 +1,177 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// LibrarySnapshot answers FindExisting queries from one walk of each library
+// root instead of one walk per query.
+//
+// FindExisting is called once per book an author sync creates, and each call
+// used to re-walk the whole library tree (#1888/#1929). On local disk with a
+// warm dentry cache that hides; on an NFS/SMB mount with a large library a
+// single walk can take seconds, and a 65-book sync paid it 65 times — which is
+// the right order of magnitude for the reported "an hour to add 65 books". The
+// walk also parses every filename per call, so the sync re-ran the same
+// ParseFilename work per book.
+//
+// A snapshot walks a root at most once, on the first query that needs it, and
+// serves every later query from the parsed entries. It deliberately holds only
+// the two root paths, not a *Scanner, so tests and callers can build one over
+// a bare directory.
+//
+// Staleness, stated: files that appear under a root after that root's walk are
+// invisible to later queries on the same snapshot. Within an author sync that
+// window is close to vacuous — auto-search for the books being created runs
+// after the create loop, so any file that can match one of them was on disk
+// before the sync started; only a file copied in by hand mid-sync is missed,
+// and the next sync sees it. One-off callers get a fresh snapshot per call
+// (Scanner.FindExisting), which is exactly the old semantics.
+type LibrarySnapshot struct {
+	libraryDir   string
+	audiobookDir string
+
+	mu    sync.Mutex
+	roots map[string][]libraryEntry
+}
+
+// libraryEntry is one book file, pre-parsed at walk time so queries are pure
+// in-memory comparisons.
+type libraryEntry struct {
+	path string
+	// firstDir is the first path segment under the root — the author folder in
+	// an Author/Title layout. Empty for files sitting directly under the root,
+	// which the author pre-filter has always exempted.
+	firstDir string
+	title    string
+	author   string
+}
+
+// NewLibrarySnapshot builds an empty snapshot over the given roots. Roots are
+// walked lazily, each on the first query that selects it, so a snapshot that
+// only ever sees ebook queries never touches the audiobook root.
+func NewLibrarySnapshot(libraryDir, audiobookDir string) *LibrarySnapshot {
+	return &LibrarySnapshot{libraryDir: libraryDir, audiobookDir: audiobookDir}
+}
+
+// FindExisting reports the first library file matching title/author, or "".
+// Semantics are identical to the pre-snapshot Scanner walk: the same media-type
+// root selection, the same author-folder pre-filter, the same title/author
+// match, in the same walk order — only the walk count changes.
+func (ls *LibrarySnapshot) FindExisting(ctx context.Context, title, authorName, mediaType string) string {
+	if title == "" {
+		return ""
+	}
+	for _, root := range ls.rootsForMediaType(mediaType) {
+		entries, ok := ls.entriesFor(ctx, root)
+		if !ok {
+			// Cancelled mid-walk: match the old walk's behaviour of quietly
+			// finding nothing, and leave the root uncached so a live caller
+			// gets a real walk.
+			return ""
+		}
+		for i := range entries {
+			e := &entries[i]
+			if authorName != "" && e.firstDir != "" && !authorMatch(authorName, e.firstDir) {
+				continue
+			}
+			if titleMatch(e.title, title) && authorMatch(authorName, e.author) {
+				return e.path
+			}
+		}
+	}
+	return ""
+}
+
+// rootsForMediaType selects which roots a query walks: ebook → libraryDir,
+// audiobook → audiobookDir (falling back to libraryDir when unset), both or
+// unknown → both with libraryDir first (#488).
+func (ls *LibrarySnapshot) rootsForMediaType(mediaType string) []string {
+	roots := make([]string, 0, 2)
+	switch mediaType {
+	case models.MediaTypeEbook:
+		if ls.libraryDir != "" {
+			roots = append(roots, ls.libraryDir)
+		}
+	case models.MediaTypeAudiobook:
+		switch {
+		case ls.audiobookDir != "":
+			roots = append(roots, ls.audiobookDir)
+		case ls.libraryDir != "":
+			roots = append(roots, ls.libraryDir)
+		}
+	default:
+		if ls.libraryDir != "" {
+			roots = append(roots, ls.libraryDir)
+		}
+		if ls.audiobookDir != "" && ls.audiobookDir != ls.libraryDir {
+			roots = append(roots, ls.audiobookDir)
+		}
+	}
+	return roots
+}
+
+// entriesFor returns the cached entries for root, walking it on first use. The
+// second return is false only when the walk was abandoned on a cancelled
+// context — that result is not cached, so the cancellation of one sync cannot
+// blind a later caller.
+func (ls *LibrarySnapshot) entriesFor(ctx context.Context, root string) ([]libraryEntry, bool) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if entries, ok := ls.roots[root]; ok {
+		return entries, true
+	}
+	entries, ok := walkLibraryEntries(ctx, root)
+	if !ok {
+		return nil, false
+	}
+	if ls.roots == nil {
+		ls.roots = make(map[string][]libraryEntry)
+	}
+	ls.roots[root] = entries
+	return entries, true
+}
+
+// walkLibraryEntries collects every book file under root. Unreadable entries
+// are skipped rather than aborting the walk, matching the old per-query walk;
+// a missing root simply yields no entries. Returns ok=false only on context
+// cancellation, which the old walk ignored outright (#1929) — a cancelled sync
+// kept walking the whole tree.
+func walkLibraryEntries(ctx context.Context, root string) ([]libraryEntry, bool) {
+	var entries []libraryEntry
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if ctx.Err() != nil {
+			return filepath.SkipAll
+		}
+		if err != nil || info.IsDir() {
+			return nil //nolint:nilerr // best-effort walk: skip unreadable entries rather than abort
+		}
+		if !IsBookFile(path) {
+			return nil
+		}
+		firstDir := ""
+		if rel, relErr := filepath.Rel(root, path); relErr == nil {
+			if parts := strings.SplitN(rel, string(filepath.Separator), 2); len(parts) >= 2 {
+				firstDir = parts[0]
+			}
+		}
+		parsed := ParseFilename(path)
+		entries = append(entries, libraryEntry{
+			path:     path,
+			firstDir: firstDir,
+			title:    parsed.Title,
+			author:   parsed.Author,
+		})
+		return nil
+	})
+	if ctx.Err() != nil {
+		return nil, false
+	}
+	return entries, true
+}

--- a/internal/importer/library_snapshot_test.go
+++ b/internal/importer/library_snapshot_test.go
@@ -1,0 +1,119 @@
+package importer
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestLibrarySnapshot_WalksARootOnce pins the whole point of the snapshot
+// (#1888/#1929): a root is walked on the first query and never again, so a
+// batch of per-book lookups pays one walk instead of one per book.
+//
+// The pin is behavioural, not instrumented: a file created AFTER the first
+// query must be invisible to the same snapshot but visible to a fresh one. If
+// the caching is removed the snapshot re-walks and finds the late file, and
+// this test fails — which is exactly the per-book-walk behaviour being fixed.
+func TestLibrarySnapshot_WalksARootOnce(t *testing.T) {
+	libDir := t.TempDir()
+	first := filepath.Join(libDir, "Jane Doe", "First Book - Jane Doe.epub")
+	writeFile(t, first)
+
+	snap := NewLibrarySnapshot(libDir, "")
+	if got := snap.FindExisting(context.Background(), "First Book", "Jane Doe", models.MediaTypeEbook); got != first {
+		t.Fatalf("first query: got %q, want %q", got, first)
+	}
+
+	late := filepath.Join(libDir, "Jane Doe", "Late Book - Jane Doe.epub")
+	writeFile(t, late)
+
+	if got := snap.FindExisting(context.Background(), "Late Book", "Jane Doe", models.MediaTypeEbook); got != "" {
+		t.Errorf("snapshot saw a file created after its walk (%q) — the root was walked again", got)
+	}
+	if got := NewLibrarySnapshot(libDir, "").FindExisting(context.Background(), "Late Book", "Jane Doe", models.MediaTypeEbook); got != late {
+		t.Errorf("fresh snapshot: got %q, want %q — the late file is genuinely findable", got, late)
+	}
+}
+
+// TestLibrarySnapshot_MatchesWalkSemantics holds the snapshot to the exact
+// predicate of the old per-query walk: the author-folder pre-filter rejects a
+// same-titled file under another author's folder, files directly under the
+// root are exempt from the pre-filter (their filename author still counts),
+// and a title mismatch never matches.
+func TestLibrarySnapshot_MatchesWalkSemantics(t *testing.T) {
+	libDir := t.TempDir()
+	// Same title under the WRONG author folder, with NO author in the filename:
+	// the parsed author is empty, which authorMatch treats as unfalsifiable, so
+	// the folder pre-filter is the ONLY thing standing between this file and a
+	// false match for Matt Dinniman (the David Wong case the old walk's comment
+	// names). A filename that carries the wrong author is caught later by the
+	// filename-level check and would mask a pre-filter regression here.
+	wrongAuthor := filepath.Join(libDir, "David Wong", "Dungeon Crawler Carl.epub")
+	writeFile(t, wrongAuthor)
+	// The real book, directly under the root — depth 1, so no folder to
+	// pre-filter on; the parsed filename author carries the match.
+	rootLevel := filepath.Join(libDir, "Dungeon Crawler Carl - Matt Dinniman.epub")
+	writeFile(t, rootLevel)
+
+	snap := NewLibrarySnapshot(libDir, "")
+	if got := snap.FindExisting(context.Background(), "Dungeon Crawler Carl", "Matt Dinniman", models.MediaTypeEbook); got != rootLevel {
+		t.Errorf("got %q, want %q — the author pre-filter or the root-level exemption drifted from the walk's", got, rootLevel)
+	}
+	if got := snap.FindExisting(context.Background(), "Some Other Title", "Matt Dinniman", models.MediaTypeEbook); got != "" {
+		t.Errorf("title mismatch matched %q", got)
+	}
+}
+
+// TestLibrarySnapshot_MediaTypeRootSelection carries the #488 root-selection
+// contract over to the snapshot: ebook → library root, audiobook → audiobook
+// root, audiobook falls back to the library root when no audiobook root is
+// configured.
+func TestLibrarySnapshot_MediaTypeRootSelection(t *testing.T) {
+	libDir := t.TempDir()
+	abDir := t.TempDir()
+	ebookPath := filepath.Join(libDir, "Jane Doe", "Title - Jane Doe.epub")
+	audioPath := filepath.Join(abDir, "Jane Doe", "Title - Jane Doe.m4b")
+	writeFile(t, ebookPath)
+	writeFile(t, audioPath)
+
+	snap := NewLibrarySnapshot(libDir, abDir)
+	if got := snap.FindExisting(context.Background(), "Title", "Jane Doe", models.MediaTypeEbook); got != ebookPath {
+		t.Errorf("ebook: got %q, want %q", got, ebookPath)
+	}
+	if got := snap.FindExisting(context.Background(), "Title", "Jane Doe", models.MediaTypeAudiobook); got != audioPath {
+		t.Errorf("audiobook: got %q, want %q", got, audioPath)
+	}
+
+	// No audiobook root configured: audiobook queries fall back to the library
+	// root instead of finding nothing.
+	fallback := NewLibrarySnapshot(libDir, "")
+	audioInLib := filepath.Join(libDir, "Jane Doe", "Spoken - Jane Doe.m4b")
+	writeFile(t, audioInLib)
+	if got := fallback.FindExisting(context.Background(), "Spoken", "Jane Doe", models.MediaTypeAudiobook); got != audioInLib {
+		t.Errorf("audiobook fallback: got %q, want %q", got, audioInLib)
+	}
+}
+
+// TestLibrarySnapshot_CancelledContextIsNotCached covers the two halves of the
+// cancellation contract. The old walk ignored its ctx entirely (#1929), so a
+// cancelled sync kept paying the full walk; the snapshot must abandon the walk
+// — and must NOT cache the truncated result, or one cancelled sync would blind
+// every later query to the whole library.
+func TestLibrarySnapshot_CancelledContextIsNotCached(t *testing.T) {
+	libDir := t.TempDir()
+	path := filepath.Join(libDir, "Jane Doe", "Title - Jane Doe.epub")
+	writeFile(t, path)
+
+	snap := NewLibrarySnapshot(libDir, "")
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := snap.FindExisting(cancelled, "Title", "Jane Doe", models.MediaTypeEbook); got != "" {
+		t.Errorf("cancelled query returned %q, want nothing", got)
+	}
+	// The same snapshot with a live context must do a real walk and find it.
+	if got := snap.FindExisting(context.Background(), "Title", "Jane Doe", models.MediaTypeEbook); got != path {
+		t.Errorf("post-cancel query: got %q, want %q — the abandoned walk was cached", got, path)
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1579,70 +1579,19 @@ func largestFileIsVideo(downloadPath string, explicitFiles []string) bool {
 // called before auto-searching so books the user already owns are not
 // re-downloaded.
 func (s *Scanner) FindExisting(ctx context.Context, title, authorName, mediaType string) string {
-	if title == "" {
-		return ""
-	}
-	roots := make([]string, 0, 2)
-	switch mediaType {
-	case models.MediaTypeEbook:
-		if s.libraryDir != "" {
-			roots = append(roots, s.libraryDir)
-		}
-	case models.MediaTypeAudiobook:
-		switch {
-		case s.audiobookDir != "":
-			roots = append(roots, s.audiobookDir)
-		case s.libraryDir != "":
-			roots = append(roots, s.libraryDir)
-		}
-	default:
-		if s.libraryDir != "" {
-			roots = append(roots, s.libraryDir)
-		}
-		if s.audiobookDir != "" && s.audiobookDir != s.libraryDir {
-			roots = append(roots, s.audiobookDir)
-		}
-	}
-	for _, root := range roots {
-		if found := s.findExistingInDir(root, title, authorName); found != "" {
-			return found
-		}
-	}
-	return ""
+	// A fresh snapshot per call is exactly the old semantics: one walk of each
+	// selected root, now cancellable. Callers with many lookups against the
+	// same library state — the author sync creates one lookup per new book —
+	// should hold one SnapshotFinder across the batch instead (#1888/#1929).
+	return s.SnapshotFinder().FindExisting(ctx, title, authorName, mediaType)
 }
 
-// findExistingInDir walks a single root directory looking for a book file
-// whose title matches and whose parent directory agrees with the expected
-// author, preventing cross-author false matches.
-func (s *Scanner) findExistingInDir(root, title, authorName string) string {
-	var found string
-	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() || found != "" {
-			return nil
-		}
-		if !IsBookFile(path) {
-			return nil
-		}
-		// Author-folder pre-filter: the first directory under root must match
-		// the expected author. This prevents a file under books/David Wong/
-		// from being matched as a Matt Dinniman book.
-		if authorName != "" {
-			if rel, relErr := filepath.Rel(root, path); relErr == nil {
-				parts := strings.SplitN(rel, string(filepath.Separator), 2)
-				if len(parts) >= 2 && !authorMatch(authorName, parts[0]) {
-					return nil
-				}
-			}
-		}
-		parsed := ParseFilename(path)
-		if titleMatch(parsed.Title, title) && authorMatch(authorName, parsed.Author) {
-			found = path
-		}
-		return nil
-	}); err != nil {
-		slog.Warn("failed to search library for existing file", "path", root, "error", err)
-	}
-	return found
+// SnapshotFinder returns a LibrarySnapshot over this scanner's roots: a
+// FindExisting that walks each library root at most once and answers every
+// later query from the parsed entries. See LibrarySnapshot for the staleness
+// contract.
+func (s *Scanner) SnapshotFinder() *LibrarySnapshot {
+	return NewLibrarySnapshot(s.libraryDir, s.audiobookDir)
 }
 
 // normalizeTitle folds a title into the shared title-comparison alphabet


### PR DESCRIPTION
The second half of the #1888 measurement, and the first item in #1929 — the one with unbounded cost, because it scales with the user's storage rather than with provider latency.

## The problem

`handleNewWantedBook` runs once per book an author sync creates, and its `FindExisting` did a **full recursive walk of every library root per call**. A 65-book sync walked the whole library 65 times, re-running `ParseFilename` over every file each time, and the walk ignored its `ctx` so a cancelled sync kept walking.

On local disk the dentry cache hides this. On an NFS/SMB mount every walk is real network round trips per directory entry — and at tens of seconds per walk, **65 walks is the right order of magnitude for the reported hour**. Of everything measured in #1888, this is the only cost that can plausibly reach 55 s/book on its own.

## The fix

`importer.LibrarySnapshot`: one walk per root, taken lazily on the first query that selects that root, entries parsed once, every later query a pure in-memory scan. It holds only the two root paths — not a `*Scanner` — so anything can build one over a bare directory.

**Matching semantics are identical by construction and by test**: same media-type root selection (#488), same author-folder pre-filter with the same depth-1 exemption, same title/author predicate, same walk order.

Three call shapes, three behaviours:

| caller | behaviour |
|---|---|
| author sync create loop | **one snapshot for the whole loop** (the fix) |
| `Scanner.FindExisting` one-offs (AddBook, series add, recommendations) | fresh snapshot per call — byte-for-byte the old semantics |
| non-snapshotting finders (tests, nil) | unchanged per-call path |

The sync picks the snapshot up through an optional `librarySnapshotter` capability interface, so `LibraryFinder` consumers and every existing mock are untouched.

## Staleness, argued rather than waved at

The snapshot is blind to files appearing under a root after that root's walk — but only within one sync. That window is near-vacuous: **a file that can match a book the loop is creating was on disk before the sync began**, because auto-search for those books runs only after the loop completes. The only miss is a file copied in by hand mid-refresh, and the next refresh sees it. One-off callers keep perfectly fresh reads.

## Cancellation, fixed as flagged in #1929

The walk aborts via `filepath.SkipAll` on `ctx.Err()`, and an abandoned walk is **not cached** — one cancelled sync must not blind later queries to the entire library. Both halves are pinned by test.

## Verification

Four mutations, each reverted after:

```
1. loop bypasses the snapshot   → per-call FindExisting ran for [Owned Book Missing Book],
                                   owned book file path = ""
2. remove the entry cache       → snapshot saw a file created after its walk — the root
                                   was walked again
3. drop the author pre-filter   → matched the wrong author's folder
4. cache the cancelled walk     → post-cancel query got "" — the abandoned walk was cached
```

Two honesty notes on the mutations. My first attempt at (1) failed the build rather than the test, which proves nothing — redone as a compiling mutation in `snapshotFinder`. And (3) initially *survived*, because my fixture's wrong-author file carried the author in its filename, so the filename-level check masked the folder pre-filter; the fixture now uses an author-less filename, which makes the folder filter the only guard — and the mutation fails.

The pre-existing `TestFindExisting_*` suite passes unchanged over the delegated path. Full `go test ./... -count=1` green, `-race` on the new tests at `-count=3` clean (a single `-race` run stopped being persuasive after #1924), `golangci-lint` 0 issues.

## What this doesn't do

The other #1929 item — batching the per-book Hardcover `GetEditions` (`_in`, the #1694 shape) — is bounded (~1 HTTP call/book) and stays tracked there. #1888 remains open pending Eric's timing answer; if his hour was on network storage, this PR is the likely fix, and his re-test on the next release will tell us.

refs #1888, #1929

🤖 Generated with [Claude Code](https://claude.com/claude-code)