### PR TITLE
fix(indexer): stop querying an indexer that said to come back later

### DIFF
--- a/changelog.d/1934-indexer-rate-limit-cooldown.md
+++ b/changelog.d/1934-indexer-rate-limit-cooldown.md
@@ -1,0 +1,31 @@
+### Fixed
+- **A rate-limited indexer is left alone until it says to come back**
+  ([#1934](https://github.com/vavallee/bindery/issues/1934)) — when an indexer
+  answers a search with a Newznab 500 (`Request limit reached. Retry in 485
+  minutes.`) Bindery used to record nothing, so the next search and every search
+  for the following eight hours sent it another request it had already refused.
+  The rate-limit classification existed but was consulted only inside a single
+  search, to stop the query cascade falling through to lower tiers. The retry
+  hint is now parsed out of the indexer's own message and that indexer is
+  skipped until the deadline passes, across the scheduled wanted scan, on-add
+  and bulk searches, and interactive search alike — they share one searcher, so
+  a limit hit by one is respected by all of them. An indexer that gives no hint
+  gets an hour; a parsed hint is clamped to between a minute and a day so a
+  malformed or absurd value cannot bench an indexer indefinitely. Editing the
+  indexer clears the hold immediately, so a new API key or a different account
+  takes effect on the next search rather than waiting out a lockout that
+  belonged to the old configuration. Interactive search reports the held indexer
+  as skipped with the deadline in the Search details panel, in the same place
+  the original error appeared, rather than dropping it from the list.
+
+  Two related gaps are deliberately untouched here and tracked separately:
+  authentication failures (a suspended account, a revoked key) get no cooldown,
+  because they never heal on a timer and a user who fixes their key must see it
+  work immediately — those need visibility and a notification
+  ([#1935](https://github.com/vavallee/bindery/issues/1935)) — and auto-grab
+  still decides from whatever indexers answered without recording that the
+  others were unreachable
+  ([#1936](https://github.com/vavallee/bindery/issues/1936)). The cooldown is
+  held in memory, so a restart costs one refused request per indexer per search
+  before it re-learns the limit, which is exactly the old behaviour and never
+  worse.

--- a/internal/indexer/cooldown.go
+++ b/internal/indexer/cooldown.go
@@ -1,0 +1,188 @@
+package indexer
+
+import (
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// Cooldown bounds. A rate-limit rejection carries no obligation to say when to
+// come back, so an indexer that just says "request limit reached" gets the
+// default. A parsed hint is clamped: an indexer claiming a multi-week lockout
+// (or sending a malformed number that parses to something absurd) must not be
+// able to bench itself indefinitely without the user ever seeing why, and a
+// hint of zero must not produce a cooldown that has already expired.
+const (
+	defaultRateLimitCooldown = time.Hour
+	minRateLimitCooldown     = time.Minute
+	maxRateLimitCooldown     = 24 * time.Hour
+)
+
+// retryHintRe matches the "Retry in 485 minutes" clause indexers append to a
+// Newznab 500 description. Case-insensitive, tolerant of the unit being
+// singular or plural, and anchored on nothing — the clause appears mid-sentence
+// after the human-readable reason.
+var retryHintRe = regexp.MustCompile(`(?i)retry\s+in\s+(\d+)\s*(second|minute|hour|day)s?`)
+
+// parseRetryHint extracts the indexer's own "come back in N units" hint from a
+// rate-limit description. Returns false when the description carries no hint,
+// which is common — the caller falls back to defaultRateLimitCooldown.
+func parseRetryHint(desc string) (time.Duration, bool) {
+	m := retryHintRe.FindStringSubmatch(desc)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		// Unreachable given the \d+ group, but a 20-digit number overflows
+		// Atoi and must not be read as zero.
+		return 0, false
+	}
+	var unit time.Duration
+	switch strings.ToLower(m[2]) {
+	case "second":
+		unit = time.Second
+	case "minute":
+		unit = time.Minute
+	case "hour":
+		unit = time.Hour
+	case "day":
+		unit = 24 * time.Hour
+	default:
+		return 0, false
+	}
+	return time.Duration(n) * unit, true
+}
+
+// cooldownEntry is one indexer's active lockout.
+type cooldownEntry struct {
+	until  time.Time
+	reason string
+	// recordedAt is when the lockout was registered, compared against the
+	// indexer row's UpdatedAt so an edit cancels it. See cooldownActive.
+	recordedAt time.Time
+}
+
+// indexerCooldowns tracks which indexers have told us to stop asking, and until
+// when.
+//
+// A Newznab 500 ("Request limit reached. Retry in 485 minutes.") is an explicit
+// instruction, and before #1934 Bindery discarded it: the classification in
+// newznab.IsRateLimitError was consulted only to abort tier fall-through within
+// a single search, so the next search — and every search for the next eight
+// hours — sent another request the indexer had already refused. On indexers
+// that count refused requests against the quota, that can stop the window ever
+// clearing.
+//
+// State is in memory on the single shared *Searcher (cmd/bindery/main.go), so
+// both the scheduler's auto-grab and the API's interactive search observe the
+// same cooldowns. It is lost on restart, which costs one refused request per
+// indexer per search afterwards — exactly the pre-#1934 behaviour, so a restart
+// can only ever return to the old cost, never do worse. Persisting it waits on
+// the indexer health-state work (#1935), which needs columns of its own.
+//
+// The zero value is ready to use.
+type indexerCooldowns struct {
+	mu      sync.Mutex
+	entries map[int64]cooldownEntry
+	// now is injectable so tests can advance time without sleeping. nil means
+	// time.Now.
+	now func() time.Time
+}
+
+func (c *indexerCooldowns) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// note records a cooldown for idx if err is a rate-limit rejection, and reports
+// whether it did. Auth failures (1xx) are deliberately excluded: a suspended
+// account or a bad API key never heals on a timer, and benching the indexer for
+// hours would mean a user who fixes their key sits there wondering why nothing
+// happens. Those need visibility and a notification instead (#1935).
+//
+// Indexers with no id (id 0) are not tracked — there is nothing stable to key
+// on, and every such indexer would share one entry.
+func (c *indexerCooldowns) note(idx models.Indexer, err error) bool {
+	if idx.ID == 0 || !newznab.IsRateLimitError(err) {
+		return false
+	}
+
+	d := defaultRateLimitCooldown
+	if hinted, ok := parseRetryHint(err.Error()); ok {
+		d = hinted
+	}
+	d = max(min(d, maxRateLimitCooldown), minRateLimitCooldown)
+
+	now := c.clock()
+	entry := cooldownEntry{
+		until:      now.Add(d),
+		reason:     err.Error(),
+		recordedAt: now,
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[int64]cooldownEntry)
+	}
+	c.entries[idx.ID] = entry
+	slog.Info("indexer rate-limited; holding off further searches",
+		"indexer", idx.Name, "until", entry.until.Format(time.RFC3339), "error", err)
+	return true
+}
+
+// active reports whether idx is currently in cooldown, and if so a
+// human-readable reason naming the deadline.
+//
+// A cooldown is dropped when the indexer row has been edited since it was
+// recorded (UpdatedAt newer than recordedAt). Changing an indexer is the user
+// saying "try this again" — a new API key, a different account, a re-enable —
+// and making them wait out a lockout that belonged to the old configuration
+// would be the wrong answer. The loops already hold the full models.Indexer, so
+// this needs no extra wiring back into the handlers.
+func (c *indexerCooldowns) active(idx models.Indexer) (string, bool) {
+	if idx.ID == 0 {
+		return "", false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[idx.ID]
+	if !ok {
+		return "", false
+	}
+	if !idx.UpdatedAt.IsZero() && idx.UpdatedAt.After(entry.recordedAt) {
+		delete(c.entries, idx.ID)
+		return "", false
+	}
+	now := c.clock()
+	if !now.Before(entry.until) {
+		delete(c.entries, idx.ID)
+		return "", false
+	}
+	remaining := entry.until.Sub(now).Round(time.Minute)
+	if remaining < time.Minute {
+		remaining = time.Minute
+	}
+	return fmt.Sprintf("rate limited, retrying in %s (%s)", remaining, entry.reason), true
+}
+
+// cooldownActive reports whether the searcher is currently holding off on idx.
+func (s *Searcher) cooldownActive(idx models.Indexer) (string, bool) {
+	return s.cooldowns.active(idx)
+}
+
+// noteIndexerError records a rate-limit cooldown for idx when err is one.
+func (s *Searcher) noteIndexerError(idx models.Indexer, err error) {
+	s.cooldowns.note(idx, err)
+}

--- a/internal/indexer/cooldown_test.go
+++ b/internal/indexer/cooldown_test.go
@@ -1,0 +1,255 @@
+package indexer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestParseRetryHint(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want time.Duration
+		ok   bool
+	}{
+		// The description that prompted #1934, verbatim from NZB.life.
+		{"minutes, real-world", "indexer error 500: Request limit reached. Retry in 485 minutes.", 485 * time.Minute, true},
+		{"singular unit", "Request limit reached. Retry in 1 hour", time.Hour, true},
+		{"seconds", "Too many requests, retry in 30 seconds", 30 * time.Second, true},
+		{"days", "Grab limit reached. Retry in 1 day.", 24 * time.Hour, true},
+		{"case insensitive", "RETRY IN 5 MINUTES", 5 * time.Minute, true},
+		{"space-free unit", "retry in 12minutes", 12 * time.Minute, true},
+		// No hint at all is the common case: the caller falls back to the
+		// default rather than treating it as "retry immediately".
+		{"no hint", "Request limit reached", 0, false},
+		{"unit we don't understand", "Retry in 3 fortnights", 0, false},
+		{"number missing", "Retry in a while", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseRetryHint(tc.desc)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Errorf("duration = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCooldownClampsHint pins the two ends of the clamp: an indexer cannot
+// bench itself for a month, and a zero-length hint cannot produce a cooldown
+// that has already expired by the time it is stored.
+func TestCooldownClampsHint(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		desc string
+		want time.Duration
+	}{
+		{"absurdly long hint is capped", "Request limit reached. Retry in 30 days.", maxRateLimitCooldown},
+		{"zero hint gets the floor", "Request limit reached. Retry in 0 minutes.", minRateLimitCooldown},
+		{"no hint gets the default", "Request limit reached.", defaultRateLimitCooldown},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &indexerCooldowns{now: func() time.Time { return now }}
+			if !c.note(models.Indexer{ID: 1, Name: "idx"}, &newznab.IndexerError{Code: 500, Description: tc.desc}) {
+				t.Fatal("note did not record a cooldown for a 500")
+			}
+			c.mu.Lock()
+			got := c.entries[1].until.Sub(now)
+			c.mu.Unlock()
+			if got != tc.want {
+				t.Errorf("cooldown = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCooldownExpires holds the deadline to the indexer's OWN hint: still held
+// one minute before it, released one minute after. The hint (485 minutes) is
+// deliberately far from defaultRateLimitCooldown, so a build that ignores the
+// hint and always applies the default fails this rather than coincidentally
+// passing it.
+func TestCooldownExpires(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	c := &indexerCooldowns{now: func() time.Time { return now }}
+	idx := models.Indexer{ID: 7, Name: "NZB.life"}
+	c.note(idx, &newznab.IndexerError{Code: 500, Description: "Request limit reached. Retry in 485 minutes."})
+
+	if _, held := c.active(idx); !held {
+		t.Fatal("indexer is not in cooldown immediately after a 500")
+	}
+	now = now.Add(484 * time.Minute)
+	reason, held := c.active(idx)
+	if !held {
+		t.Error("cooldown released a minute before the indexer said to come back")
+	}
+	if !strings.Contains(reason, "rate limited") {
+		t.Errorf("reason = %q, want it to name the rate limit", reason)
+	}
+	now = now.Add(2 * time.Minute)
+	if _, held := c.active(idx); held {
+		t.Error("cooldown outlived the deadline the indexer gave")
+	}
+}
+
+// TestCooldownClearedByIndexerEdit covers the recovery path: changing the
+// indexer row (new API key, different account, re-enable) means the user wants
+// it retried now, and must not be made to wait out a lockout that belonged to
+// the old configuration.
+func TestCooldownClearedByIndexerEdit(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	c := &indexerCooldowns{now: func() time.Time { return now }}
+	idx := models.Indexer{ID: 7, Name: "NZB.life", UpdatedAt: now.Add(-time.Hour)}
+	c.note(idx, &newznab.IndexerError{Code: 500, Description: "Request limit reached. Retry in 485 minutes."})
+
+	if _, held := c.active(idx); !held {
+		t.Fatal("indexer is not in cooldown after a 500")
+	}
+	edited := idx
+	edited.UpdatedAt = now.Add(time.Minute)
+	if _, held := c.active(edited); held {
+		t.Error("an edited indexer is still held; the user's change should retry immediately")
+	}
+	// The entry is gone, not merely bypassed, so the un-edited copy is clear too.
+	if _, held := c.active(idx); held {
+		t.Error("the cooldown entry survived the edit")
+	}
+}
+
+// TestCooldownIgnoresNonRateLimitErrors is the deliberate scope line of #1934:
+// a suspended account (101) or a network failure must not bench the indexer on
+// a timer. Auth failures need a human, and one who fixes their API key must see
+// it work immediately (#1935).
+func TestCooldownIgnoresNonRateLimitErrors(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	idx := models.Indexer{ID: 3, Name: "NZB Finder"}
+	for _, err := range []error{
+		&newznab.IndexerError{Code: 101, Description: "Account suspended"},
+		&newznab.IndexerError{Code: 100, Description: "Incorrect user credentials"},
+		context.DeadlineExceeded,
+	} {
+		c := &indexerCooldowns{now: func() time.Time { return now }}
+		if c.note(idx, err) {
+			t.Errorf("%v recorded a cooldown", err)
+		}
+		if _, held := c.active(idx); held {
+			t.Errorf("%v put the indexer in cooldown", err)
+		}
+	}
+}
+
+// TestCooldownIgnoresUnidentifiedIndexers guards the map key: an indexer with
+// no id has nothing stable to key on, and tracking them all under 0 would let
+// one rate-limited indexer bench every other unsaved one.
+func TestCooldownIgnoresUnidentifiedIndexers(t *testing.T) {
+	c := &indexerCooldowns{}
+	idx := models.Indexer{Name: "unsaved"}
+	if c.note(idx, &newznab.IndexerError{Code: 500, Description: "Request limit reached."}) {
+		t.Error("recorded a cooldown against indexer id 0")
+	}
+	if _, held := c.active(idx); held {
+		t.Error("an id-less indexer is in cooldown")
+	}
+}
+
+// rateLimitedIndexer serves the Newznab 500 that NZB.life sends and counts how
+// many times it was asked.
+func rateLimitedIndexer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+			`<error code="500" description="Request limit reached. Retry in 485 minutes."/>`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// TestSearchBookStopsQueryingARateLimitedIndexer is the behavioural pin for
+// #1934: the second search must not reach an indexer that already said to come
+// back in 485 minutes.
+func TestSearchBookStopsQueryingARateLimitedIndexer(t *testing.T) {
+	srv, hits := rateLimitedIndexer(t)
+	s := newTestSearcher()
+	idxs := []models.Indexer{{ID: 1, Name: "NZB.life", URL: srv.URL, Enabled: true, Categories: []int{7020}}}
+	crit := MatchCriteria{Title: "Redshirts", Author: "John Scalzi", MediaType: models.MediaTypeEbook}
+
+	s.SearchBook(context.Background(), idxs, crit)
+	first := hits.Load()
+	if first == 0 {
+		t.Fatal("the first search never reached the indexer")
+	}
+
+	s.SearchBook(context.Background(), idxs, crit)
+	if got := hits.Load(); got != first {
+		t.Errorf("the indexer was queried %d more time(s) while in cooldown", got-first)
+	}
+}
+
+// TestSearchBookWithDebugReportsCooldown pins the visibility half: the panel
+// that showed the original error must also show why the indexer is no longer
+// being queried, rather than silently dropping it from the list.
+func TestSearchBookWithDebugReportsCooldown(t *testing.T) {
+	srv, hits := rateLimitedIndexer(t)
+	s := newTestSearcher()
+	idxs := []models.Indexer{{ID: 1, Name: "NZB.life", URL: srv.URL, Enabled: true, Categories: []int{7020}}}
+	crit := MatchCriteria{Title: "Redshirts", Author: "John Scalzi", MediaType: models.MediaTypeEbook}
+
+	_, dbg := s.SearchBookWithDebug(context.Background(), idxs, crit)
+	if len(dbg.Indexers) != 1 || dbg.Indexers[0].Error == "" {
+		t.Fatalf("first search did not record the indexer error: %+v", dbg.Indexers)
+	}
+	first := hits.Load()
+
+	_, dbg = s.SearchBookWithDebug(context.Background(), idxs, crit)
+	if got := hits.Load(); got != first {
+		t.Errorf("the indexer was queried %d more time(s) while in cooldown", got-first)
+	}
+	if len(dbg.Indexers) != 1 {
+		t.Fatalf("the held indexer vanished from the debug output: %+v", dbg.Indexers)
+	}
+	entry := dbg.Indexers[0]
+	if !entry.Skipped {
+		t.Error("the held indexer is not marked skipped")
+	}
+	if !strings.Contains(entry.SkipReason, "rate limited") {
+		t.Errorf("skipReason = %q, want it to explain the rate limit", entry.SkipReason)
+	}
+}
+
+// TestCooldownIsSharedAcrossSearchPaths matters because one *Searcher is shared
+// by the scheduler's auto-grab and the API's interactive search
+// (cmd/bindery/main.go). A limit hit by one must be respected by the other, or
+// the 12-hour wanted scan keeps hammering an indexer the user can see is held.
+func TestCooldownIsSharedAcrossSearchPaths(t *testing.T) {
+	srv, hits := rateLimitedIndexer(t)
+	s := newTestSearcher()
+	idxs := []models.Indexer{{ID: 1, Name: "NZB.life", URL: srv.URL, Enabled: true, Categories: []int{7020}}}
+
+	s.SearchBookWithDebug(context.Background(), idxs, MatchCriteria{Title: "Redshirts", Author: "John Scalzi", MediaType: models.MediaTypeEbook})
+	first := hits.Load()
+	if first == 0 {
+		t.Fatal("the interactive search never reached the indexer")
+	}
+
+	s.SearchBook(context.Background(), idxs, MatchCriteria{Title: "Lock In", Author: "John Scalzi", MediaType: models.MediaTypeEbook})
+	s.SearchQuery(context.Background(), idxs, "scalzi")
+	if got := hits.Load(); got != first {
+		t.Errorf("auto-grab and freeform search sent %d more request(s) to a held indexer", got-first)
+	}
+}

--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -115,6 +115,18 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 			mu.Unlock()
 			continue
 		}
+		// An indexer that told us to come back later is reported as skipped
+		// rather than silently omitted, so the panel that showed the original
+		// rate-limit error also shows why it is no longer being queried
+		// (#1934).
+		if reason, held := s.cooldownActive(idx); held {
+			entry.Skipped = true
+			entry.SkipReason = reason
+			mu.Lock()
+			perIdx = append(perIdx, entry)
+			mu.Unlock()
+			continue
+		}
 
 		wg.Add(1)
 		go func(idx models.Indexer, entry IndexerDebug) {
@@ -129,6 +141,7 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 			entry.DurationMs = time.Since(start).Milliseconds()
 			if err != nil {
 				entry.Error = err.Error()
+				s.noteIndexerError(idx, err)
 				slog.Warn("indexer search failed", "indexer", idx.Name, "error", err)
 				mu.Lock()
 				perIdx = append(perIdx, entry)

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -42,6 +42,11 @@ type Searcher struct {
 	// cache that respects their factory.
 	cacheOnce sync.Once
 	cache     *clientCache
+
+	// cooldowns holds the indexers that have answered a search with a
+	// rate-limit rejection, so we stop asking until the deadline they gave
+	// us passes (#1934). The zero value is ready to use.
+	cooldowns indexerCooldowns
 }
 
 // NewSearcher creates a new multi-indexer searcher.
@@ -250,6 +255,10 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 		if !idx.Enabled {
 			continue
 		}
+		if reason, held := s.cooldownActive(idx); held {
+			slog.Debug("skipping indexer in rate-limit cooldown", "indexer", idx.Name, "reason", reason)
+			continue
+		}
 		wg.Add(1)
 		go func(idx models.Indexer) {
 			defer wg.Done()
@@ -258,6 +267,7 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 			cats := filterCategoriesForMedia(idx.Categories, c.MediaType, idx.IncludeParentCategories)
 			hits, err := client.BookSearch(ctx, c.Title, c.Author, cats)
 			if err != nil {
+				s.noteIndexerError(idx, err)
 				slog.Warn("indexer search failed", "indexer", idx.Name, "error", err)
 				return
 			}
@@ -316,6 +326,10 @@ func (s *Searcher) SearchQuery(ctx context.Context, indexers []models.Indexer, q
 		if !idx.Enabled {
 			continue
 		}
+		if reason, held := s.cooldownActive(idx); held {
+			slog.Debug("skipping indexer in rate-limit cooldown", "indexer", idx.Name, "reason", reason)
+			continue
+		}
 		wg.Add(1)
 		go func(idx models.Indexer) {
 			defer wg.Done()
@@ -323,6 +337,7 @@ func (s *Searcher) SearchQuery(ctx context.Context, indexers []models.Indexer, q
 			client := s.makeClient(idx.URL, idx.APIKey)
 			hits, err := client.Search(ctx, query, idx.Categories)
 			if err != nil {
+				s.noteIndexerError(idx, err)
 				slog.Warn("indexer search failed", "indexer", idx.Name, "error", err)
 				return
 			}


### PR DESCRIPTION
Closes #1934.

## The defect

An indexer answers a search with a Newznab 500:

```
indexer error 500: Request limit reached. Retry in 485 minutes.
```

Bindery recorded nothing. `newznab.IsRateLimitError` existed and was consulted at `newznab/client.go:387,459,471,504`, but only to abort tier fall-through *within one search* — nothing outlived the call, and `Searcher` had no per-indexer state. So the next search, and every search for the following eight hours, sent that indexer another request it had already refused. On indexers that count refused requests against the quota, that can stop the window ever clearing.

The hint saying exactly when to come back arrived as free text in `IndexerError.Description` and was thrown away.

## The change

`internal/indexer/cooldown.go` (new) holds a per-indexer deadline on the shared `*Searcher` — one instance, `cmd/bindery/main.go:317`, used by both the scheduler and the API handlers, so a limit hit by auto-grab is respected by interactive search and vice versa.

- `parseRetryHint` reads `retry in <N> second|minute|hour|day` out of the description, case-insensitively. No hint means an hour.
- The duration is clamped to `[1m, 24h]`: an indexer must not be able to bench itself for a month, and a zero-length hint must not produce a cooldown that has already expired.
- All three fan-out loops (`SearchBook`, `SearchQuery`, `SearchBookWithDebug`) skip a held indexer and record the cooldown on error.
- `SearchBookWithDebug` marks it `Skipped` with a `SkipReason` naming the deadline. Both fields already existed on `IndexerDebug` and `SearchDebugPanel.tsx:95` already renders them, so the hold appears in the same panel the original error did. No frontend change.
- A cooldown is dropped when `models.Indexer.UpdatedAt` is newer than when it was recorded. Editing an indexer is the user saying "try this again", and the loops already receive the full struct, so this needs no wiring back into the handlers.

## Scope lines, both deliberate

**Auth errors (1xx) get no cooldown.** A suspended account or a revoked key never heals on a timer, and silently benching an indexer for hours after someone mistypes an API key would be worse than today — the moment they fix it, it has to work. Those need visibility and a notification, which is #1935.

**No persistence, no migration.** The state is in memory and lost on restart, costing one refused request per indexer per search afterwards, i.e. exactly the pre-fix behaviour — a restart can only return to the old cost, never do worse. Persisting it wants a column, an API field and a UI surface, all of which #1935 needs anyway; doing it here would design that schema twice.

Also related: #1936, auto-grab still deciding from whatever indexers answered without recording that the rest were unreachable.

## Verification

`go test ./... -count=1` green; `internal/indexer` at `-race -count=3` clean; `golangci-lint run ./internal/indexer/...` 0 issues.

Six mutations, each confirmed to fail the test that should catch it, so none of the new tests are vacuous:

| Mutation | Test that fails |
|---|---|
| `SearchBook` no longer skips held indexers | `TestSearchBookStopsQueryingARateLimitedIndexer`, `TestCooldownIsSharedAcrossSearchPaths` |
| `SearchBookWithDebug` no longer skips | `TestSearchBookWithDebugReportsCooldown` (queried again, and `skipped`/`skipReason` empty) |
| cool down on every hard error, not just 5xx | `TestCooldownIgnoresNonRateLimitErrors` (101 and 100 both held) |
| never clear a cooldown on an indexer edit | `TestCooldownClearedByIndexerEdit` |
| drop the clamp | `TestCooldownClampsHint` (30 days survives as 720h) |
| ignore the retry hint, always use the default | `TestCooldownExpires`, `TestCooldownClampsHint` |

The last one is why `TestCooldownExpires` uses a 485-minute hint rather than 60: with a 60-minute hint it would pass against a build that ignored the hint entirely, since the default is an hour.