### PR TITLE
fix(importer): trust the file's language over the provider's

### DIFF
--- a/changelog.d/1933-embedded-language-correction.md
+++ b/changelog.d/1933-embedded-language-correction.md
@@ -1,0 +1,24 @@
+### Fixed
+- **A book whose file is in a different language than the catalogue says now
+  gets corrected on import**
+  ([#1933](https://github.com/vavallee/bindery/issues/1933)) — the language on a
+  book page came from the metadata provider, which describes the abstract
+  *work*, not the file you actually hold. The embedded `dc:language` tag was
+  read only when the provider had supplied nothing at all, so a Spanish EPUB
+  imported against an English OpenLibrary record displayed "English"
+  indefinitely, with the release name buried in a history row the only hint
+  otherwise. The tag is now read on every EPUB import and, when it disagrees
+  with the stored value, the file wins: a work has editions in many languages,
+  but the file on disk is one specific edition and is the thing you open. The
+  correction is recorded as a **Language Corrected** history event showing both
+  codes, so "why does my English book read as Spanish" has an answer in the
+  place you would look for it rather than only in a log line.
+
+  Precedence is user, then file, then provider. A language you set by hand locks
+  the field, and a locked field is left alone — the EPUB is not even opened.
+  Filling a language the catalogue never had is unchanged and stays silent: it
+  is a gap being filled, not a disagreement, and OpenLibrary routinely supplies
+  no work-level language at all. Comparison normalises both sides first, so a
+  provider's `en` against a file's `eng` is not mistaken for a conflict, and
+  nothing is written when an import fails — a book that never landed must not
+  rewrite its own catalogue entry.

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -566,6 +566,56 @@ func (s *Scanner) createHistoryEvent(ctx context.Context, eventType string, sour
 	}
 }
 
+// applyEmbeddedLanguage reconciles the language recorded for a book with the
+// one embedded in the EPUB just imported for it.
+//
+// Precedence is user > file > provider. A user's own edit locks the field and
+// the caller never even opens the EPUB. Otherwise the file wins: a provider
+// describes an abstract *work* whose editions exist in many languages, while
+// the file on disk is one specific edition and is the thing the user opens.
+// Before #1933 the provider won unconditionally, so a Spanish EPUB imported
+// against an English OpenLibrary record displayed "English" indefinitely, with
+// the release name buried in a history row the only hint otherwise.
+//
+// detected is expected already normalised to ISO 639-2/B (ReadEpubMetadata does
+// this); book.Language is normalised here before comparing because provider
+// values arrive in both two- and three-letter forms (#1729).
+//
+// Best-effort throughout: a persistence failure is logged and leaves the
+// existing value alone rather than failing an import that otherwise succeeded.
+func (s *Scanner) applyEmbeddedLanguage(ctx context.Context, book *models.Book, detected, sourceTitle string) {
+	if book == nil || detected == "" {
+		return
+	}
+	previous := models.NormalizeLanguageCode(book.Language)
+	if previous == detected {
+		return
+	}
+	if err := s.books.SetLanguage(ctx, book.ID, detected); err != nil {
+		slog.Warn("failed to persist EPUB-detected language", "bookID", book.ID, "language", detected, "error", err)
+		return
+	}
+	book.Language = detected
+
+	if previous == "" {
+		// The catalogue had nothing; this is the #1160 backfill, and there is
+		// no disagreement to report.
+		slog.Info("filled book language from embedded EPUB metadata", "bookID", book.ID, "language", detected)
+		return
+	}
+	// A genuine disagreement means the file is not the edition the catalogue
+	// described. That is worth a history row: it is the answer to "why does my
+	// English book read as Spanish", and the language field alone cannot say
+	// that it was ever wrong.
+	slog.Info("corrected book language from embedded EPUB metadata",
+		"bookID", book.ID, "from", previous, "to", detected)
+	bookID := book.ID
+	s.createHistoryEvent(ctx, models.HistoryEventBookLanguageCorrected, sourceTitle, &bookID, map[string]string{
+		"from": previous,
+		"to":   detected,
+	})
+}
+
 func (s *Scanner) markDownloadFailed(ctx context.Context, dl *models.Download, message string) {
 	s.setDownloadError(ctx, dl.ID, message)
 	s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": message})
@@ -1181,11 +1231,18 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// RemoveAll-ing the whole download path (issue #705 finding 4).
 	var importedSrcFiles []string
 	// detectedLang holds a language read from an embedded EPUB dc:language, used
-	// to backfill an empty book language after the loop (#1160). Captured inside
-	// the loop because move mode consumes the source file on commit, so it must
-	// be read while srcFile still exists.
+	// after the loop to fill or correct the book's language (#1160, #1933).
+	// Captured inside the loop because move mode consumes the source file on
+	// commit, so it must be read while srcFile still exists.
+	//
+	// The tag is read on every import, not only when the catalogue left the
+	// field empty. A provider describes a *work*, which has editions in many
+	// languages; the file on disk is one specific edition, so when they
+	// disagree the file is the one telling the truth (#1933). Only a user's own
+	// edit outranks it, and that locks the field — in which case the EPUB is
+	// not opened at all.
 	var detectedLang string
-	fillLanguage := book != nil && book.Language == "" && !book.IsFieldLocked(models.BookFieldLanguage)
+	readLanguage := book != nil && !book.IsFieldLocked(models.BookFieldLanguage)
 	// Resolve the ebook destination root and (auto) placement mode once: the
 	// root is stable for this author across the loop, and choosing hardlink-vs-
 	// copy against it rather than s.libraryDir avoids a cross-device hardlink
@@ -1203,7 +1260,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		// Read the embedded EPUB language while the source is still present
 		// (move mode deletes it on commit). Only when we actually intend to
 		// backfill, so we never open the zip needlessly.
-		if fillLanguage && detectedLang == "" && IsEpubFile(srcFile) {
+		if readLanguage && detectedLang == "" && IsEpubFile(srcFile) {
 			if meta, err := ReadEpubMetadata(srcFile); err == nil && meta.Language != "" {
 				detectedLang = meta.Language
 			}
@@ -1296,18 +1353,11 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath, "format": models.MediaTypeEbook})
 	}
 
-	// Backfill the book's language from the embedded EPUB dc:language when the
-	// catalogue left it empty (#1160). Providers frequently have no work-level
-	// language (OpenLibrary especially), so an imported file is often the most
-	// reliable source. Best-effort: gated on an empty, unlocked field and at
-	// least one imported file; a persistence error just leaves it empty.
-	if fillLanguage && imported > 0 && detectedLang != "" {
-		if err := s.books.SetLanguage(ctx, book.ID, detectedLang); err != nil {
-			slog.Warn("failed to persist EPUB-detected language", "bookID", book.ID, "language", detectedLang, "error", err)
-		} else {
-			slog.Info("filled book language from embedded EPUB metadata", "bookID", book.ID, "language", detectedLang)
-			book.Language = detectedLang
-		}
+	// Reconcile the book's language with the file that just landed (#1160,
+	// #1933). Gated on at least one imported file: a failed import must not
+	// rewrite the catalogue from a file that is not in the library.
+	if readLanguage && imported > 0 && detectedLang != "" {
+		s.applyEmbeddedLanguage(ctx, book, detectedLang, dl.Title)
 	}
 
 	// If every file failed to copy/move, the destination is likely not writable —

--- a/internal/importer/scanner_language_test.go
+++ b/internal/importer/scanner_language_test.go
@@ -2,6 +2,7 @@ package importer
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,9 +33,9 @@ func writeEpubWithLanguage(t *testing.T, dst, language string) {
 	}
 }
 
-// languageFixture wires an author + ebook book (empty language) + a completed
-// download pointing at it, and returns the scanner, download, book repo and ctx.
-func languageFixture(t *testing.T, libraryDir string, book *models.Book) (*Scanner, *models.Download, *db.BookRepo, context.Context) {
+// languageFixture wires an author + ebook book + a completed download pointing
+// at it, and returns the scanner, download, book repo, history repo and ctx.
+func languageFixture(t *testing.T, libraryDir string, book *models.Book) (*Scanner, *models.Download, *db.BookRepo, *db.HistoryRepo, context.Context) {
 	t.Helper()
 	database, err := db.OpenMemory()
 	if err != nil {
@@ -69,7 +70,7 @@ func languageFixture(t *testing.T, libraryDir string, book *models.Book) (*Scann
 	if err := dlRepo.Create(ctx, dl); err != nil {
 		t.Fatal(err)
 	}
-	return s, dl, bookRepo, ctx
+	return s, dl, bookRepo, histRepo, ctx
 }
 
 // TestTryImportInternal_FillsLanguageFromEpub verifies the #1160 import-time
@@ -86,7 +87,7 @@ func TestTryImportInternal_FillsLanguageFromEpub(t *testing.T) {
 		ForeignID: "OL-lang-book", Title: "Recursion", SortTitle: "recursion",
 		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook, Language: "",
 	}
-	s, dl, bookRepo, ctx := languageFixture(t, libraryDir, book)
+	s, dl, bookRepo, _, ctx := languageFixture(t, libraryDir, book)
 
 	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", "", nil, nil)
 
@@ -115,7 +116,7 @@ func TestTryImportInternal_DoesNotOverwriteLockedLanguage(t *testing.T) {
 		Language:     "eng",
 		LockedFields: []string{models.BookFieldLanguage},
 	}
-	s, dl, bookRepo, ctx := languageFixture(t, libraryDir, book)
+	s, dl, bookRepo, hist, ctx := languageFixture(t, libraryDir, book)
 
 	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", "", nil, nil)
 
@@ -125,5 +126,181 @@ func TestTryImportInternal_DoesNotOverwriteLockedLanguage(t *testing.T) {
 	}
 	if got.Language != "eng" {
 		t.Fatalf("locked language = %q, want %q (must not be overwritten by EPUB de)", got.Language, "eng")
+	}
+	// Precedence is user > file > provider (#1933): the lock wins outright, so
+	// there is no disagreement to report either.
+	if events := correctionEvents(t, ctx, hist); len(events) != 0 {
+		t.Errorf("a locked field produced %d correction event(s), want 0", len(events))
+	}
+}
+
+// correctionEvents returns the bookLanguageCorrected rows recorded for the
+// book, decoded into from/to pairs.
+func correctionEvents(t *testing.T, ctx context.Context, hist *db.HistoryRepo) []map[string]string {
+	t.Helper()
+	events, err := hist.ListByType(ctx, models.HistoryEventBookLanguageCorrected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make([]map[string]string, 0, len(events))
+	for _, e := range events {
+		var data map[string]string
+		if err := json.Unmarshal([]byte(e.Data), &data); err != nil {
+			t.Fatalf("event data %q: %v", e.Data, err)
+		}
+		out = append(out, data)
+	}
+	return out
+}
+
+// TestTryImportInternal_CorrectsLanguageWhenEpubDisagrees is the #1933 fix: the
+// catalogue said English (a work-level value from the provider), the file that
+// actually landed is Spanish, and the file wins. Before this the embedded tag
+// was only read when the catalogue field was empty, so the book displayed
+// "English" for a Spanish EPUB indefinitely.
+func TestTryImportInternal_CorrectsLanguageWhenEpubDisagrees(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	downloadPath := t.TempDir()
+	writeEpubWithLanguage(t, filepath.Join(downloadPath, "Recursion.epub"), "es")
+
+	book := &models.Book{
+		ForeignID: "OL-lang-correct", Title: "Recursion", SortTitle: "recursion",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook,
+		Language: "eng",
+	}
+	s, dl, bookRepo, hist, ctx := languageFixture(t, libraryDir, book)
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", "", nil, nil)
+
+	got, err := bookRepo.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Language != "spa" {
+		t.Errorf("book language = %q, want %q (the imported file is Spanish)", got.Language, "spa")
+	}
+
+	// The correction must be visible, not silent: the language field alone
+	// cannot say the catalogue was ever wrong.
+	events := correctionEvents(t, ctx, hist)
+	if len(events) != 1 {
+		t.Fatalf("got %d correction events, want 1", len(events))
+	}
+	if events[0]["from"] != "eng" || events[0]["to"] != "spa" {
+		t.Errorf("event data = %v, want from=eng to=spa", events[0])
+	}
+}
+
+// TestTryImportInternal_NoCorrectionWhenLanguagesAgree guards against a write
+// and a history row on every single import. The stored value is deliberately
+// the two-letter "en" a provider supplies rather than the canonical "eng":
+// the catalogue is NOT normalised on write, so comparing raw strings would see
+// "en" against the EPUB's normalised "eng", call it a disagreement, and
+// "correct" every English book to English on every import (#1729).
+func TestTryImportInternal_NoCorrectionWhenLanguagesAgree(t *testing.T) {
+	t.Parallel()
+
+	for _, stored := range []string{"en", "eng", "en-US"} {
+		t.Run(stored, func(t *testing.T) {
+			t.Parallel()
+
+			libraryDir := t.TempDir()
+			downloadPath := t.TempDir()
+			writeEpubWithLanguage(t, filepath.Join(downloadPath, "Recursion.epub"), "en")
+
+			book := &models.Book{
+				ForeignID: "OL-lang-agree-" + stored, Title: "Recursion", SortTitle: "recursion",
+				Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook,
+				Language: stored,
+			}
+			s, dl, bookRepo, hist, ctx := languageFixture(t, libraryDir, book)
+
+			s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", "", nil, nil)
+
+			got, err := bookRepo.GetByID(ctx, book.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Language != stored {
+				t.Errorf("book language = %q, want %q unchanged — the EPUB agrees, so nothing should be written", got.Language, stored)
+			}
+			if events := correctionEvents(t, ctx, hist); len(events) != 0 {
+				t.Errorf("got %d correction events for an agreeing language, want 0: %v", len(events), events)
+			}
+		})
+	}
+}
+
+// TestTryImportInternal_FillEmitsNoCorrectionEvent keeps the two cases apart.
+// Filling a language the catalogue never had is the #1160 backfill and is not
+// a correction — nothing disagreed, so a history row would be noise on every
+// OpenLibrary import, which routinely arrives with no work-level language.
+func TestTryImportInternal_FillEmitsNoCorrectionEvent(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	downloadPath := t.TempDir()
+	writeEpubWithLanguage(t, filepath.Join(downloadPath, "Recursion.epub"), "es")
+
+	book := &models.Book{
+		ForeignID: "OL-lang-fill", Title: "Recursion", SortTitle: "recursion",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook,
+		Language: "",
+	}
+	s, dl, bookRepo, hist, ctx := languageFixture(t, libraryDir, book)
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", "", nil, nil)
+
+	got, err := bookRepo.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Language != "spa" {
+		t.Errorf("book language = %q, want %q", got.Language, "spa")
+	}
+	if events := correctionEvents(t, ctx, hist); len(events) != 0 {
+		t.Errorf("a backfill emitted %d correction event(s), want 0", len(events))
+	}
+}
+
+// TestTryImportInternal_NoLanguageWriteWhenNothingImported pins the guard on
+// the reconcile: the EPUB is read while the source file still exists, which is
+// before we know whether any file actually landed. A failed import must not
+// rewrite the catalogue from a file that is not in the library — the user would
+// be left with a book whose language describes something they do not have.
+func TestTryImportInternal_NoLanguageWriteWhenNothingImported(t *testing.T) {
+	t.Parallel()
+
+	// A library root whose parent is a regular file: every MkdirAll under it
+	// fails with ENOTDIR for any user, so no file can be placed.
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	libraryDir := filepath.Join(blocker, "library")
+
+	downloadPath := t.TempDir()
+	writeEpubWithLanguage(t, filepath.Join(downloadPath, "Recursion.epub"), "es")
+
+	book := &models.Book{
+		ForeignID: "OL-lang-noimport", Title: "Recursion", SortTitle: "recursion",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook,
+		Language: "eng",
+	}
+	s, dl, bookRepo, hist, ctx := languageFixture(t, libraryDir, book)
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", "", nil, nil)
+
+	got, err := bookRepo.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Language != "eng" {
+		t.Errorf("book language = %q, want %q — nothing was imported, so nothing should have been rewritten", got.Language, "eng")
+	}
+	if events := correctionEvents(t, ctx, hist); len(events) != 0 {
+		t.Errorf("a failed import emitted %d correction event(s), want 0", len(events))
 	}
 }

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -86,4 +86,10 @@ const (
 	HistoryEventDownloadStalled      = "downloadStalled"
 	HistoryEventDownloadRequeued     = "downloadRequeued"
 	HistoryEventBookRebound          = "bookRebound"
+	// HistoryEventBookLanguageCorrected records that an imported EPUB's
+	// embedded dc:language disagreed with the language the metadata provider
+	// supplied, and the file's value was adopted (#1933). Data carries "from"
+	// and "to". Only emitted on a disagreement — filling a language the
+	// catalogue never had is not a correction.
+	HistoryEventBookLanguageCorrected = "bookLanguageCorrected"
 )

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -359,7 +359,8 @@
       "bookImported": "Book Imported",
       "bookFileDeleted": "File Deleted",
       "bookRenamed": "File Renamed",
-      "bookRebound": "Rebound"
+      "bookRebound": "Rebound",
+      "bookLanguageCorrected": "Language Corrected"
     },
     "empty": "No history events found",
     "colEvent": "Event",

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -16,6 +16,9 @@ const EVENT_TYPE_COLORS: Record<string, string> = {
   renamed: 'bg-purple-500/20 text-purple-400',
   ignored: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400',
   bookFileRenamed: 'bg-purple-500/20 text-purple-400',
+  // Amber rather than green: the import worked, but the file turned out not to
+  // be the edition the catalogue described, which is worth a second look.
+  bookLanguageCorrected: 'bg-amber-500/20 text-amber-600 dark:text-amber-400',
 }
 
 // humanizeEventType turns a camelCase event enum into a Title Case fallback
@@ -36,6 +39,18 @@ function formatDate(s: string) {
 function parseEventData(data: string): { message?: string; path?: string; size?: number; [k: string]: unknown } {
   if (!data) return {}
   try { return JSON.parse(data) } catch { return {} }
+}
+
+// Detail line shown under the source title. Most events carry a `message` or a
+// `path`; a language correction carries `from`/`to` ISO codes, which only mean
+// anything shown together.
+function eventDetail(type: string, parsed: ReturnType<typeof parseEventData>): string {
+  if (type === 'bookLanguageCorrected') {
+    const from = typeof parsed.from === 'string' ? parsed.from : ''
+    const to = typeof parsed.to === 'string' ? parsed.to : ''
+    if (from && to) return `${from} → ${to}`
+  }
+  return parsed.message || parsed.path || ''
 }
 
 function formatSize(n: number): string {
@@ -74,6 +89,7 @@ const KNOWN_EVENT_TYPES = [
   'downloadStalled',
   'downloadRequeued',
   'bookRebound',
+  'bookLanguageCorrected',
 ]
 
 export default function HistoryPage() {
@@ -177,7 +193,7 @@ export default function HistoryPage() {
                 <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
                   {events.map(event => {
                     const parsed = parseEventData(event.data)
-                    const detail = parsed.message || parsed.path || ''
+                    const detail = eventDetail(event.eventType, parsed)
                     const isError = event.eventType === 'downloadFailed' || event.eventType === 'importFailed'
                     const size = typeof parsed.size === 'number' ? parsed.size : 0
                     const mt = detectMediaType(event.sourceTitle)
@@ -243,7 +259,7 @@ export default function HistoryPage() {
           <div className="sm:hidden space-y-2">
             {events.map(event => {
               const parsed = parseEventData(event.data)
-              const detail = parsed.message || parsed.path || ''
+              const detail = eventDetail(event.eventType, parsed)
               const isError = event.eventType === 'downloadFailed' || event.eventType === 'importFailed'
               const size = typeof parsed.size === 'number' ? parsed.size : 0
               const mt = detectMediaType(event.sourceTitle)


### PR DESCRIPTION
Closes #1933.

## The defect

The language on a book page is `Book.Language`, written only by metadata providers. A provider describes an abstract *work*, which has editions in many languages; the file on disk is one specific edition. When the two disagreed, nothing noticed.

`internal/importer/scanner.go:1188` read the embedded `dc:language` only when the catalogue had supplied nothing:

```go
fillLanguage := book != nil && book.Language == "" && !book.IsFieldLocked(models.BookFieldLanguage)
```

So a Spanish EPUB imported against an English OpenLibrary record displayed **English** indefinitely. Reported from the field on *Redshirts* by John Scalzi, imported from `John.Scalzi-Redshirts.2014.Spanish.Retail.EPUB.eBook-BitBook` — the release name in the history row was the only trace of the truth anywhere in the product.

## The change

- The tag is read on **every** EPUB import. The parse already existed (`epubmeta.go:139-144`, same pass that extracts title/author/ISBN), so this costs one zip open on an import that is already touching the file.
- When the embedded value disagrees with the stored one, the file wins and the book is updated.
- A disagreement is recorded as a `bookLanguageCorrected` history event carrying `from` and `to`, so the change is auditable rather than a silent overwrite. The History page gets a label, an amber badge, and a `from → to` detail line; unknown types already degraded gracefully, but a curated label makes it look deliberate.

**Precedence is user > file > provider.** A hand-set language locks the field (`api/books.go:510-512` already does this) and short-circuits before the EPUB is opened.

## Three deliberate non-changes

- **A plain fill stays silent.** An empty catalogue language being populated is the #1160 backfill, not a correction — nothing disagreed. OpenLibrary supplies no work-level language often enough that an event per import would be pure noise.
- **Both sides are normalised before comparing.** The catalogue is *not* normalised on write, so a provider's `en` against a file's `eng` would otherwise read as a conflict and "correct" every English book to English on every import (#1729's problem, one layer up).
- **Nothing is written when the import failed.** The tag is read while the source file still exists, which is necessarily before we know whether anything landed, so the reconcile stays gated on `imported > 0`.

## Verification

`go test ./... -count=1` green; `golangci-lint run ./internal/...` 0 issues; `npx tsc --noEmit` clean; frontend 535 tests across 56 files pass.

Six mutations, each confirmed to fail the test that should catch it:

| Mutation | Test that fails |
|---|---|
| restore the `book.Language == ""` gate | `TestTryImportInternal_CorrectsLanguageWhenEpubDisagrees` |
| compare raw strings, no normalisation | `TestTryImportInternal_NoCorrectionWhenLanguagesAgree` |
| emit a correction event for a plain fill too | `TestTryImportInternal_FillEmitsNoCorrectionEvent` |
| ignore the field lock | `TestTryImportInternal_DoesNotOverwriteLockedLanguage` |
| drop the `imported > 0` guard | `TestTryImportInternal_NoLanguageWriteWhenNothingImported` |
| never persist, only log | three of the above |

Two of these did not fail on the first attempt and the tests were fixed, not the claim:

- The agree-test stored `"eng"`, which is already canonical, so it never exercised normalisation at all. It now runs over `en`, `eng`, and `en-US` — the shapes providers actually supply.
- The `imported > 0` guard had **no** test; a failed import happily rewrote the catalogue from a file that never landed. `TestTryImportInternal_NoLanguageWriteWhenNothingImported` covers it by rooting the library under a regular file, so every `MkdirAll` fails with `ENOTDIR` for any user.

## Not addressed here

#1933 also notes that nothing in the import path checks a file's language against the metadata profile at all, so a hand-dropped Spanish EPUB still imports against an `eng`-only profile. That is a policy question (block? warn? import and flag?) rather than a correctness one, and this PR deliberately only fixes the record being wrong.