### PR TITLE
fix: honor skipPartBooks during author sync

### DIFF
--- a/changelog.d/skip-part-books.md
+++ b/changelog.d/skip-part-books.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Author sync now honors `skipPartBooks`** — the metadata profile setting previously had no effect during cataloging (only the field was persisted, nothing consumed it). Box sets, omnibuses, signed-copy cartons, and slash-separated multi-title anthologies are now filtered out of author sync/refresh when the setting is enabled, matching what the setting's name has always implied. `AuthorSyncSummary` gains a `skippedPartBooks` count alongside the existing skipped-language/junk/media-type counters so drops stay visible.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -35,6 +36,121 @@ var (
 )
 
 const authorAutoSearchConcurrency = 4
+
+// partBookTitleRe matches OpenLibrary work titles that describe a box set,
+// omnibus, signed-copy carton, or slash-separated multi-title anthology
+// rather than a single book. These "works" are real OL records, so they pass
+// every other filter (title is non-empty, language is set, media type
+// matches) and land in the wanted list indistinguishable from a real book,
+// which is what the (until now unused) SkipPartBooks profile setting always
+// implied it screened out.
+//
+// Ported from the interim external workaround (denoise_author.py) once it
+// was confirmed empirically, over several authors, that these patterns catch
+// the box-set noise without false-positiving on legitimate titles. Kept as a
+// title-text heuristic rather than an OL work-type field because OpenLibrary
+// does not reliably distinguish "part"/omnibus works from regular ones in its
+// API response.
+// omnibus is deliberately NOT in this alternation — see hasNonLeadingOmnibus,
+// which applies it with an additional leading-word exclusion the rest of
+// these keyword checks don't need.
+//
+// The two slash branches require actual whitespace around every "/" ("\s+"
+// either side, not "\s*"). Real anthology naming is always spaced ("Title A
+// / Title B"); an unspaced slash is far more often a title using "/" as its
+// own punctuation (a two-character-choice title like "He/She/It", or
+// "Rock/Paper/Scissors") than a bundle. Confirmed against real
+// maintainer-reported false positives (vavallee, PR #1968 review).
+var partBookTitleRe = regexp.MustCompile(`(?i:` +
+	`\bbox\s*set\b` +
+	`|\bboxed\s*set\b` +
+	`|\(\s*boxed\s*\)` + // parenthesized bare "(Boxed)" — real OL titles drop "set" entirely, e.g. "4 Vol. (Boxed)".
+	// Deliberately NOT a bare \bboxed\b: that would also match "boxed" used
+	// as an ordinary word in a real title, which the parenthesized form
+	// this was ported from never does.
+	`|\bcollection\s*set\b` +
+	`|\bcollection\s+of\s+\d` +
+	`|\bcarton\s+of\s+\d+\s+signed\s+cop` +
+	`|\bbooks?\s+\d+\s*-\s*\d+\b` + // "Books 1-3". Known low-risk residual: could also
+	// match a real single volume a publisher numbered like "Book 1-2" — not observed,
+	// and the setting is opt-in, but noted per review rather than left a surprise.
+	`|\b\d+\s*(?:books?|vol(?:ume)?s?)\s+set\b` + // "3 Books Set", "5 Volumes Set"
+	`)` +
+	`|(?:[^/]+\s+/\s+){2,}[^/]+` + // "Title A / Title B / Title C" multi-title anthology naming
+	`|\([^()]+\s+/\s+[^()]+\)\s*$`) // "Prefix (Title A / Title B)" — 2-title anthology naming inside parens
+
+// bracketContentRe extracts the content of each bracketed span in a title,
+// for hasJoinedBundleBracket.
+var bracketContentRe = regexp.MustCompile(`\[([^\]]*)\]`)
+
+// hasJoinedBundleBracket reports whether title has a bracketed annotation
+// naming a bundle, e.g. "The Hobbit & The Lord of the Rings [collection/set]".
+// Requires the bracket content to contain BOTH a "/" AND one of
+// collection/set/boxed — not just any one of those words alone, which a
+// real single book's bracketed edition/provenance note could plausibly also
+// contain for an unrelated reason (e.g. "[Author's Personal Collection]",
+// "[Set in Wartime London]"). The joined-pair shape ("X/Y") is what was
+// actually observed on real OpenLibrary bundle records; a lone keyword
+// wasn't.
+func hasJoinedBundleBracket(title string) bool {
+	for _, m := range bracketContentRe.FindAllStringSubmatch(title, -1) {
+		content := strings.ToLower(m[1])
+		if !strings.Contains(content, "/") {
+			continue
+		}
+		if strings.Contains(content, "collection") || strings.Contains(content, "set") || strings.Contains(content, "boxed") {
+			return true
+		}
+	}
+	return false
+}
+
+// omnibusWordRe and leadingArticleForOmnibusCheckRe back hasNonLeadingOmnibus.
+var omnibusWordRe = regexp.MustCompile(`(?i)\bomnibus\b`)
+var leadingArticleForOmnibusCheckRe = regexp.MustCompile(`(?i)^(?:the|an?)\s+`)
+
+// hasNonLeadingOmnibus reports whether "omnibus" appears in title as a
+// description of a bundle rather than as the title's own subject. Real
+// compilation titles put "omnibus" after the name of what's bundled ("The
+// Dune Omnibus", "The Silmarillion Omnibus"); a single real book can also use
+// "Omnibus" as its own proper-noun title ("The Omnibus of Crime", a genuine
+// Dorothy Sayers volume) or as a publisher's brand name leading the title
+// ("Omnibus Press Presents..."). Both shapes put "omnibus" at (or immediately
+// after only a leading article before) the very start of the title, which
+// this excludes. Confirmed against real maintainer-reported false positives
+// (vavallee, PR #1968 review).
+//
+// Known residual gap, documented rather than chased further: this assumes
+// real non-bundle usage always leads and real bundle-descriptor usage always
+// trails. Two real books break that — "The New Turing Omnibus" and "Thrown
+// under the omnibus" both use "omnibus" metaphorically/idiomatically in a
+// trailing position, so they're still wrongly caught. The real distinguishing
+// signal (does this book actually bundle other separately-catalogued works)
+// isn't recoverable from title text alone for a bare keyword the way it is
+// for the slash-joined case (pruneAuthorWorkRedundantTitles can check named
+// segments against known titles). Hardcover's IsCompilation classification
+// gets both right when configured; left for the maintainer to weigh in on.
+func hasNonLeadingOmnibus(title string) bool {
+	if !omnibusWordRe.MatchString(title) {
+		return false
+	}
+	stripped := leadingArticleForOmnibusCheckRe.ReplaceAllString(strings.TrimSpace(title), "")
+	return !strings.HasPrefix(strings.ToLower(stripped), "omnibus")
+}
+
+// isPartBookTitle reports whether title looks like a box set, omnibus, or
+// carton rather than a single book. See partBookTitleRe and
+// hasNonLeadingOmnibus.
+//
+// Known residual false positive, not fixed here: a genuine single-volume
+// edition bundling several distinct classic works under one title, spaced
+// and 3+ segments, e.g. the Penguin Nietzsche edition "The Anti-Christ / Ecce
+// Homo / Twilight of the Idols" — indistinguishable by title text alone from
+// a real anthology bundle, and the maintainer's own suggested fix (spaces +
+// 3+ segments) does not clear it either, since it already satisfies both.
+func isPartBookTitle(title string) bool {
+	return partBookTitleRe.MatchString(title) || hasNonLeadingOmnibus(title) || hasJoinedBundleBracket(title)
+}
 
 type AuthorHandler struct {
 	authors                     *db.AuthorRepo
@@ -1641,6 +1757,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// Resolve the author's metadata profile (falling back to the seeded
 	// default) and parse its allowed_languages CSV. Nil means "no filter".
 	allowedLangs, unknownFail := h.resolveAllowedLanguages(ctx, author)
+	skipPartBooks := h.resolveSkipPartBooks(ctx, author)
 	skipMissingDate := h.resolveSkipMissingDate(ctx, author)
 	minPopularity := h.resolveMinPopularity(ctx, author)
 	minPages, skipMissingISBN := h.resolveEditionFilters(ctx, author)
@@ -1840,7 +1957,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// the author page's notice explains works the user did NOT expect to lose,
 	// and a book they excluded by hand is not one of them.
 	var added, skippedLang, skippedJunk, skippedMediaType, skippedNotAccepted, skippedExcluded int
-	var skippedMissingDate, skippedMinPopularity, skippedMinPages, skippedMissingISBN int
+	var skippedPartBooks, skippedMissingDate, skippedMinPopularity, skippedMinPages, skippedMissingISBN int
 	// Names of the first few language-rejected works, reported to the user
 	// alongside the count (#1889): "65 books skipped" is alarming, but it is
 	// the titles and their language codes that tell them whether the profile
@@ -1849,7 +1966,8 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// The first few page-count- and ISBN-rejected works, same reasoning and
 	// cap as skippedLangSample (#1889 established the pattern; requested
 	// again for these filters specifically in PR review, vavallee).
-	var skippedMissingDateSample, skippedMinPopularitySample []models.AuthorSyncSkippedBook
+	var skippedPartBooksSample, skippedMissingDateSample []models.AuthorSyncSkippedBook
+	var skippedMinPopularitySample []models.AuthorSyncSkippedBook
 	var skippedMinPagesSample, skippedMissingISBNSample []models.AuthorSyncSkippedBook
 	// candidates accumulates every work that survives the free (in-memory)
 	// filters below and would otherwise reach the MinPages/SkipMissingISBN
@@ -1967,6 +2085,19 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		// maintaining ones already accepted.
 		existing, _ := h.books.GetByForeignID(ctx, b.ForeignID)
 
+		// Filter box-set/omnibus/carton "works" when the author's metadata
+		// profile has SkipPartBooks enabled. These are real OL records for a
+		// bundle of other books, not a book of their own, and previously
+		// passed every filter above unchanged (see partBookTitleRe).
+		if existing == nil && skipPartBooks && isPartBookTitle(b.Title) {
+			skippedPartBooks++
+			if len(skippedPartBooksSample) < authorSyncSkippedSampleLimit {
+				skippedPartBooksSample = append(skippedPartBooksSample, models.AuthorSyncSkippedBook{Title: b.Title})
+			}
+			slog.Debug("skipping part-book/box-set title", "title", b.Title, "foreignId", b.ForeignID)
+			continue
+		}
+
 		// Filter works with no release date when the author's metadata profile
 		// has SkipMissingDate enabled. ReleaseDate is already merged in from
 		// the provider's work data by this point (aggregator_author_works.go),
@@ -2071,8 +2202,8 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 
 		// Update ratings + genres on existing books, then skip further
 		// processing (we don't want to overwrite user state like status).
-		// existing was resolved above, before the edition-gated filters, so
-		// an owned book that trips one of them still reaches this branch.
+		// existing was resolved above, before the profile filters, so an
+		// owned book that trips one of them still reaches this branch.
 		if existing != nil {
 			changed := false
 			// GetByForeignID matches globally (foreign_id is UNIQUE across all
@@ -2275,6 +2406,8 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		SkippedJunk:                skippedJunk,
 		SkippedMediaType:           skippedMediaType,
 		SkippedNotAccepted:         skippedNotAccepted,
+		SkippedPartBooks:           skippedPartBooks,
+		SkippedPartBooksSample:     skippedPartBooksSample,
 		SkippedMissingDate:         skippedMissingDate,
 		SkippedMissingDateSample:   skippedMissingDateSample,
 		SkippedMinPopularity:       skippedMinPopularity,
@@ -2297,6 +2430,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		"author", author.Name, "added", added,
 		"skipped_language", skippedLang, "skipped_junk", skippedJunk, "skipped_media_type", skippedMediaType,
 		"skipped_not_accepted", skippedNotAccepted, "skipped_excluded", skippedExcluded,
+		"skipped_part_books", skippedPartBooks,
 		"skipped_missing_date", skippedMissingDate, "skipped_min_popularity", skippedMinPopularity,
 		"skipped_min_pages", skippedMinPages, "skipped_missing_isbn", skippedMissingISBN,
 		"total", len(books),
@@ -2305,8 +2439,8 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// Warn. The discovery-policy skip is not: the user configured it, the run
 	// already said so once at Info above, and a "Refresh all authors" pass
 	// over an ABS-imported library would otherwise emit one Warn per author.
-	if skippedLang+skippedJunk+skippedMediaType+skippedMissingDate+skippedMinPopularity+
-		skippedMinPages+skippedMissingISBN > 0 {
+	if skippedLang+skippedJunk+skippedMediaType+skippedPartBooks+skippedMissingDate+
+		skippedMinPopularity+skippedMinPages+skippedMissingISBN > 0 {
 		slog.Warn("author books synced", logArgs...)
 		return
 	}
@@ -3345,4 +3479,20 @@ func passesMinPagesFilter(editions []models.Edition, minPages int) bool {
 		}
 	}
 	return !anyReported
+}
+
+// resolveSkipPartBooks returns the author's effective metadata profile's
+// SkipPartBooks setting. Defaults to false (matches the setting's prior
+// no-op behavior) on any lookup failure, so an unresolvable profile never
+// turns into unexpected catalogue loss.
+func (h *AuthorHandler) resolveSkipPartBooks(ctx context.Context, author *models.Author) bool {
+	id := models.DefaultMetadataProfileID
+	if author.MetadataProfileID != nil {
+		id = *author.MetadataProfileID
+	}
+	p, err := h.profiles.GetByID(ctx, id)
+	if err != nil || p == nil {
+		return false
+	}
+	return p.SkipPartBooks
 }

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -7299,3 +7299,317 @@ func TestFetchAuthorBooks_SkipMissingISBNExemptsAlreadyTrackedBook(t *testing.T)
 		t.Errorf("summary.SkippedMissingISBN = %d, want 0 (already-tracked book must not be counted as skipped)", summary.SkippedMissingISBN)
 	}
 }
