### PR TITLE
fix(downloader): surface configured path hints (#1984)

### DIFF
--- a/changelog.d/1984-pathcheck-hints.md
+++ b/changelog.d/1984-pathcheck-hints.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Download client path warnings** (#1984) — Show Bindery's configured ebook and audiobook directories when a qBittorrent completed-downloads path is not visible.

--- a/internal/downloader/pathcheck.go
+++ b/internal/downloader/pathcheck.go
@@ -94,8 +94,29 @@ func qbittorrentPathVisibility(ctx context.Context, client *models.DownloadClien
 	if savePath == "" {
 		return PathVisibility{Status: PathUnknown}
 	}
-	expected := ExpectedDownloadDirForClient(client, models.MediaTypeEbook, downloadDir, audiobookDownloadDir)
+	expected := qbittorrentExpectedHint(client, downloadDir, audiobookDownloadDir)
 	return statRemappedPath(client, savePath, expected, globalRemap)
+}
+
+// qbittorrentExpectedHint describes the local directories Bindery is configured
+// to read for the categories this client serves. When audiobooks use a separate
+// category, include both media-specific directories so a failed visibility check
+// does not misleadingly point only at the ebook directory (#1984).
+func qbittorrentExpectedHint(client *models.DownloadClient, downloadDir, audiobookDownloadDir string) string {
+	ebookDir := strings.TrimSpace(ExpectedDownloadDirForClient(client, models.MediaTypeEbook, downloadDir, audiobookDownloadDir))
+	hints := make([]string, 0, 2)
+	if ebookDir != "" {
+		hints = append(hints, fmt.Sprintf("the ebook download directory %q", filepath.Clean(ebookDir)))
+	}
+
+	if strings.TrimSpace(client.CategoryAudiobook) != "" && strings.TrimSpace(client.CategoryAudiobook) != strings.TrimSpace(client.Category) {
+		audiobookDir := strings.TrimSpace(ExpectedDownloadDirForClient(client, models.MediaTypeAudiobook, downloadDir, audiobookDownloadDir))
+		if audiobookDir != "" {
+			hints = append(hints, fmt.Sprintf("the audiobook download directory %q", filepath.Clean(audiobookDir)))
+		}
+	}
+
+	return strings.Join(hints, " and ")
 }
 
 func nzbgetPathVisibility(ctx context.Context, client *models.DownloadClient, globalRemap string) PathVisibility {
@@ -123,8 +144,8 @@ func remapClientPath(client *models.DownloadClient, rawPath, globalRemap string)
 
 // statRemappedPath resolves a client-reported path via remapClientPath (client
 // PathRemap then global remap fallback) and os.Stats the result. expectedHint,
-// when non-empty, is included in the warning message as the directory Bindery
-// was configured to read from.
+// when non-empty, is included in the warning message as the configured local
+// directory description Bindery was expected to read from.
 func statRemappedPath(client *models.DownloadClient, clientPath, expectedHint, globalRemap string) PathVisibility {
 	localPath := filepath.Clean(remapClientPath(client, strings.TrimSpace(clientPath), globalRemap))
 	if localPath == "." || localPath == "" {
@@ -154,6 +175,9 @@ func statRemappedPath(client *models.DownloadClient, clientPath, expectedHint, g
 	msg := fmt.Sprintf("Connected, but Bindery can't read the client's completed-downloads folder at %q — %s.", localPath, hint)
 	if local := strings.TrimSpace(clientPath); local != "" && filepath.Clean(local) != localPath {
 		msg = fmt.Sprintf("Connected, but Bindery can't read the client's completed-downloads folder. The client writes to %q, which maps to %q inside Bindery, but that path does not exist — %s.", filepath.Clean(local), localPath, hint)
+	}
+	if expected := strings.TrimSpace(expectedHint); expected != "" {
+		msg += fmt.Sprintf(" Bindery is configured to read from %s.", expected)
 	}
 	return PathVisibility{Status: PathNotVisible, Message: msg, Path: localPath}
 }

--- a/internal/downloader/pathcheck_test.go
+++ b/internal/downloader/pathcheck_test.go
@@ -20,31 +20,46 @@ func TestCheckCompletedPathVisibility_Qbittorrent(t *testing.T) {
 	visible := t.TempDir()
 
 	tests := []struct {
-		name       string
-		categories string
-		pathRemap  string
-		wantStatus string
-		wantInMsg  string
+		name              string
+		categories        string
+		pathRemap         string
+		categoryAudiobook string
+		downloadDir       string
+		audiobookDir      string
+		wantStatus        string
+		wantInMsg         []string
 	}{
 		{
 			name:       "remapped path exists -> visible",
 			categories: `{"books":{"name":"books","savePath":"/remote/downloads"}}`,
 			pathRemap:  "/remote/downloads:" + visible,
 			wantStatus: PathVisible,
-			wantInMsg:  "can read",
+			wantInMsg:  []string{"can read"},
 		},
 		{
 			name:       "remapped path missing -> warning",
 			categories: `{"books":{"name":"books","savePath":"/remote/downloads"}}`,
 			pathRemap:  "/remote/downloads:" + filepath.Join(visible, "does-not-exist"),
 			wantStatus: PathNotVisible,
-			wantInMsg:  "can't read",
+			wantInMsg:  []string{"can't read", `the ebook download directory "/some/download/dir"`},
 		},
 		{
 			name:       "no remap, client path missing -> warning",
 			categories: `{"books":{"name":"books","savePath":"/totally/not/here/xyz"}}`,
 			wantStatus: PathNotVisible,
-			wantInMsg:  "path remap",
+			wantInMsg:  []string{"path remap", `the ebook download directory "/some/download/dir"`},
+		},
+		{
+			name:              "separate audiobook category includes both configured directories",
+			categories:        `{"books":{"name":"books","savePath":"/totally/not/here/xyz"}}`,
+			categoryAudiobook: "audiobooks",
+			downloadDir:       "/bindery/downloads/ebooks",
+			audiobookDir:      "/bindery/downloads/audiobooks",
+			wantStatus:        PathNotVisible,
+			wantInMsg: []string{
+				`the ebook download directory "/bindery/downloads/ebooks"`,
+				`the audiobook download directory "/bindery/downloads/audiobooks"`,
+			},
 		},
 		{
 			name:       "category not found -> unknown (no false alarm)",
@@ -71,20 +86,27 @@ func TestCheckCompletedPathVisibility_Qbittorrent(t *testing.T) {
 
 			host, port := serverHostPort(t, srv.URL)
 			client := &models.DownloadClient{
-				Type:      "qbittorrent",
-				Host:      host,
-				Port:      port,
-				Username:  "u",
-				Password:  "p",
-				Category:  "books",
-				PathRemap: tc.pathRemap,
+				Type:              "qbittorrent",
+				Host:              host,
+				Port:              port,
+				Username:          "u",
+				Password:          "p",
+				Category:          "books",
+				CategoryAudiobook: tc.categoryAudiobook,
+				PathRemap:         tc.pathRemap,
 			}
-			got := CheckCompletedPathVisibility(context.Background(), client, "/some/download/dir", "", "")
+			downloadDir := tc.downloadDir
+			if downloadDir == "" {
+				downloadDir = "/some/download/dir"
+			}
+			got := CheckCompletedPathVisibility(context.Background(), client, downloadDir, tc.audiobookDir, "")
 			if got.Status != tc.wantStatus {
 				t.Fatalf("status = %q, want %q; message=%s", got.Status, tc.wantStatus, got.Message)
 			}
-			if tc.wantInMsg != "" && !strings.Contains(got.Message, tc.wantInMsg) {
-				t.Fatalf("message %q does not contain %q", got.Message, tc.wantInMsg)
+			for _, want := range tc.wantInMsg {
+				if !strings.Contains(got.Message, want) {
+					t.Fatalf("message %q does not contain %q", got.Message, want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Use the previously dead `expectedHint` to make qBittorrent path-visibility warnings show the configured local download directory. When ebook and audiobook categories are separate, the warning lists both directories instead of hardcoding the ebook target. Closes #1984.

## Why minimal / scope decisions

This changes warning text only. The visibility verdict still stats the same completed-download path, and NZBGet behavior is unchanged.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no environment variables, config, or upgrade path changed; Godoc and a changelog fragment were updated
- [x] Wiki pages updated if user-facing behaviour changed — not applicable; no wiki page documents this warning

## Test plan

- [x] `go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...`
- [x] `go test -race -timeout=15m ./internal/downloader`
- [x] `go vet ./...`
- [x] `gofmt -l . | tee /dev/stderr | (! read)`
- [x] `golangci-lint run --timeout=5m` (v2.11.4)
- [x] `govulncheck ./...`
- [x] `make changelog`
- [x] Frontend checks not applicable — no files under `web/` changed
