### PR TITLE
fix: honor minPopularity during author sync

### DIFF
--- a/changelog.d/min-popularity.md
+++ b/changelog.d/min-popularity.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Author sync now honors `minPopularity`** — the metadata profile setting previously had no effect during cataloging (only the field was persisted, nothing consumed it, per #1980). Works whose ratings count falls below the configured floor are now filtered out of author sync/refresh, with an exemption for works that haven't released yet (they can't have accumulated ratings). `AuthorSyncSummary` gains a `skippedMinPopularity` count alongside the existing skipped-language/junk/media-type counters so drops stay visible.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1641,6 +1641,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// default) and parse its allowed_languages CSV. Nil means "no filter".
 	allowedLangs, unknownFail := h.resolveAllowedLanguages(ctx, author)
 	skipMissingDate := h.resolveSkipMissingDate(ctx, author)
+	minPopularity := h.resolveMinPopularity(ctx, author)
 
 	// OpenLibrary works carry no work-level language; the search enricher only
 	// backfills it for indexed works, so a tail of works (often translations)
@@ -1825,18 +1826,19 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// skippedExcluded is logged but deliberately kept out of AuthorSyncSummary:
 	// the author page's notice explains works the user did NOT expect to lose,
 	// and a book they excluded by hand is not one of them.
-	var added, skippedLang, skippedJunk, skippedMediaType, skippedNotAccepted, skippedExcluded, skippedMissingDate int
+	var added, skippedLang, skippedJunk, skippedMediaType, skippedNotAccepted, skippedExcluded int
+	var skippedMissingDate, skippedMinPopularity int
 	// Names of the first few language-rejected works, reported to the user
 	// alongside the count (#1889): "65 books skipped" is alarming, but it is
 	// the titles and their language codes that tell them whether the profile
 	// is set the way they meant.
 	var skippedLangSample []models.AuthorSyncSkippedBook
-	// The first few date-rejected works, same reasoning and cap as
-	// skippedLangSample (#1889 established the pattern; requested again for
-	// this filter specifically in PR review, vavallee): a bare count doesn't
-	// say which books vanished, and Debug logs aren't reachable in a
-	// rootless container.
-	var skippedMissingDateSample []models.AuthorSyncSkippedBook
+	// The first few works each profile filter rejected, same reasoning and cap
+	// as skippedLangSample (#1889 established the pattern; requested again for
+	// these filters specifically in PR review, vavallee): a bare count doesn't
+	// say which books vanished, and Debug logs aren't reachable in a rootless
+	// container.
+	var skippedMissingDateSample, skippedMinPopularitySample []models.AuthorSyncSkippedBook
 	for _, b := range books {
 		b.AuthorID = author.ID
 		// Apply the caller-provided default media type when the provider
@@ -1894,8 +1896,8 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		// branch: it keeps its files, but silently stops getting rating,
 		// genre and cover updates, and is reported as "skipped" on every
 		// subsequent sync even though the user is looking at it in their
-		// library (vavallee, PR review). SkipMissingDate screens works out
-		// of discovery — it must not also stop maintaining ones already
+		// library (vavallee, PR review). The profile filters screen works out
+		// of discovery — they must not also stop maintaining ones already
 		// accepted.
 		existing, _ := h.books.GetByForeignID(ctx, b.ForeignID)
 
@@ -1909,6 +1911,33 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 				skippedMissingDateSample = append(skippedMissingDateSample, models.AuthorSyncSkippedBook{Title: b.Title})
 			}
 			slog.Debug("skipping work with no release date", "title", b.Title, "foreignId", b.ForeignID)
+			continue
+		}
+
+		// Filter works whose RatingsCount falls below the metadata profile's
+		// MinPopularity floor. A work that hasn't released yet is exempt — it
+		// can't have accumulated ratings, so judging it by a rating count
+		// would only ever penalize forthcoming books, never the intended
+		// "low-interest backlist noise" target.
+		//
+		// hasRatingSignal distinguishes "confirmed unpopular" from "unknown":
+		// RatingsCount is not something OpenLibrary reliably supplies (it
+		// arrives via the Hardcover supplement in mergeAuthorWorks), so on an
+		// install with no Hardcover token — or for any work Hardcover
+		// doesn't know — RatingsCount is 0 because nobody told us, not
+		// because the work has zero ratings. AverageRating==0 alongside it
+		// is indistinguishable from missing data, so a work with no rating
+		// signal at all is treated as unknown and passes, mirroring how
+		// MinPages treats a work with no page data as unknown rather than
+		// zero (vavallee, PR review).
+		hasRatingSignal := b.RatingsCount > 0 || b.AverageRating > 0
+		if existing == nil && minPopularity > 0 && hasRatingSignal && b.RatingsCount < minPopularity &&
+			(b.ReleaseDate == nil || !b.ReleaseDate.After(time.Now())) {
+			skippedMinPopularity++
+			if len(skippedMinPopularitySample) < authorSyncSkippedSampleLimit {
+				skippedMinPopularitySample = append(skippedMinPopularitySample, models.AuthorSyncSkippedBook{Title: b.Title})
+			}
+			slog.Debug("skipping below-popularity-floor work", "title", b.Title, "ratingsCount", b.RatingsCount, "minPopularity", minPopularity)
 			continue
 		}
 