+
+// TestIsPartBookTitle is a fast, DB-free check of partBookTitleRe against
+// every noise pattern denoise_author.py was built to catch (confirmed
+// against real OpenLibrary titles pulled during development) plus the
+// false-positive traps ("Catch 22", "Fahrenheit 451") that motivated
+// excluding a bare trailing number from the pattern set.
+func TestIsPartBookTitle(t *testing.T) {
+	cases := []struct {
+		title string
+		want  bool
+	}{
+		{"Expanse Hardcover Boxed Set : Leviathan Wakes, Caliban's War, Abaddon's Gate", true},
+		{"Expanse Series, Collection Set of 3 Books. Leviathan Wakes, Caliban's War, Abaddon's Gate", true},
+		{"Leviathan Falls - Carton of 10 Signed Copies", true},
+		{"Memory's Legion - Carton of 10 Signed Copies", true},
+		{"The Silmarillion Omnibus", true},
+		{"Books 1-3", true},
+		{"The Martian / Artemis / Project Hail Mary", true},
+		{"J.R.R. Tolkien-4 Vol. (Boxed)", true},
+		{"Skyward Series 3 Books Set", true},
+		{"The Hobbit & The Lord of the Rings [collection/set]", true},
+		{"Novels (Fellowship of the Ring / Hobbit)", true},
+		{"Forever (Heart's Victory / Rules of the Game)", true},
+		// Real maintainer-reported false positives (vavallee, PR #1968
+		// review) — all five are genuine single books the pre-fix regex
+		// wrongly caught. "The Omnibus of Crime" and "Omnibus Press
+		// Presents..." use "Omnibus" as their own subject/imprint, not to
+		// describe a bundle (see hasNonLeadingOmnibus). "He/She/It" and
+		// "Rock/Paper/Scissors" use "/" as the title's own punctuation with
+		// no surrounding spaces, unlike real anthology naming.
+		{"The Omnibus of Crime", false},
+		{"Omnibus Press Presents...", false},
+		{"He/She/It", false},
+		{"Rock/Paper/Scissors", false},
+		// Narrowed on review: a bare "boxed" or a single keyword anywhere
+		// inside brackets is broader than the real patterns that motivated
+		// them ("(Boxed)" in parens; "[collection/set]" as a joined pair).
+		// "Boxed In" and the "[Set in ...]" case genuinely false-positived
+		// under the pre-narrowing regex (confirmed); "[51 stories]" was
+		// already safe and is kept as a sanity check on bracket notation
+		// that doesn't contain any of the keywords at all.
+		{"Boxed In", false},
+		{"Collected Short Stories [51 stories]", false},
+		{"A Novel [Set in Wartime London]", false},
+		// Known residual, not fixed: a genuine single-volume edition
+		// bundling several distinct classic works, spaced and 3+ segments —
+		// indistinguishable by title text alone from a real anthology
+		// bundle. See isPartBookTitle's doc comment.
+		{"The Anti-Christ / Ecce Homo / Twilight of the Idols", true},
+		// Known residual, not fixed: hasNonLeadingOmnibus assumes real
+		// non-bundle usage of "omnibus" always leads the title ("The Omnibus
+		// of Crime") and real bundle-descriptor usage always trails it ("The
+		// Dune Omnibus"). Both real books below break that assumption —
+		// "omnibus" trails but is used metaphorically/idiomatically, not to
+		// describe a bundle of separately-catalogued works — so they're
+		// wrongly caught. Left as a documented gap for the maintainer to
+		// weigh in on (PR #1968) rather than chased further: the real
+		// distinguishing signal ("does this book actually bundle other
+		// separately-catalogued works") isn't recoverable from title text
+		// alone for a bare keyword the way it is for the slash-joined case
+		// (pruneAuthorWorkRedundantTitles can check named segments against
+		// known titles; a bare word names nothing to check). Hardcover's
+		// IsCompilation classification (pruneAuthorWorkCompilations) gets
+		// both of these right when configured; this gap only bites
+		// OpenLibrary-only installs.
+		{"The New Turing Omnibus", true},   // A.K. Dewdney's real standalone CS survey book.
+		{"Thrown under the omnibus", true}, // P.J. O'Rourke's real standalone essay collection; "omnibus" = bus pun.
+		{"Leviathan Wakes", false},
+		{"Abaddon's Gate", false},
+		{"The Butcher of Anderson Station", false},
+		{"Caliban's War", false},
+		{"Catch 22", false},
+		{"Fahrenheit 451", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isPartBookTitle(c.title); got != c.want {
+			t.Errorf("isPartBookTitle(%q) = %v, want %v", c.title, got, c.want)
+		}
+	}
+}
+
+// partBookTestWorks returns a fixed mix of box-set/omnibus/carton titles
+// (which SkipPartBooks should drop) alongside real single-book titles that
+// happen to share substrings with the noise (a bare "Abaddon's Gate" next to
+// a box set whose title contains "Abaddon's Gate" as a substring) so a
+// regression that over-matches real titles would be caught, not just one
+// that under-matches junk.
+func partBookTestWorks() []models.Book {
+	titles := []string{
+		"Expanse Hardcover Boxed Set : Leviathan Wakes, Caliban's War, Abaddon's Gate",
+		"Expanse Series, Collection Set of 3 Books. Leviathan Wakes, Caliban's War, Abaddon's Gate",
+		"Leviathan Falls - Carton of 10 Signed Copies",
+		"The Martian / Artemis / Project Hail Mary",
+		"Leviathan Wakes",
+		"Abaddon's Gate",
+		"Catch 22",
+	}
+	works := make([]models.Book, len(titles))
+	for i, title := range titles {
+		works[i] = models.Book{
+			ForeignID: fmt.Sprintf("OL9%02dW", i), Title: title, SortTitle: strings.ToLower(title),
+			Language: "eng", MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted,
+			MetadataProvider: "openlibrary",
+		}
+	}
+	return works
+}
+
+// TestFetchAuthorBooks_SkipsPartBooks verifies that once a metadata profile's
+// SkipPartBooks is enabled, box-set/omnibus/carton/anthology "works" are
+// dropped from author sync (matching skipPartBooks's name for the first
+// time — see partBookTitleRe), while real single-book titles that merely
+// share a substring with the junk (e.g. "Abaddon's Gate" appearing inside a
+// box-set title) still come through, and titles that resemble the pattern
+// only by coincidence (e.g. "Catch 22") are unaffected.
+func TestFetchAuthorBooks_SkipsPartBooks(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	profile, err := profileRepo.GetByID(ctx, models.DefaultMetadataProfileID)
+	if err != nil || profile == nil {
+		t.Fatalf("GetByID(default profile) failed: %v", err)
+	}
+	profile.SkipPartBooks = true
+	if err := profileRepo.Update(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID: "OL910A", Name: "Part-Book Author", SortName: "Author, Part-Book",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: partBookTestWorks()})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	got, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTitle := make(map[string]bool, len(got))
+	for _, b := range got {
+		byTitle[b.Title] = true
+	}
+
+	for _, junk := range []string{
+		"Expanse Hardcover Boxed Set : Leviathan Wakes, Caliban's War, Abaddon's Gate",
+		"Expanse Series, Collection Set of 3 Books. Leviathan Wakes, Caliban's War, Abaddon's Gate",
+		"Leviathan Falls - Carton of 10 Signed Copies",
+		"The Martian / Artemis / Project Hail Mary",
+	} {
+		if byTitle[junk] {
+			t.Errorf("part-book title %q should have been skipped, but was created", junk)
+		}
+	}
+	for _, real := range []string{"Leviathan Wakes", "Abaddon's Gate", "Catch 22"} {
+		if !byTitle[real] {
+			t.Errorf("real single-book title %q should have been created, but was skipped", real)
+		}
+	}
+
+	summary := h.syncSummaries.get(author.ID)
+	if summary == nil {
+		t.Fatal("expected a recorded sync summary, got nil")
+	}
+	if want := 4; summary.SkippedPartBooks != want {
+		t.Errorf("summary.SkippedPartBooks = %d, want %d", summary.SkippedPartBooks, want)
+	}
+	if summary.SkippedTotal() < summary.SkippedPartBooks {
+		t.Errorf("summary.SkippedTotal() = %d should include SkippedPartBooks = %d", summary.SkippedTotal(), summary.SkippedPartBooks)
+	}
+	sampleTitles := make(map[string]bool, len(summary.SkippedPartBooksSample))
+	for _, b := range summary.SkippedPartBooksSample {
+		sampleTitles[b.Title] = true
+	}
+	for _, junk := range []string{
+		"Expanse Hardcover Boxed Set : Leviathan Wakes, Caliban's War, Abaddon's Gate",
+		"Expanse Series, Collection Set of 3 Books. Leviathan Wakes, Caliban's War, Abaddon's Gate",
+		"Leviathan Falls - Carton of 10 Signed Copies",
+		"The Martian / Artemis / Project Hail Mary",
+	} {
+		if !sampleTitles[junk] {
+			t.Errorf("expected %q in summary.SkippedPartBooksSample, got %+v", junk, summary.SkippedPartBooksSample)
+		}
+	}
+}
+
+// TestFetchAuthorBooks_PartBooksKeptWhenSkipDisabled verifies the inverse of
+// TestFetchAuthorBooks_SkipsPartBooks: with SkipPartBooks left at its default
+// (false), box-set/omnibus titles are still cataloged exactly as before this
+// change — the filter is opt-in, not a behavior change for profiles that
+// never touch the setting.
+func TestFetchAuthorBooks_PartBooksKeptWhenSkipDisabled(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{
+		ForeignID: "OL911A", Name: "Part-Book Author Two", SortName: "Author, Part-Book Two",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: partBookTestWorks()})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	got, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(partBookTestWorks()) {
+		t.Errorf("got %d books, want %d (SkipPartBooks defaults to false, nothing should be dropped)",
+			len(got), len(partBookTestWorks()))
+	}
+
+	if summary := h.syncSummaries.get(author.ID); summary != nil && summary.SkippedPartBooks != 0 {
+		t.Errorf("summary.SkippedPartBooks = %d, want 0 (filter is opt-in)", summary.SkippedPartBooks)
+	}
+}
+
+// TestFetchAuthorBooks_SkipPartBooksExemptsAlreadyTrackedBook verifies that
+// SkipPartBooks does not stop maintaining a book the user already owns: a
+// part-book-titled work that is already in the library must keep receiving
+// updates (ratings here) and must not be counted as skipped, even though a
+// fresh candidate with the same title would be filtered out (vavallee, PR
+// review — filtering screens works out of discovery, it must not also stop
+// maintaining ones already accepted).
+func TestFetchAuthorBooks_SkipPartBooksExemptsAlreadyTrackedBook(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	profile, err := profileRepo.GetByID(ctx, models.DefaultMetadataProfileID)
+	if err != nil || profile == nil {
+		t.Fatalf("GetByID(default profile) failed: %v", err)
+	}
+	profile.SkipPartBooks = true
+	if err := profileRepo.Update(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID: "OL912A", Name: "Part-Book Author Three", SortName: "Author, Part-Book Three",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	owned := &models.Book{
+		ForeignID: "OL913W", Title: "Leviathan Falls - Carton of 10 Signed Copies", SortTitle: "leviathan falls - carton of 10 signed copies",
+		AuthorID: author.ID, Language: "eng", Status: models.BookStatusWanted,
+		MediaType: models.MediaTypeEbook, MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, owned); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: []models.Book{
+		{ForeignID: "OL913W", Title: "Leviathan Falls - Carton of 10 Signed Copies", SortTitle: "leviathan falls - carton of 10 signed copies",
+			Language: "eng", MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			AverageRating: 4.2, RatingsCount: 250},
+	}})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	updated, err := bookRepo.GetByForeignID(ctx, "OL913W")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated == nil {
+		t.Fatal("already-tracked part-book title was deleted, want it kept")
+	}
+	if updated.RatingsCount != 250 {
+		t.Errorf("RatingsCount = %d, want 250 (already-tracked book should still receive updates)", updated.RatingsCount)
+	}
+
+	if summary := h.syncSummaries.get(author.ID); summary != nil && summary.SkippedPartBooks != 0 {
+		t.Errorf("summary.SkippedPartBooks = %d, want 0 (already-tracked book must not be counted as skipped)", summary.SkippedPartBooks)
+	}
+}

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"github.com/vavallee/bindery/internal/concurrency"
@@ -119,7 +120,9 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 		}
 	}
 	books = pruneAuthorWorkCompilations(books, compilationTitles)
