### PR TITLE
fix: honor skipMissingDate during author sync

### DIFF
--- a/changelog.d/skip-missing-date.md
+++ b/changelog.d/skip-missing-date.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Author sync now honors `skipMissingDate`** — the metadata profile setting previously had no effect during cataloging (only the field was persisted, nothing consumed it, per #1980). Works with no release date are now filtered out of author sync/refresh when the setting is enabled. `AuthorSyncSummary` gains a `skippedMissingDate` count alongside the existing skipped-language/junk/media-type counters so drops stay visible.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1640,6 +1640,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// Resolve the author's metadata profile (falling back to the seeded
 	// default) and parse its allowed_languages CSV. Nil means "no filter".
 	allowedLangs, unknownFail := h.resolveAllowedLanguages(ctx, author)
+	skipMissingDate := h.resolveSkipMissingDate(ctx, author)
 
 	// OpenLibrary works carry no work-level language; the search enricher only
 	// backfills it for indexed works, so a tail of works (often translations)
@@ -1824,7 +1825,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// skippedExcluded is logged but deliberately kept out of AuthorSyncSummary:
 	// the author page's notice explains works the user did NOT expect to lose,
 	// and a book they excluded by hand is not one of them.
-	var added, skippedLang, skippedJunk, skippedMediaType, skippedNotAccepted, skippedExcluded int
+	var added, skippedLang, skippedJunk, skippedMediaType, skippedNotAccepted, skippedExcluded, skippedMissingDate int
 	// Names of the first few language-rejected works, reported to the user
 	// alongside the count (#1889): "65 books skipped" is alarming, but it is
 	// the titles and their language codes that tell them whether the profile
@@ -1877,6 +1878,16 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		if normalizedTitle == "" || normalizedTitle == normalizedAuthor {
 			skippedJunk++
 			slog.Debug("skipping junk-title OL work", "title", b.Title, "foreignId", b.ForeignID)
+			continue
+		}
+
+		// Filter works with no release date when the author's metadata profile
+		// has SkipMissingDate enabled. ReleaseDate is already merged in from
+		// the provider's work data by this point (aggregator_author_works.go),
+		// so this is a straight presence check, not a fetch.
+		if skipMissingDate && b.ReleaseDate == nil {
+			skippedMissingDate++
+			slog.Debug("skipping work with no release date", "title", b.Title, "foreignId", b.ForeignID)
 			continue
 		}
 
@@ -2121,6 +2132,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		SkippedJunk:           skippedJunk,
 		SkippedMediaType:      skippedMediaType,
 		SkippedNotAccepted:    skippedNotAccepted,
+		SkippedMissingDate:    skippedMissingDate,
 		AllowedLanguages:      allowedLangs,
 		UnknownLanguageFail:   unknownFail,
 		SkippedLanguageSample: skippedLangSample,
@@ -2135,13 +2147,14 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		"author", author.Name, "added", added,
 		"skipped_language", skippedLang, "skipped_junk", skippedJunk, "skipped_media_type", skippedMediaType,
 		"skipped_not_accepted", skippedNotAccepted, "skipped_excluded", skippedExcluded,
+		"skipped_missing_date", skippedMissingDate,
 		"total", len(books),
 	}
 	// The metadata filters dropping works is the surprising case and stays at
 	// Warn. The discovery-policy skip is not: the user configured it, the run
 	// already said so once at Info above, and a "Refresh all authors" pass
 	// over an ABS-imported library would otherwise emit one Warn per author.
-	if skippedLang+skippedJunk+skippedMediaType > 0 {
+	if skippedLang+skippedJunk+skippedMediaType+skippedMissingDate > 0 {
 		slog.Warn("author books synced", logArgs...)
 		return
 	}
@@ -3092,4 +3105,20 @@ func applyAuthorMajorityLanguageFallback(books []models.Book) {
 			books[i].Language = majorityLang
 		}
 	}