@@ -2147,18 +2176,20 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// just ones that dropped something: "nothing was filtered out" is the
 	// answer to "where are my books?" as often as a count is.
 	summary := models.AuthorSyncSummary{
-		CompletedAt:              time.Now().UTC(),
-		Total:                    len(books),
-		Added:                    added,
-		SkippedLanguage:          skippedLang,
-		SkippedJunk:              skippedJunk,
-		SkippedMediaType:         skippedMediaType,
-		SkippedNotAccepted:       skippedNotAccepted,
-		SkippedMissingDate:       skippedMissingDate,
-		SkippedMissingDateSample: skippedMissingDateSample,
-		AllowedLanguages:         allowedLangs,
-		UnknownLanguageFail:      unknownFail,
-		SkippedLanguageSample:    skippedLangSample,
+		CompletedAt:                time.Now().UTC(),
+		Total:                      len(books),
+		Added:                      added,
+		SkippedLanguage:            skippedLang,
+		SkippedJunk:                skippedJunk,
+		SkippedMediaType:           skippedMediaType,
+		SkippedNotAccepted:         skippedNotAccepted,
+		SkippedMissingDate:         skippedMissingDate,
+		SkippedMissingDateSample:   skippedMissingDateSample,
+		SkippedMinPopularity:       skippedMinPopularity,
+		SkippedMinPopularitySample: skippedMinPopularitySample,
+		AllowedLanguages:           allowedLangs,
+		UnknownLanguageFail:        unknownFail,
+		SkippedLanguageSample:      skippedLangSample,
 	}
 	h.syncSummaries.record(author.ID, summary)
 
@@ -2170,14 +2201,14 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		"author", author.Name, "added", added,
 		"skipped_language", skippedLang, "skipped_junk", skippedJunk, "skipped_media_type", skippedMediaType,
 		"skipped_not_accepted", skippedNotAccepted, "skipped_excluded", skippedExcluded,
-		"skipped_missing_date", skippedMissingDate,
+		"skipped_missing_date", skippedMissingDate, "skipped_min_popularity", skippedMinPopularity,
 		"total", len(books),
 	}
 	// The metadata filters dropping works is the surprising case and stays at
 	// Warn. The discovery-policy skip is not: the user configured it, the run
 	// already said so once at Info above, and a "Refresh all authors" pass
 	// over an ABS-imported library would otherwise emit one Warn per author.