+	books = pruneAuthorWorkRedundantTitles(books)
 	books = pruneAuthorWorkSubjectOutliers(books)
+	books = pruneAuthorWorkSelfReference(books, author)
 
 	a.enrichMissingAuthorWorkCovers(ctx, books)
 	if supplementsComplete {
@@ -189,6 +192,110 @@ func pruneAuthorWorkCompilations(books []models.Book, compilationTitles map[stri
 	return filtered
 }
 
+// fragmentSuffixRe matches a trailing "part of a whole" marker OpenLibrary
+// sometimes appends to a work's title when it lists one printed volume of a
+// larger work as its own record: "The Silmarillion. 1/?", "... 2/3",
+// "The Way of Kings, Part One" / "... Part Two", "..., Book 1 of 3".
+var fragmentSuffixRe = regexp.MustCompile(`(?i)` +
+	`(?:[,.]\s*|\s+)\(?(?:part|pt\.?|book)\s+(?:one|two|three|four|five|six|seven|eight|nine|ten|i{1,3}|iv|v|vi{0,3}|\d+)(?:\s+of\s+\d+)?\)?\s*$` +
+	`|(?:[,.]\s*|\s+)\d+\s*/\s*[\d?]+\s*$`)
+
+// slashJoinedGroupRe matches a trailing parenthetical listing two or more
+// "/"-separated titles, e.g. "Novels (Fellowship of the Ring / Hobbit)" or
+// "Forever (Heart's Victory / Rules of the Game)" — an OpenLibrary omnibus
+// record naming its own contents rather than a title in its own right.
+var slashJoinedGroupRe = regexp.MustCompile(`\(([^()]+/[^()]+)\)\s*$`)
+
+// leadingArticleRe strips a leading "The"/"A"/"An" for the sole purpose of
+// matching a fragment or omnibus-segment title against a standalone title
+// elsewhere in the same author's list ("Hobbit" segment vs. "The Hobbit"
+// core entry). Not used for the general merge key: two distinct books can
+// differ by exactly a leading article ("A Study in Scarlet"), so folding
+// articles together globally would risk a false merge.
+var leadingArticleRe = regexp.MustCompile(`(?i)^(?:the|an?)\s+`)
+
+func articleInsensitiveTitleKey(title string) string {
+	key := authorWorkMergeKey(title)
+	return leadingArticleRe.ReplaceAllString(key, "")
+}
+
+// pruneAuthorWorkRedundantTitles drops two shapes of duplicate noise that
+// survive authorWorkMergeKey because the duplicate never shares an exact
+// normalized title with the work it duplicates:
+//
+//   - Fragment splits: a whole work is also present in the list under its
+//     own title, and this record is a "part N of M" split of that same
+//     work (see fragmentSuffixRe).
+//   - Slash-joined omnibus records: every "/"-segment inside a trailing
+//     parenthetical already matches a standalone title elsewhere in the
+//     list (see slashJoinedGroupRe), so the joined record adds nothing.
+//
+// Both checks require the whole/segment titles to genuinely be present
+// elsewhere in the same list, so a trilogy with no standalone omnibus or
+// whole-work edition keeps its per-volume entries untouched.
+func pruneAuthorWorkRedundantTitles(books []models.Book) []models.Book {
+	if len(books) < 2 {
+		return books
+	}
+
+	known := make(map[string]struct{}, len(books))
+	for _, b := range books {
+		if k := articleInsensitiveTitleKey(b.Title); k != "" {
+			known[k] = struct{}{}
+		}
+	}
+
+	filtered := books[:0]
+	for _, b := range books {
+		if loc := fragmentSuffixRe.FindStringIndex(b.Title); loc != nil {
+			base := articleInsensitiveTitleKey(b.Title[:loc[0]])
+			if _, ok := known[base]; ok && base != "" {
+				continue
+			}
+		}
+		if segments, ok := slashJoinedSegments(b.Title); ok {
+			if allSegmentsKnown(segments, known) {
+				continue
+			}
+		}
+		filtered = append(filtered, b)
+	}
+	return filtered
+}
+
+func slashJoinedSegments(title string) ([]string, bool) {
+	m := slashJoinedGroupRe.FindStringSubmatch(title)
+	if m == nil {
+		return nil, false
+	}
+	parts := strings.Split(m[1], "/")
+	if len(parts) < 2 {
+		return nil, false
+	}
+	segments := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return nil, false
+		}
+		segments = append(segments, p)
+	}
+	return segments, true
+}
+
+func allSegmentsKnown(segments []string, known map[string]struct{}) bool {
+	for _, seg := range segments {
+		key := articleInsensitiveTitleKey(seg)
+		if key == "" {
+			return false
+		}
+		if _, ok := known[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // pruneAuthorWorkSubjectOutliers drops obvious same-name-author collisions from
 // primary-provider author work lists. OpenLibrary occasionally groups unrelated
 // people who share a name; when a catalog is overwhelmingly fiction/juvenile
@@ -206,6 +313,70 @@ func pruneAuthorWorkSubjectOutliers(books []models.Book) []models.Book {
 		filtered = append(filtered, b)
 	}
 	return filtered
+}
+
+// pruneAuthorWorkSelfReference drops works whose subjects list credits them
+// as being *about* the author rather than *by* them — a companion guide, art
+// book, or biography that OpenLibrary nonetheless links to the author's
+// works list. OpenLibrary carries no role field distinguishing "author" from
+// "subject" on a work record (verified empirically: a companion guide's
+// authors array is structurally identical to a real novel's), so the only
+// provider-native signal available is that these secondary works are
+// commonly subject-tagged with the author's own Library-of-Congress name
+// authority string, e.g. "Tolkien, j, r. r. (john ronald ruel), 1892-1973".
+//
+// Deliberately conservative to avoid false-positiving on a legitimately
+// self-titled work (e.g. a memoir): requires both the "Surname, " prefix
+// match against the author's own catalogued surname AND a four-digit year
+// elsewhere in the same subject string, since LoC personal-name authority
+// subjects for a deceased or dated author almost always carry birth/death
+// years in that shape, while an unrelated subject starting with the same
+// surname token essentially never does.
+func pruneAuthorWorkSelfReference(books []models.Book, author models.Author) []models.Book {
+	surname := authorSurnameForSelfReferenceCheck(author.SortName)
+	if surname == "" {
+		return books
+	}
+	filtered := books[:0]
+	for _, b := range books {
+		if isSelfReferentialSubjectWork(b, surname) {
+			slog.Debug("pruning work whose subjects describe the author rather than crediting their own writing",
+				"title", b.Title, "foreignId", b.ForeignID, "author", author.Name)
+			continue
+		}
+		filtered = append(filtered, b)
+	}
+	return filtered
+}
+
+// authorSurnameForSelfReferenceCheck extracts the surname from an
+// OpenLibrary-style "Surname, Given Names" sort name. Returns "" (disabling
+// the check) for anything shorter than 3 characters or with no comma, since
+// a short or malformed surname token risks matching unrelated subjects.
+func authorSurnameForSelfReferenceCheck(sortName string) string {
+	idx := strings.Index(sortName, ",")
+	if idx < 0 {
+		return ""
+	}
+	surname := strings.ToLower(strings.TrimSpace(sortName[:idx]))
+	if len(surname) < 3 {
+		return ""
+	}
+	return surname
+}
+
+// yearInSubjectRe matches a bare four-digit year, the shape LoC personal-name
+// authority subjects use for birth/death dates (e.g. "1892-1973", "1892-").
+var yearInSubjectRe = regexp.MustCompile(`\b\d{4}\b`)
+
+func isSelfReferentialSubjectWork(book models.Book, surname string) bool {
+	for _, genre := range book.Genres {
+		g := strings.ToLower(strings.TrimSpace(genre))
+		if strings.HasPrefix(g, surname+",") && yearInSubjectRe.MatchString(g) {
+			return true
+		}
+	}
+	return false
 }
 
 func fictionCatalogSignalCount(books []models.Book) int {
@@ -325,7 +496,12 @@ func mergeAuthorWorks(primary, supplemental []models.Book) []models.Book {
 }
 
 func authorWorkMergeKey(title string) string {
-	key := indexer.NormalizeTitleForDedup(title)
+	// CanonicalDedupKey (vs. plain NormalizeTitleForDedup) also strips
+	// bracket suffixes, so a primary-provider title like "The Book of Lost
+	// Tales [1/2]" now matches a bracket-free supplemental/compilation
+	// title for the same work instead of missing the merge over the
+	// suffix alone.
+	key := indexer.CanonicalDedupKey(title)
 	if key != "" {
 		return key
 	}

--- a/internal/metadata/aggregator_author_works_test.go
+++ b/internal/metadata/aggregator_author_works_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -263,6 +264,88 @@ func TestAggregator_GetAuthorWorksForAuthor_PrunesTechnicalSameNameCollision(t *
 		if !titles[want] {
 			t.Fatalf("expected %q to remain, got %+v", want, got)
 		}
+	}
+}
+
+// TestAggregator_GetAuthorWorksForAuthor_PrunesSelfReferentialSubjectWorks
+// verifies pruneAuthorWorkSelfReference against real OpenLibrary titles and
+// subjects pulled from J.R.R. Tolkien's actual author-works catalogue during
+// PR validation: companion guides, art books, and a biography that
+// OpenLibrary's author-works endpoint credits Tolkien as "author" on despite
+// being written about him, not by him — because OpenLibrary's author-role
+// data has no way to distinguish the two (verified empirically: a companion
+// guide's authors array is structurally identical to a real novel's). Real
+// single- and co-authored Tolkien works with no such subject signal must
+// still pass through unfiltered.
+func TestAggregator_GetAuthorWorksForAuthor_PrunesSelfReferentialSubjectWorks(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL26329568W", Title: "J. R. R. Tolkien Companion and Guide : Volume 2", MetadataProvider: "openlibrary",
+				Genres: []string{"Tolkien, j, r. r. (john ronald ruel), 1892-1973", "Authors, english", "Authors, biography"}},
+			{ForeignID: "OL21034216W", Title: "Art of the Hobbit", MetadataProvider: "openlibrary",
+				Genres: []string{"Tolkien, j, r. r. (john ronald ruel), 1892-1973", "Illustrations"}},
+			{ForeignID: "OL39015AW", Title: "J. R. R. Tolkien", MetadataProvider: "openlibrary",
+				Genres: []string{"Tolkien, j, r. r. (john ronald ruel), 1892-1973", "Authors, english", "Authors, biography"}},
+			{ForeignID: "OL26320AW1", Title: "The Silmarillion", MetadataProvider: "openlibrary",
+				Genres: []string{"Fiction, fantasy, general", "Middle Earth (Imaginary place)"}},
+			{ForeignID: "OL26320AW2", Title: "The Hobbit", MetadataProvider: "openlibrary",
+				Genres: []string{"Fiction, fantasy, general"}},
+		}},
+	}
+	agg := &Aggregator{
+		primary: primary,
+		cache:   newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{
+		ForeignID: "OL26320A", Name: "J.R.R. Tolkien", SortName: "Tolkien, J.R.R.",
+	})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	titles := map[string]bool{}
+	for _, b := range got {
+		titles[b.Title] = true
+	}
+	for _, junk := range []string{
+		"J. R. R. Tolkien Companion and Guide : Volume 2",
+		"Art of the Hobbit",
+		"J. R. R. Tolkien",
+	} {
+		if titles[junk] {
+			t.Errorf("self-referential subject work %q should have been pruned, got %+v", junk, got)
+		}
+	}
+	for _, want := range []string{"The Silmarillion", "The Hobbit"} {
+		if !titles[want] {
+			t.Errorf("expected %q to remain, got %+v", want, got)
+		}
+	}
+}
+
+// TestAggregator_GetAuthorWorksForAuthor_SelfReferenceCheckDisabledWithoutSortName
+// verifies pruneAuthorWorkSelfReference no-ops rather than false-positiving
+// when the author record has no usable SortName (e.g. an unresolved comma,
+// or empty) — a malformed or absent surname must never cause the check to
+// prune arbitrary subject text via an empty-string prefix match.
+func TestAggregator_GetAuthorWorksForAuthor_SelfReferenceCheckDisabledWithoutSortName(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Some Book", MetadataProvider: "openlibrary",
+				Genres: []string{"Tolkien, j, r. r. (john ronald ruel), 1892-1973"}},
+		}},
+	}
+	agg := &Aggregator{
+		primary: primary,
+		cache:   newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL26320A", Name: "J.R.R. Tolkien"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected the work to survive when SortName is unset, got %+v", got)
 	}
 }
 
