### PR TITLE
chore(deps): update Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Run live-provider canaries
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -73,7 +73,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -102,7 +102,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -151,7 +151,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - name: Run API race shard
         if: matrix.scope == 'api'
@@ -204,7 +204,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -259,7 +259,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - name: Run API race shard
         if: matrix.scope == 'api'
@@ -449,7 +449,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -521,7 +521,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - name: Run ABS contract suite
         env:
@@ -550,7 +550,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - name: Wait for ArgoCD dev to sync
         env:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Locate Go fuzz corpus cache

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -300,7 +300,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY web/ .
 RUN npm run build
 
 # Stage 2: Build Go binary (native on BUILDPLATFORM, cross-compile to TARGETOS/TARGETARCH)
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/changelog.d/go-1266-toolchain.md
+++ b/changelog.d/go-1266-toolchain.md
@@ -1,0 +1,7 @@
+### Security
+
+- **Go toolchain updated to 1.26.6** — picks up fixes for six Go standard
+  library advisories affecting `net/http`, `crypto/tls`, `net/url`,
+  `encoding/xml` and `encoding/asn1` (GO-2026-6218, GO-2026-6090, GO-2026-6089,
+  GO-2026-6088, GO-2026-5972, GO-2026-5026). Applies to the release binaries and
+  the Docker image alike.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vavallee/bindery
 
 go 1.25.11
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/coreos/go-oidc/v3 v3.20.0


### PR DESCRIPTION
## Why this is urgent

**CI's `lint` job is red on `main` right now, and `lint` is a required check — so every open PR is blocked behind it.**

Nothing in the code caused it. `govulncheck` queries the live advisory database, so it goes red on its own when a new advisory publishes. The v1.30.4 tag run passed the identical job a few hours earlier at `eb453bd4`.

## The advisories

Six Go standard library vulnerabilities against 1.26.5, all fixed in 1.26.6:

| ID | Package |
|---|---|
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` |
| [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) | `net/http` |
| [GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088) | `encoding/xml` |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` |

`encoding/xml` is worth a second look given #1966 adds an XML-RPC codec that parses responses from an operator-configured rTorrent endpoint.

## What changed

- `go.mod` — `toolchain go1.26.5` → `go1.26.6`. The `go 1.25.11` language directive is untouched.
- `go-version` pins in `ci.yml` (9 occurrences), `canary.yml`, `fuzz.yml`, `security.yml`.
- `Dockerfile` builder image → `golang:1.26.6-alpine@sha256:af8d674…`.

**The Dockerfile bump is not incidental.** Only the goreleaser binaries pick up the workflow toolchain; without it the published Docker image keeps the vulnerable standard library even once CI is green. The digest came from the Docker Hub API, and I verified the method by confirming the same endpoint returns the exact digest already pinned for `1.26.5-alpine` — so this isn't a guessed hash.

## Verification

`go build ./...` clean on 1.26.6 (the toolchain directive pulls it automatically). The real proof is this PR's own `lint` job going green where `main`'s is red.

## Merge order

Worth merging first — the other open PRs inherit the failing `lint` and can't be evaluated on their own merits until this lands.

## Closes #1990

Independently filed while reviewing #1966. Worth recording the detail from that report: **GO-2026-6088 is `encoding/xml`'s "add recursion depth guard during decode"** — the same unbounded-recursion-on-untrusted-input class as #1987, in the same Go release. Bindery's newznab client parses indexer-controlled XML with that package, so this is a security fix rather than routine dependency hygiene.