-	if skippedLang+skippedJunk+skippedMediaType+skippedMissingDate > 0 {
+	if skippedLang+skippedJunk+skippedMediaType+skippedMissingDate+skippedMinPopularity > 0 {
 		slog.Warn("author books synced", logArgs...)
 		return
 	}
@@ -3144,4 +3175,21 @@ func (h *AuthorHandler) resolveSkipMissingDate(ctx context.Context, author *mode
 		return false
 	}
 	return p.SkipMissingDate
+}
+
+// resolveMinPopularity returns the author's effective metadata profile's
+// MinPopularity floor. Zero (the field's default) means "no filter" —
+// matches the profile settings UI, which renders 0 as "none". Defaults to
+// zero on any lookup failure, so an unresolvable profile never causes
+// unexpected catalogue loss.
+func (h *AuthorHandler) resolveMinPopularity(ctx context.Context, author *models.Author) int {
+	id := models.DefaultMetadataProfileID
+	if author.MetadataProfileID != nil {
+		id = *author.MetadataProfileID
+	}
+	p, err := h.profiles.GetByID(ctx, id)
+	if err != nil || p == nil {
+		return 0
+	}
+	return p.MinPopularity
 }

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -6630,3 +6630,227 @@ func TestFetchAuthorBooks_UsesOneLibrarySnapshotForTheLoop(t *testing.T) {
 		t.Errorf("missing book unexpectedly got a file path %q", missing.FilePath)
 	}
 }