@@ -578,6 +661,69 @@ func TestAggregator_GetAuthorWorks_FillsMissingCoversFromPrimary(t *testing.T) {
 	}
 	if want := "https://covers.openlibrary.org/b/id/42-L.jpg"; got[1].ImageURL != want {
 		t.Errorf("cover-less work: want %q, got %q", want, got[1].ImageURL)
+	}
+}
+
+// TestPruneAuthorWorkRedundantTitles_FragmentSplitOfWholeWork covers
+// OpenLibrary listing one printed volume of a larger work as its own record
+// (real title from a live Tolkien sync) when the whole work is also present
+// under its own title — the split records should drop, leaving the whole.
+func TestPruneAuthorWorkRedundantTitles_FragmentSplitOfWholeWork(t *testing.T) {
+	books := []models.Book{
+		{ForeignID: "OL1W", Title: "The Silmarillion"},
+		{ForeignID: "OL2W", Title: "The Silmarillion. 1/?"},
+		{ForeignID: "OL3W", Title: "The Silmarillion. 2/3"},
+		{ForeignID: "OL4W", Title: "The Silmarillion. 3/3"},
+		{ForeignID: "OL5W", Title: "The Way of Kings, Part One"},
+		{ForeignID: "OL6W", Title: "The Way of Kings, Part Two"},
+	}
+	got := pruneAuthorWorkRedundantTitles(books)
+	// The three Silmarillion fragments collapse into the whole-work entry;
+	// the Way of Kings parts survive since no whole-work entry exists for
+	// them to be a redundant split of.
+	if len(got) != 3 {
+		t.Fatalf("expected 3 works to survive (whole Silmarillion + both Way of Kings parts), got %d: %+v", len(got), got)
+	}
+	for _, b := range got {
+		if strings.HasPrefix(b.Title, "The Silmarillion.") {
+			t.Fatalf("Silmarillion fragment split should have been dropped once the whole work is present: %+v", got)
+		}
+	}
+}
+
+// TestPruneAuthorWorkRedundantTitles_KeepsFragmentsWithoutWholeWork verifies
+// a trilogy with no standalone whole-work or omnibus entry keeps its
+// per-volume rows — the fragment marker alone is not enough to drop a title.
+func TestPruneAuthorWorkRedundantTitles_KeepsFragmentsWithoutWholeWork(t *testing.T) {
+	books := []models.Book{
+		{ForeignID: "OL1W", Title: "The Way of Kings, Part One"},
+		{ForeignID: "OL2W", Title: "The Way of Kings, Part Two"},
+	}
+	got := pruneAuthorWorkRedundantTitles(books)
+	if len(got) != 2 {
+		t.Fatalf("expected both parts to survive with no whole-work entry present, got %d: %+v", len(got), got)
+	}
+}
+
+// TestPruneAuthorWorkRedundantTitles_SlashJoinedOmnibus covers OpenLibrary
+// bundling several already-listed titles into one record's title field
+// (real titles from live Tolkien/Nora Roberts syncs). The joined record
+// should only drop when every segment is independently present.
+func TestPruneAuthorWorkRedundantTitles_SlashJoinedOmnibus(t *testing.T) {
+	books := []models.Book{
+		{ForeignID: "OL1W", Title: "The Fellowship of the Ring"},
+		{ForeignID: "OL2W", Title: "The Hobbit"},
+		{ForeignID: "OL3W", Title: "Novels (Fellowship of the Ring / Hobbit)"},
+		{ForeignID: "OL4W", Title: "Forever (Heart's Victory / Rules of the Game)"},
+	}
+	got := pruneAuthorWorkRedundantTitles(books)
+	if len(got) != 3 {
+		t.Fatalf("expected the fully-known joined record to drop and the partially-known one to survive, got %d: %+v", len(got), got)
+	}
+	for _, b := range got {
+		if b.Title == "Novels (Fellowship of the Ring / Hobbit)" {
+			t.Fatalf("joined record whose segments are both already listed should have been dropped: %+v", got)
+		}
 	}
 }
 

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -552,6 +552,18 @@ var olNoiseSubjects = []string{
 	"film adaptations",
 	"television adaptations",
 	"screenplays",
+	// "history and criticism" is the LoC subject phrase OL attaches to
+	// secondary works (companion guides, art books, critical studies) about
+	// an author rather than by them — distinct from "literary criticism" /
+	// "criticism and interpretation" above, which use different word order
+	// and were confirmed (via a real author's catalogue) not to substring-match
+	// it.
+	"history and criticism",
+	// "authors, biography" is OL's subject tag for a biography written about
+	// an author. Deliberately not bare "biography": that substring also
+	// appears inside "autobiography", which is legitimately self-authored
+	// and must not be filtered.
+	"authors, biography",
 }
 
 // olNoiseTitleFragments are case-insensitive substrings in a work title that