+}
+
+// resolveSkipMissingDate returns the author's effective metadata profile's
+// SkipMissingDate setting. Defaults to false (matches the setting's prior
+// no-op behavior) on any lookup failure, so an unresolvable profile never
+// turns into unexpected catalogue loss.
+func (h *AuthorHandler) resolveSkipMissingDate(ctx context.Context, author *models.Author) bool {
+	id := models.DefaultMetadataProfileID
+	if author.MetadataProfileID != nil {
+		id = *author.MetadataProfileID
+	}
+	p, err := h.profiles.GetByID(ctx, id)
+	if err != nil || p == nil {
+		return false
+	}
+	return p.SkipMissingDate
 }

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1831,6 +1831,12 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// the titles and their language codes that tell them whether the profile
 	// is set the way they meant.
 	var skippedLangSample []models.AuthorSyncSkippedBook
+	// The first few date-rejected works, same reasoning and cap as
+	// skippedLangSample (#1889 established the pattern; requested again for
+	// this filter specifically in PR review, vavallee): a bare count doesn't
+	// say which books vanished, and Debug logs aren't reachable in a
+	// rootless container.
+	var skippedMissingDateSample []models.AuthorSyncSkippedBook
 	for _, b := range books {
 		b.AuthorID = author.ID
 		// Apply the caller-provided default media type when the provider
@@ -1887,6 +1893,9 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		// so this is a straight presence check, not a fetch.
 		if skipMissingDate && b.ReleaseDate == nil {
 			skippedMissingDate++
+			if len(skippedMissingDateSample) < authorSyncSkippedSampleLimit {
+				skippedMissingDateSample = append(skippedMissingDateSample, models.AuthorSyncSkippedBook{Title: b.Title})
+			}
 			slog.Debug("skipping work with no release date", "title", b.Title, "foreignId", b.ForeignID)
 			continue
 		}
@@ -2125,17 +2134,18 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// just ones that dropped something: "nothing was filtered out" is the
 	// answer to "where are my books?" as often as a count is.
 	summary := models.AuthorSyncSummary{
-		CompletedAt:           time.Now().UTC(),
-		Total:                 len(books),
-		Added:                 added,
-		SkippedLanguage:       skippedLang,
-		SkippedJunk:           skippedJunk,
-		SkippedMediaType:      skippedMediaType,
-		SkippedNotAccepted:    skippedNotAccepted,
-		SkippedMissingDate:    skippedMissingDate,
-		AllowedLanguages:      allowedLangs,
-		UnknownLanguageFail:   unknownFail,
-		SkippedLanguageSample: skippedLangSample,
+		CompletedAt:              time.Now().UTC(),
+		Total:                    len(books),
+		Added:                    added,
+		SkippedLanguage:          skippedLang,
+		SkippedJunk:              skippedJunk,
+		SkippedMediaType:         skippedMediaType,
+		SkippedNotAccepted:       skippedNotAccepted,
+		SkippedMissingDate:       skippedMissingDate,
+		SkippedMissingDateSample: skippedMissingDateSample,
+		AllowedLanguages:         allowedLangs,
+		UnknownLanguageFail:      unknownFail,
+		SkippedLanguageSample:    skippedLangSample,
 	}
 	h.syncSummaries.record(author.ID, summary)
 

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1887,11 +1887,23 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 			continue
 		}
 
+		// Hoisted above the profile filters below (rather than left at its
+		// original position just before the update branch) so a filter that
+		// fires after this point can exempt a book the user already owns.
+		// Without this, a filtered-but-owned book never reaches the update
+		// branch: it keeps its files, but silently stops getting rating,
+		// genre and cover updates, and is reported as "skipped" on every
+		// subsequent sync even though the user is looking at it in their
+		// library (vavallee, PR review). SkipMissingDate screens works out
+		// of discovery — it must not also stop maintaining ones already
+		// accepted.
+		existing, _ := h.books.GetByForeignID(ctx, b.ForeignID)
+
 		// Filter works with no release date when the author's metadata profile
 		// has SkipMissingDate enabled. ReleaseDate is already merged in from
 		// the provider's work data by this point (aggregator_author_works.go),
 		// so this is a straight presence check, not a fetch.