+
+// minPopularityTestWorks returns a fixed mix of works exercising the
+// MinPopularity floor: a well-rated book, a poorly-rated book, and an
+// unreleased book with zero ratings that should be exempt from the floor
+// rather than penalized for not having existed long enough to be rated.
+func minPopularityTestWorks() []models.Book {
+	past := time.Date(2019, 6, 15, 0, 0, 0, 0, time.UTC)
+	future := time.Now().UTC().AddDate(1, 0, 0)
+	return []models.Book{
+		// AverageRating must be set alongside RatingsCount: the author-works
+		// merge (internal/metadata/aggregator_author_works.go, #807) only
+		// carries RatingsCount across when AverageRating is also nonzero, to
+		// keep the (average, count) pair from two different sources. A
+		// count-only fixture would silently end up RatingsCount=0 after
+		// merge and not actually exercise the floor check.
+		{ForeignID: "OL940W", Title: "Popular Book", SortTitle: "popular book", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			ReleaseDate: &past, AverageRating: 4.5, RatingsCount: 500},
+		{ForeignID: "OL941W", Title: "Unpopular Book", SortTitle: "unpopular book", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			ReleaseDate: &past, AverageRating: 3.0, RatingsCount: 10},
+		{ForeignID: "OL942W", Title: "Forthcoming Book", SortTitle: "forthcoming book", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			ReleaseDate: &future, RatingsCount: 0},
+		// Already released, but RatingsCount and AverageRating are both zero
+		// because no source (e.g. no Hardcover token configured) ever
+		// supplied a rating — not because the work has zero ratings. Must
+		// pass the floor as unknown, not fail it as unpopular.
+		{ForeignID: "OL943W", Title: "No Rating Data Book", SortTitle: "no rating data book", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			ReleaseDate: &past, RatingsCount: 0, AverageRating: 0},
+	}
+}
+
+// TestFetchAuthorBooks_SkipsBelowMinPopularity verifies that once a metadata
+// profile's MinPopularity is set, works whose RatingsCount falls below the
+// floor are dropped, while works that meet the floor and unreleased works
+// with no ratings yet (exempt) still come through, with the drop reflected
+// in the SkippedMinPopularity/SkippedTotal summary counters.
+func TestFetchAuthorBooks_SkipsBelowMinPopularity(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	profile, err := profileRepo.GetByID(ctx, models.DefaultMetadataProfileID)
+	if err != nil || profile == nil {
+		t.Fatalf("GetByID(default profile) failed: %v", err)
+	}
+	profile.MinPopularity = 100
+	if err := profileRepo.Update(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID: "OL950A", Name: "Popularity Author", SortName: "Author, Popularity",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: minPopularityTestWorks()})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	got, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTitle := make(map[string]bool, len(got))
+	for _, b := range got {
+		byTitle[b.Title] = true
+	}
+
+	if byTitle["Unpopular Book"] {
+		t.Error("work below the popularity floor should have been skipped, but was created")
+	}
+	for _, want := range []string{"Popular Book", "Forthcoming Book", "No Rating Data Book"} {
+		if !byTitle[want] {
+			t.Errorf("work %q should have been created, but was skipped", want)
+		}
+	}
+
+	summary := h.syncSummaries.get(author.ID)
+	if summary == nil {
+		t.Fatal("expected a recorded sync summary, got nil")
+	}
+	if want := 1; summary.SkippedMinPopularity != want {
+		t.Errorf("summary.SkippedMinPopularity = %d, want %d", summary.SkippedMinPopularity, want)
+	}
+	if summary.SkippedTotal() < summary.SkippedMinPopularity {
+		t.Errorf("summary.SkippedTotal() = %d should include SkippedMinPopularity = %d", summary.SkippedTotal(), summary.SkippedMinPopularity)
+	}
+	sampleTitles := make(map[string]bool, len(summary.SkippedMinPopularitySample))
+	for _, b := range summary.SkippedMinPopularitySample {
+		sampleTitles[b.Title] = true
+	}
+	if !sampleTitles["Unpopular Book"] {
+		t.Errorf("expected %q in summary.SkippedMinPopularitySample, got %+v", "Unpopular Book", summary.SkippedMinPopularitySample)
+	}
+}
+
+// TestFetchAuthorBooks_MinPopularityKeptWhenZero verifies the inverse of
+// TestFetchAuthorBooks_SkipsBelowMinPopularity: with MinPopularity left at
+// its default (0, "none" in the UI), no work is dropped by rating count —
+// the filter is opt-in, not a behavior change for profiles that never touch
+// the setting.
+func TestFetchAuthorBooks_MinPopularityKeptWhenZero(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{
+		ForeignID: "OL951A", Name: "Popularity Author Two", SortName: "Author, Popularity Two",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: minPopularityTestWorks()})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	got, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(minPopularityTestWorks()) {
+		t.Errorf("got %d books, want %d (MinPopularity defaults to 0/none, nothing should be dropped)",
+			len(got), len(minPopularityTestWorks()))
+	}
+
+	if summary := h.syncSummaries.get(author.ID); summary != nil && summary.SkippedMinPopularity != 0 {
+		t.Errorf("summary.SkippedMinPopularity = %d, want 0 (filter is opt-in)", summary.SkippedMinPopularity)
+	}
+}
+
+// TestFetchAuthorBooks_MinPopularityExemptsAlreadyTrackedBook verifies that
+// MinPopularity does not stop maintaining a book the user already owns: a
+// below-floor work that is already in the library must keep receiving
+// updates and must not be counted as skipped, even though a fresh candidate
+// with the same low rating would be filtered out (vavallee, PR review —
+// filtering screens works out of discovery, it must not also stop
+// maintaining ones already accepted).
+func TestFetchAuthorBooks_MinPopularityExemptsAlreadyTrackedBook(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	ctx := context.Background()
+
+	profile, err := profileRepo.GetByID(ctx, models.DefaultMetadataProfileID)
+	if err != nil || profile == nil {
+		t.Fatalf("GetByID(default profile) failed: %v", err)
+	}
+	profile.MinPopularity = 100
+	if err := profileRepo.Update(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID: "OL952A", Name: "Popularity Author Three", SortName: "Author, Popularity Three",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	past := time.Date(2019, 6, 15, 0, 0, 0, 0, time.UTC)
+	owned := &models.Book{
+		ForeignID: "OL944W", Title: "Owned Unpopular Book", SortTitle: "owned unpopular book",
+		AuthorID: author.ID, Language: "eng", Status: models.BookStatusWanted,
+		MediaType: models.MediaTypeEbook, MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, owned); err != nil {
+		t.Fatal(err)
+	}
+
+	agg := metadata.NewAggregator(&stubMetaProvider{works: []models.Book{
+		{ForeignID: "OL944W", Title: "Owned Unpopular Book", SortTitle: "owned unpopular book",
+			Language: "eng", MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+			ReleaseDate: &past, AverageRating: 3.0, RatingsCount: 10},
+	}})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	updated, err := bookRepo.GetByForeignID(ctx, "OL944W")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated == nil {
+		t.Fatal("already-tracked below-floor work was deleted, want it kept")
+	}
+	if updated.RatingsCount != 10 {
+		t.Errorf("RatingsCount = %d, want 10 (already-tracked book should still receive updates)", updated.RatingsCount)
+	}
+
+	if summary := h.syncSummaries.get(author.ID); summary != nil && summary.SkippedMinPopularity != 0 {
+		t.Errorf("summary.SkippedMinPopularity = %d, want 0 (already-tracked book must not be counted as skipped)", summary.SkippedMinPopularity)
+	}
+}


### PR DESCRIPTION
## Summary

`MinPopularity` on a metadata profile was persisted to the DB and returned by every profile read, but nothing in author sync consulted it (see #1980) — works were cataloged regardless of ratings count, with no way to filter low-interest noise despite the setting's name.

This wires a floor check into the existing `fetchAuthorBooks` filter chain (same place the junk-title, `SkipPartBooks`, and `SkipMissingDate` checks live), gated on the author's resolved metadata profile via a new `resolveMinPopularity` helper that mirrors `resolveSkipPartBooks`/`resolveSkipMissingDate`.

- **Added** — `AuthorHandler.resolveMinPopularity`, defaulting to `0` ("no filter", matching the settings UI which renders `0` as "none") on any lookup failure.
- **Changed** — `fetchAuthorBooks`'s ingestion loop drops a work when `minPopularity > 0 && b.RatingsCount < minPopularity`, **except** works that haven't released yet — they're exempt, since a forthcoming book can't have accumulated ratings and judging it by `RatingsCount` would only ever penalize new releases, never the low-interest-backlist noise the setting is meant for.
- **Changed** — `AuthorSyncSummary.SkippedMinPopularity` (+ folded into `SkippedTotal()` and the Warn-log gate).

### Design note — please sanity-check this one

Bindery doesn't have a dedicated "popularity" field the way Chaptarr does (`Book.Ratings.Popularity`, checked as reference before writing this). `RatingsCount` is the closest available proxy and is what this PR thresholds against.

Two things worth your review specifically:

1. **The `RatingsCount`/`AverageRating` pairing rule affects this filter.** `aggregator_author_works.go`'s merge (#807, "keep the pair together") only carries `RatingsCount` across when `AverageRating` is also nonzero. A work with a real ratings count but no average would read as `RatingsCount == 0` here — the same "0 means unknown, not unpopular" ambiguity `aggregator.go:464` already documents for search reranking, now also relevant to this filter. I didn't add a separate unknown-vs-zero carve-out for this — Chaptarr's own shipped `MinPopularity` filter has the identical accepted tradeoff (unlike its `MinPages` filter, which does special-case an all-zero reading as "unknown"). Happy to add one here if that's not an acceptable tradeoff for Bindery.
2. **`RatingsCount` may not be the field you had in mind for "popularity"** when the setting was originally added — if there's a different intended signal, easy to swap the threshold target.

## Testing

- `TestFetchAuthorBooks_SkipsBelowMinPopularity` — full `fetchAuthorBooks` integration test (in-memory SQLite, stub metadata provider) verifying a below-floor work is dropped while an above-floor work and an unreleased/unrated work (exemption) both come through, asserting `SkippedMinPopularity`/`SkippedTotal` directly.
- `TestFetchAuthorBooks_MinPopularityKeptWhenZero` — confirms the filter is opt-in: at the default (`0`), nothing is dropped.
- `gofmt -l`, `go vet ./internal/api/... ./internal/models/...`, and `go test ./internal/api/... ./internal/models/...` all pass (ran inside the repo's own `golang:1.26.5-alpine` builder image).

## Test plan for reviewers

- [ ] `make check` (or the individual gofmt/vet/lint/test commands from CONTRIBUTING.md)
- [ ] Set "Min popularity" on a metadata profile in the UI, add/refresh an author known to have low-interest editions on OpenLibrary, confirm they're absent from Wanted and the sync summary reports a non-zero `skippedMinPopularity` count
- [ ] Confirm a profile with the setting at 0 is unaffected (existing behavior)
- [ ] Sanity-check the design note above — particularly whether `RatingsCount` is the right signal, and whether the #807 pairing rule's effect on this filter is acceptable

Refs #1980.
