### PR TITLE
test(importer): rename formatScopeFixture to resolve a redeclaration on main

### DIFF
--- a/internal/importer/scanner_format_scope_test.go
+++ b/internal/importer/scanner_format_scope_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
-// dualFormatFixture builds an in-memory Scanner with a real author and a
+// formatScopeFixture builds an in-memory Scanner with a real author and a
 // media_type=both book that is Wanted in BOTH slots, plus separate ebook and
 // audiobook library roots.
-func dualFormatFixture(t *testing.T, libraryDir, audiobookDir string) (
+func formatScopeFixture(t *testing.T, libraryDir, audiobookDir string) (
 	s *Scanner,
 	book *models.Book,
 	dlRepo *db.DownloadRepo,
@@ -90,7 +90,7 @@ func TestTryImportInternal_AudiobookImportDoesNotCloseEbookGrab(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			libraryDir := t.TempDir()
 			audiobookDir := t.TempDir()
-			s, book, dlRepo, bookRepo, ctx := dualFormatFixture(t, libraryDir, audiobookDir)
+			s, book, dlRepo, bookRepo, ctx := formatScopeFixture(t, libraryDir, audiobookDir)
 
 			// 17:42:19 — the audiobook grab lands a real m4b in its download dir.
 			audioDownloadDir := t.TempDir()
@@ -197,7 +197,7 @@ func TestTryImportInternal_EbookImportDoesNotCloseAudiobookGrab(t *testing.T) {
 		t.Run(title, func(t *testing.T) {
 			libraryDir := t.TempDir()
 			audiobookDir := t.TempDir()
-			s, book, dlRepo, bookRepo, ctx := dualFormatFixture(t, libraryDir, audiobookDir)
+			s, book, dlRepo, bookRepo, ctx := formatScopeFixture(t, libraryDir, audiobookDir)
 
 			// The ebook is already imported and on disk.
 			libEpub := filepath.Join(libraryDir, "we-who-wrestle-with-god.epub")
@@ -266,7 +266,7 @@ func TestTryImportInternal_EbookImportDoesNotCloseAudiobookGrab(t *testing.T) {
 func TestTryImportInternal_FormatScopedShortCircuitStillFires(t *testing.T) {
 	libraryDir := t.TempDir()
 	audiobookDir := t.TempDir()
-	s, book, dlRepo, bookRepo, ctx := dualFormatFixture(t, libraryDir, audiobookDir)
+	s, book, dlRepo, bookRepo, ctx := formatScopeFixture(t, libraryDir, audiobookDir)
 
 	libEpub := filepath.Join(libraryDir, "we-who-wrestle-with-god.epub")
 	if err := os.WriteFile(libEpub, []byte("epub-in-library"), 0o644); err != nil {


### PR DESCRIPTION
## main is currently broken

```
vet: internal/importer/scanner_format_scope_test.go:20:6: dualFormatFixture redeclared in this block
```

#1961 and #1962 each added a package-level test helper called `dualFormatFixture` — `scanner_format_scope_test.go:20` and `scanner_dualformat_claim_test.go:15` — with different signatures. Neither branch contained the other's file, so both were legitimately green in isolation. Together they don't compile, and because the signatures differ, `golangci-lint` reports a cascade of follow-on typecheck errors at every call site.

## Fix

Renames the format-scope helper to `formatScopeFixture`, matching its own file and purpose, and leaves the dual-format claim helper untouched. Test-only; no production code.

`go vet ./internal/importer/` clean, `go test ./internal/importer/` passes in 20.8s.

## How it happened, and the cheaper habit

I merged #1962 without refreshing its base after #1961 landed, on the reasoning that the two touch different subsystems of `scanner.go` (download-import retry vs filesystem scan) and git reported no textual conflict. That reasoning was right about the *production* code and blind to the test package, where both PRs added a helper into the same namespace.

Git's "no conflict" answer is about overlapping lines, not about whether two changes can coexist. `gh pr update-branch` before merging the second of any pair costs one CI cycle and would have caught this; main's own post-merge run caught it instead, which is strictly worse.

Found by an agent resolving #1966's conflict, which verified it against a clean export of `origin/main` rather than assuming its own worktree was at fault.