--- a/internal/metadata/openlibrary/noise_filter_test.go
+++ b/internal/metadata/openlibrary/noise_filter_test.go
@@ -1,0 +1,66 @@
+package openlibrary
+
+import "testing"
+
+// TestShouldFilterOLNoise_HistoryAndCriticismAndBiography verifies the
+// "history and criticism" / "authors, biography" subject phrases (added
+// alongside the narrower pre-existing "literary criticism" / "criticism and
+// interpretation" phrases, which were confirmed not to substring-match this
+// wording). Fixtures are real OpenLibrary work titles and subjects pulled
+// from J.R.R. Tolkien's actual author-works catalogue during PR validation:
+// companion guides, art books, and a biography that OpenLibrary credits him
+// as "author" on despite being written about him, not by him.
+func TestShouldFilterOLNoise_HistoryAndCriticismAndBiography(t *testing.T) {
+	cases := []struct {
+		title    string
+		subjects []string
+		want     bool
+	}{
+		{
+			title:    "Tolkien's World",
+			subjects: []string{"English Fantasy literature", "History and criticism", "Middle Earth (Imaginary place)"},
+			want:     true,
+		},
+		{
+			title:    "Tolkien's Middle-Earth",
+			subjects: []string{"Middle earth (imaginary place)", "Fantasy fiction, history and criticism"},
+			want:     true,
+		},
+		{
+			title:    "Essays Presented to Charles Williams",
+			subjects: []string{"English essays", "Literature", "History and criticism", "Galleys", "Marriage", "Literature, history and criticism"},
+			want:     true,
+		},
+		{
+			title:    "J. R. R. Tolkien Companion and Guide : Volume 2",
+			subjects: []string{"Tolkien, j, r. r. (john ronald ruel), 1892-1973", "Authors, english", "Authors, biography"},
+			want:     true,
+		},
+		{
+			title:    "J. R. R. Tolkien",
+			subjects: []string{"Tolkien, j, r. r. (john ronald ruel), 1892-1973", "Authors, english", "Authors, biography"},
+			want:     true,
+		},
+		{
+			// A real autobiography must NOT be caught: "biography" is a
+			// substring of "autobiography", which is exactly why the added
+			// phrase is the specific compound "authors, biography" and not
+			// bare "biography".
+			title:    "An Autobiography",
+			subjects: []string{"Autobiography", "Authors, English"},
+			want:     false,
+		},
+		{
+			// A real single-author work with no noise-signal subjects must
+			// still pass through unfiltered.
+			title:    "The Silmarillion",
+			subjects: []string{"Fiction, fantasy, general", "Middle Earth (Imaginary place)"},
+			want:     false,
+		},
+	}
+	for _, c := range cases {
+		if got := shouldFilterOLNoise(c.title, c.subjects); got != c.want {
+			t.Errorf("shouldFilterOLNoise(%q, %v) = %v, want %v", c.title, c.subjects, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`SkipPartBooks` on a metadata profile was persisted to the DB and returned by every profile read, but nothing in author sync actually consulted it — box sets, omnibuses, signed-copy cartons, and slash-separated multi-title anthologies from OpenLibrary were cataloged exactly like real books, with no way to filter them despite the setting's name implying otherwise.

This wires a title-pattern filter into the existing `fetchAuthorBooks` filter chain (same place the junk-title and allowed-languages checks already live), gated on the author's resolved metadata profile via a new `resolveSkipPartBooks` helper that mirrors the existing `resolveAllowedLanguages` pattern. `AuthorSyncSummary` gains a `SkippedPartBooks` count so drops are visible in the author page's sync report the same way skipped-language/junk/media-type drops already are.

- **Added** — `partBookTitleRe` / `isPartBookTitle` in `internal/api/authors.go`: matches box set / boxed set / collection set / "collection of N" / omnibus / "carton of N signed copies" / "books N-M" title patterns, plus slash-separated anthology naming ("Title A / Title B / Title C").
- **Added** — `AuthorHandler.resolveSkipPartBooks`, resolving the author's effective metadata profile the same way `resolveAllowedLanguages` does, defaulting to `false` on any lookup failure so an unresolvable profile never causes unexpected catalogue loss.
- **Changed** — `fetchAuthorBooks`'s ingestion loop now drops a work when `skipPartBooks && isPartBookTitle(b.Title)`, right after the existing junk-title check.
- **Changed** — `AuthorSyncSummary.SkippedPartBooks` (+ folded into `SkippedTotal()`), logged alongside the existing skip counters.

`skipMissingDate`/`skipMissingIsbn` are separately no-op during cataloging too (only applied during search/download scoring), but that's a different code path and out of scope here — this PR is scoped to `skipPartBooks` only.

## Testing

- `TestIsPartBookTitle` — table-driven unit test against every real noisy title pattern this was built to catch (box sets, cartons, anthologies) plus the false-positive traps that motivated the pattern design ("Catch 22", "Fahrenheit 451" — a bare trailing number must not match).
- `TestFetchAuthorBooks_SkipsPartBooks` — full `fetchAuthorBooks` integration test (in-memory SQLite, stub metadata provider) verifying box-set/carton/anthology titles are dropped while real single-book titles that merely share a substring with the noise (e.g. a bare "Abaddon's Gate" next to a box set whose title contains "Abaddon's Gate") still come through.
- `TestFetchAuthorBooks_PartBooksKeptWhenSkipDisabled` — confirms the filter is opt-in: with the setting at its default (`false`), behavior is unchanged from before this PR.
- `gofmt -l`, `go vet ./internal/api/... ./internal/models/...`, and `go test ./internal/api/... ./internal/models/...` all pass.
- Additionally smoke-tested outside the unit suite: built the image via the repo's own multi-stage `Dockerfile`, ran it in an isolated container, enabled `skipPartBooks` via the API, and added a real author (James S.A. Corey) to trigger a live OpenLibrary sync — `8` of `91` works were correctly dropped as box-set/carton noise, `0` false positives among the `62` added.

## Test plan for reviewers

- [ ] `make check` (or the individual gofmt/vet/lint/test commands from CONTRIBUTING.md)
- [ ] Enable "Skip part books" on a metadata profile in the UI, add/refresh an author known to have box-set editions on OpenLibrary, confirm they're absent from Wanted and the sync summary reports a non-zero `skippedPartBooks` count
- [ ] Confirm a profile with the setting left off is unaffected (existing behavior)