-		if skipMissingDate && b.ReleaseDate == nil {
+		if existing == nil && skipMissingDate && b.ReleaseDate == nil {
 			skippedMissingDate++
 			if len(skippedMissingDateSample) < authorSyncSkippedSampleLimit {
 				skippedMissingDateSample = append(skippedMissingDateSample, models.AuthorSyncSkippedBook{Title: b.Title})
@@ -1938,7 +1950,8 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 
 		// Update ratings + genres on existing books, then skip further
 		// processing (we don't want to overwrite user state like status).
-		existing, _ := h.books.GetByForeignID(ctx, b.ForeignID)
+		// existing was resolved above, before the profile filters, so an
+		// owned book that trips one of them still reaches this branch.
 		if existing != nil {
 			changed := false
 			// GetByForeignID matches globally (foreign_id is UNIQUE across all

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -922,6 +922,76 @@ func TestFetchAuthorBooks_MissingDateKeptWhenSkipDisabled(t *testing.T) {
 	}
 }
 
+// TestFetchAuthorBooks_SkipMissingDateExemptsAlreadyTrackedBook verifies that
+// SkipMissingDate does not stop maintaining a book the user already owns: an
+// undated work that is already in the library must keep receiving updates
+// (ratings here) and must not be counted as skipped, even though a fresh
+// candidate with no release date would be filtered out (vavallee, PR review
+// — filtering screens works out of discovery, it must not also stop
+// maintaining ones already accepted).
+func TestFetchAuthorBooks_SkipMissingDateExemptsAlreadyTrackedBook(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	profile, err := profileRepo.GetByID(ctx, models.DefaultMetadataProfileID)
+	if err != nil || profile == nil {
+		t.Fatalf("GetByID(default profile) failed: %v", err)
+	}
+	profile.SkipMissingDate = true
+	if err := profileRepo.Update(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID: "OL932A", Name: "Missing-Date Author Three", SortName: "Author, Missing-Date Three",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	owned := &models.Book{
+		ForeignID: "OL933W", Title: "Undated Owned Work", SortTitle: "undated owned work",
+		AuthorID: author.ID, Language: "eng", Status: models.BookStatusWanted,
+		MediaType: models.MediaTypeEbook, MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, owned); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: []models.Book{
+		{ForeignID: "OL933W", Title: "Undated Owned Work", SortTitle: "undated owned work",
+			Language: "eng", MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			AverageRating: 4.2, RatingsCount: 250},
+	}})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	updated, err := bookRepo.GetByForeignID(ctx, "OL933W")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated == nil {
+		t.Fatal("already-tracked undated work was deleted, want it kept")
+	}
+	if updated.RatingsCount != 250 {
+		t.Errorf("RatingsCount = %d, want 250 (already-tracked book should still receive updates)", updated.RatingsCount)
+	}
+
+	if summary := h.syncSummaries.get(author.ID); summary != nil && summary.SkippedMissingDate != 0 {
+		t.Errorf("summary.SkippedMissingDate = %d, want 0 (already-tracked book must not be counted as skipped)", summary.SkippedMissingDate)
+	}
+}
+
 // stubLibraryFinder is a mock LibraryFinder that returns a fixed path for
 // a specific title and "" for everything else.
 type stubLibraryFinder struct {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -780,6 +780,139 @@ func TestFetchAuthorBooks_StrictMediaType(t *testing.T) {
 	}
 }
 
+// missingDateTestWorks returns a fixed mix of works with and without a
+// release date, so SkipMissingDate's effect can be checked against both.
+func missingDateTestWorks() []models.Book {
+	dated := time.Date(2019, 6, 15, 0, 0, 0, 0, time.UTC)
+	return []models.Book{
+		{ForeignID: "OL920W", Title: "Leviathan Wakes", SortTitle: "leviathan wakes", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			ReleaseDate: &dated},
+		{ForeignID: "OL921W", Title: "Caliban's War", SortTitle: "caliban's war", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			ReleaseDate: &dated},
+		{ForeignID: "OL922W", Title: "Undated Work One", SortTitle: "undated work one", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary"},
+		{ForeignID: "OL923W", Title: "Undated Work Two", SortTitle: "undated work two", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary"},
+	}
+}
+
+// TestFetchAuthorBooks_SkipsMissingDate verifies that once a metadata
+// profile's SkipMissingDate is enabled, works with no release date are
+// dropped from author sync while dated works still come through, and that
+// the drop is reflected in both the SkippedMissingDate and SkippedTotal
+// summary counters.
+func TestFetchAuthorBooks_SkipsMissingDate(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	profile, err := profileRepo.GetByID(ctx, models.DefaultMetadataProfileID)
+	if err != nil || profile == nil {
+		t.Fatalf("GetByID(default profile) failed: %v", err)
+	}
+	profile.SkipMissingDate = true
+	if err := profileRepo.Update(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID: "OL930A", Name: "Missing-Date Author", SortName: "Author, Missing-Date",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: missingDateTestWorks()})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	got, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTitle := make(map[string]bool, len(got))
+	for _, b := range got {
+		byTitle[b.Title] = true
+	}
+
+	for _, undated := range []string{"Undated Work One", "Undated Work Two"} {
+		if byTitle[undated] {
+			t.Errorf("undated work %q should have been skipped, but was created", undated)
+		}
+	}
+	for _, dated := range []string{"Leviathan Wakes", "Caliban's War"} {
+		if !byTitle[dated] {
+			t.Errorf("dated work %q should have been created, but was skipped", dated)
+		}
+	}
+
+	summary := h.syncSummaries.get(author.ID)
+	if summary == nil {
+		t.Fatal("expected a recorded sync summary, got nil")
+	}
+	if want := 2; summary.SkippedMissingDate != want {
+		t.Errorf("summary.SkippedMissingDate = %d, want %d", summary.SkippedMissingDate, want)
+	}
+	if summary.SkippedTotal() < summary.SkippedMissingDate {
+		t.Errorf("summary.SkippedTotal() = %d should include SkippedMissingDate = %d", summary.SkippedTotal(), summary.SkippedMissingDate)
+	}
+}
+
+// TestFetchAuthorBooks_MissingDateKeptWhenSkipDisabled verifies the inverse
+// of TestFetchAuthorBooks_SkipsMissingDate: with SkipMissingDate left at its
+// default (false), undated works are still cataloged exactly as before this
+// change — the filter is opt-in, not a behavior change for profiles that
+// never touch the setting.
+func TestFetchAuthorBooks_MissingDateKeptWhenSkipDisabled(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{
+		ForeignID: "OL931A", Name: "Missing-Date Author Two", SortName: "Author, Missing-Date Two",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: missingDateTestWorks()})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	got, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(missingDateTestWorks()) {
+		t.Errorf("got %d books, want %d (SkipMissingDate defaults to false, nothing should be dropped)",
+			len(got), len(missingDateTestWorks()))
+	}
+
+	if summary := h.syncSummaries.get(author.ID); summary != nil && summary.SkippedMissingDate != 0 {
+		t.Errorf("summary.SkippedMissingDate = %d, want 0 (filter is opt-in)", summary.SkippedMissingDate)
+	}
+}
+
 // stubLibraryFinder is a mock LibraryFinder that returns a fixed path for
 // a specific title and "" for everything else.
 type stubLibraryFinder struct {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -867,6 +867,15 @@ func TestFetchAuthorBooks_SkipsMissingDate(t *testing.T) {
 	if summary.SkippedTotal() < summary.SkippedMissingDate {
 		t.Errorf("summary.SkippedTotal() = %d should include SkippedMissingDate = %d", summary.SkippedTotal(), summary.SkippedMissingDate)
 	}
+	sampleTitles := make(map[string]bool, len(summary.SkippedMissingDateSample))
+	for _, b := range summary.SkippedMissingDateSample {
+		sampleTitles[b.Title] = true
+	}
+	for _, undated := range []string{"Undated Work One", "Undated Work Two"} {
+		if !sampleTitles[undated] {
+			t.Errorf("expected %q in summary.SkippedMissingDateSample, got %+v", undated, summary.SkippedMissingDateSample)
+		}
+	}
 }
 
 // TestFetchAuthorBooks_MissingDateKeptWhenSkipDisabled verifies the inverse


### PR DESCRIPTION
## Summary

`SkipMissingDate` on a metadata profile was persisted to the DB and returned by every profile read, but nothing in author sync actually consulted it (see #1980) — works with no release date were cataloged the same as any other, with no way to filter them despite the setting's name.

This wires a title-agnostic date-presence check into the existing `fetchAuthorBooks` filter chain (same place the junk-title and `SkipPartBooks` checks live), gated on the author's resolved metadata profile via a new `resolveSkipMissingDate` helper that mirrors the existing `resolveAllowedLanguages`/`resolveSkipPartBooks` pattern. `AuthorSyncSummary` gains a `SkippedMissingDate` count so drops are visible in the author page's sync report the same way the other skip counters already are.

- **Added** — `AuthorHandler.resolveSkipMissingDate`, resolving the author's effective metadata profile the same way `resolveAllowedLanguages`/`resolveSkipPartBooks` do, defaulting to `false` on any lookup failure so an unresolvable profile never causes unexpected catalogue loss.
- **Changed** — `fetchAuthorBooks`'s ingestion loop now drops a work when `skipMissingDate && b.ReleaseDate == nil`, right after the junk-title check.
- **Changed** — `AuthorSyncSummary.SkippedMissingDate` (+ folded into `SkippedTotal()` and the Warn-level log gate, alongside the other metadata-filter counters), logged as `skipped_missing_date`.

### Why this one and not `SkipMissingISBN`

#1980 groups four write-only filters together, but they're not the same shape of fix. I traced both before touching either (full writeup in a comment on #1980):

- `SkipMissingDate` is safe to filter at cataloging time: `ReleaseDate` is already merged onto the book from the provider's work data (`aggregator_author_works.go`) before `fetchAuthorBooks`'s filter chain runs — this is a presence check on data already in hand, same as `SkipPartBooks`.
- `SkipMissingISBN` is not: ISBN data lives on `Editions`, not `Book.ISBN`, in this flow, and isn't fetched until `hydrateHardcoverEditions` runs **after** a book is already created. Wiring it the same way would mean either creating the book first (defeating the filter) or fetching edition data for every candidate work up front (a real API-cost change, not a copy of this pattern). That one needs a design decision first, which I've raised on #1980 rather than guessing at in code.

## Testing

- `TestFetchAuthorBooks_SkipsMissingDate` — full `fetchAuthorBooks` integration test (in-memory SQLite, stub metadata provider) verifying undated works are dropped while dated works come through, and asserting the `SkippedMissingDate`/`SkippedTotal` summary counters directly (not just book presence in the DB).
- `TestFetchAuthorBooks_MissingDateKeptWhenSkipDisabled` — confirms the filter is opt-in: with the setting at its default (`false`), behavior is unchanged and the counter stays at zero.
- `gofmt -l`, `go vet ./internal/api/... ./internal/models/...`, and `go test ./internal/api/... ./internal/models/...` all pass (ran inside the repo's own `golang:1.26.5-alpine` builder image).

## Test plan for reviewers

- [ ] `make check` (or the individual gofmt/vet/lint/test commands from CONTRIBUTING.md)
- [ ] Enable "Skip missing date" on a metadata profile in the UI, add/refresh an author known to have undated editions on OpenLibrary, confirm they're absent from Wanted and the sync summary reports a non-zero `skippedMissingDate` count
- [ ] Confirm a profile with the setting left off is unaffected (existing behavior)

Refs #1980.
