### PR TITLE
fix(importer): cap path components by bytes, not runes (#1982)

### DIFF
--- a/changelog.d/1982-path-component-byte-cap.md
+++ b/changelog.d/1982-path-component-byte-cap.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Books with long non-ASCII titles no longer fail to import** (#1982) — a
+  Japanese, Chinese, Korean, Russian, Greek or heavily accented title of roughly
+  83 characters or more could kill the import with "file name too long". The
+  importer was limiting each name to 200 *characters*, but filesystems count
+  *bytes*, and one CJK character is three or four of them. The limit is now 200
+  bytes, cut on a character boundary so a name never ends in half a character.
+  Titles in plain ASCII are unaffected — nothing already in your library gets
+  renamed.

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
@@ -1199,10 +1200,33 @@ func CopyDirCtx(ctx context.Context, src, dst string) error {
 	return copyDirPublicCtx(ctx, src, dst)
 }
 
-// maxPathComponentLen caps each sanitized path segment. Most filesystems limit
-// a single name to 255 bytes (NAME_MAX); 200 leaves room for the extension and
-// any uniqueness suffix the importer appends.
-const maxPathComponentLen = 200
+// maxPathComponentBytes caps each sanitized path segment. NAME_MAX is measured
+// in BYTES, not characters — 255 on ext4, XFS, btrfs and APFS — so a rune-based
+// cap let a non-ASCII title through at up to 4x the budget and the import died
+// with ENAMETOOLONG (#1982).
+//
+// The budget is 200 rather than 255 because sanitizePath does not sanitise a
+// finished filename: it sanitises one template *value* ({Title}, {Author}, …)
+// that is then substituted into a user-configurable naming template alongside
+// literal glue, before an extension and any " (2)" uniqueness suffix are
+// appended. A value capped at exactly NAME_MAX overflows the moment it becomes
+// part of a real name. 200 also keeps ASCII byte-for-byte identical to the old
+// 200-rune cap, so no existing library's paths change.
+const maxPathComponentBytes = 200
+
+// truncateUTF8 returns s limited to at most maxBytes bytes, cut on a rune
+// boundary so a multi-byte character is never split mid-encoding (which would
+// leave invalid UTF-8 in a filename and in the book_files path row).
+func truncateUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	end := maxBytes
+	for end > 0 && !utf8.RuneStart(s[end]) {
+		end--
+	}
+	return s[:end]
+}
 
 // pathCharReplacer neutralises characters that are problematic in file
 // paths. Shared by sanitizePath (full field sanitisation) and sanitizeInline
@@ -1251,10 +1275,10 @@ func sanitizePath(s string) string {
 		if p == "" || p == "." || p == ".." {
 			continue
 		}
-		// Cap each component (rune-safe) so an overlong metadata field can't
-		// produce an ENAMETOOLONG that fails the whole import.
-		if r := []rune(p); len(r) > maxPathComponentLen {
-			p = strings.TrimSpace(string(r[:maxPathComponentLen]))
+		// Cap each component by BYTES (rune-safe) so an overlong metadata field
+		// can't produce an ENAMETOOLONG that fails the whole import.
+		if len(p) > maxPathComponentBytes {
+			p = strings.TrimSpace(truncateUTF8(p, maxPathComponentBytes))
 		}
 		kept = append(kept, p)
 	}

--- a/internal/importer/renamer_sanitize_test.go
+++ b/internal/importer/renamer_sanitize_test.go
@@ -1,6 +1,8 @@
 package importer
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -20,20 +22,104 @@ func TestSanitizePath_StripsControlChars(t *testing.T) {
 	}
 }
 
+// TestSanitizePath_CapsComponentLength pins the cap as a BYTE budget (#1982).
+// It used to assert RuneCountInString(got) == maxPathComponentLen, which is the
+// defect itself: filesystems measure NAME_MAX in bytes, so a rune cap let a
+// non-ASCII component through at up to 4x the budget. For pure ASCII the byte
+// cap is numerically identical to the old rune cap, which is why this case is
+// kept unchanged in value — it is the guarantee that existing libraries' paths
+// do not move.
 func TestSanitizePath_CapsComponentLength(t *testing.T) {
 	got := sanitizePath(strings.Repeat("x", 500))
-	if n := utf8.RuneCountInString(got); n != maxPathComponentLen {
-		t.Errorf("component length = %d, want %d", n, maxPathComponentLen)
+	if n := len(got); n != maxPathComponentBytes {
+		t.Errorf("component length = %d bytes, want %d", n, maxPathComponentBytes)
+	}
+	// ASCII: byte-for-byte identical to the pre-#1982 200-rune behaviour.
+	if n := utf8.RuneCountInString(got); n != maxPathComponentBytes {
+		t.Errorf("ASCII rune count = %d, want %d (ASCII must not change)", n, maxPathComponentBytes)
 	}
 }
 
+// TestSanitizePath_CapIsRuneSafe keeps the half of the old test that was always
+// right — truncation must not split a character mid-encoding — and replaces the
+// half that encoded the bug (rune count == cap) with the byte budget.
 func TestSanitizePath_CapIsRuneSafe(t *testing.T) {
-	// Multi-byte runes must not be split mid-encoding by the length cap.
-	got := sanitizePath(strings.Repeat("é", 500))
-	if !utf8.ValidString(got) {
-		t.Errorf("truncation produced invalid UTF-8: %q", got)
+	for name, unit := range map[string]string{
+		"accented latin": "é", // 2 bytes
+		"cyrillic":       "щ", // 2 bytes
+		"cjk":            "転", // 3 bytes
+		"emoji":          "📚", // 4 bytes
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := sanitizePath(strings.Repeat(unit, 500))
+			if !utf8.ValidString(got) {
+				t.Errorf("truncation produced invalid UTF-8: %q", got)
+			}
+			if n := len(got); n > maxPathComponentBytes {
+				t.Errorf("component = %d bytes, want <= %d", n, maxPathComponentBytes)
+			}
+			// Cut on a rune boundary means we lose at most one unit's worth of
+			// bytes off the budget — not that we silently return far less.
+			if n := len(got); n <= maxPathComponentBytes-len(unit) {
+				t.Errorf("component = %d bytes, truncated more than one rune below the %d-byte budget", n, maxPathComponentBytes)
+			}
+			// Every rune must be whole: the string is a clean repeat of unit.
+			if want := strings.Repeat(unit, utf8.RuneCountInString(got)); got != want {
+				t.Errorf("truncation split a rune: got %q", got)
+			}
+		})
 	}
-	if n := utf8.RuneCountInString(got); n != maxPathComponentLen {
-		t.Errorf("rune count = %d, want %d", n, maxPathComponentLen)
+}
+
+// TestSanitizePath_ComponentIsCreatableOnDisk is the test the string-length
+// assertions could never be: it actually calls os.Create with the sanitised
+// name plus a realistic extension. The #1982 failure was ENAMETOOLONG
+// (errno 36) from the kernel, which no RuneCountInString check can observe —
+// the old tests passed on exactly the inputs that could not be written.
+func TestSanitizePath_ComponentIsCreatableOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string]string{
+		"ascii":          "x",
+		"accented latin": "é",
+		"cyrillic":       "Достоевский",
+		"greek":          "Ω",
+		"cjk":            "転",
+		"hangul":         "한",
+		"emoji":          "📚",
+	}
+	// The longest extension the importer appends, plus the widest uniqueness
+	// suffix UniqueDir can add — the value is only ever part of a real name.
+	const suffix = " (999).epub"
+	for name, unit := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := sanitizePath(strings.Repeat(unit, 500))
+			f, err := os.Create(filepath.Join(dir, got+suffix)) // #nosec G304 -- test-local temp dir
+			if err != nil {
+				t.Fatalf("os.Create with sanitised component (%d bytes + %d-byte suffix): %v",
+					len(got), len(suffix), err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+		})
+	}
+}
+
+// TestSanitizePath_DirectoryComponentIsCreatableOnDisk covers the other half of
+// the import: the destination folder, which is a component in its own right.
+func TestSanitizePath_DirectoryComponentIsCreatableOnDisk(t *testing.T) {
+	root := t.TempDir()
+	author := sanitizePath(strings.Repeat("転", 500))
+	title := sanitizePath(strings.Repeat("Достоевский", 100))
+	dst := filepath.Join(root, author, title)
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		t.Fatalf("MkdirAll(%d-byte author / %d-byte title): %v", len(author), len(title), err)
+	}
+	f, err := os.Create(filepath.Join(dst, title+".m4b")) // #nosec G304 -- test-local temp dir
+	if err != nil {
+		t.Fatalf("os.Create inside deep non-ASCII path: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`sanitizePath` capped each sanitised template value at 200 **runes**. `NAME_MAX` is measured in **bytes** — 255 on ext4, XFS, btrfs and APFS — so for any non-ASCII title the cap permitted a component the filesystem then rejected, which is precisely the failure the cap exists to prevent. Imports died with `ENAMETOOLONG` at roughly 83 CJK characters or 125 Cyrillic. ASCII never tripped it, which is why it went unnoticed.

The cap is now a byte budget, truncated on a rune boundary. Closes #1982.

## Why 200 bytes and not 255

`sanitizePath` does not sanitise a finished filename. It sanitises **one template value** — `{Title}`, `{Author}`, `{Series}`, `{SeriesNumber}`, `{Genre}`, `{Lang}`, `{ASIN}`, `{SortAuthor}` (`renamer.go:232-240`) — which is then substituted into a user-configurable naming template alongside literal glue, before an extension and any `" (2)"` uniqueness suffix are appended. A value capped at exactly `NAME_MAX` overflows the moment it becomes part of a real name; the issue's own measurements show 85 CJK runes = 255 bytes failing at 260 once `.epub` is added.

200 bytes has a second virtue: **for ASCII it is byte-for-byte identical to the old 200-rune cap** (200 runes == 200 bytes), so no existing library's paths change and there is nothing to re-baseline. Only non-ASCII values get shorter, and those currently produce paths that do not work at all.

## What changed in the two existing tests

Both `TestSanitizePath_CapsComponentLength` and `TestSanitizePath_CapIsRuneSafe` asserted `utf8.RuneCountInString(got) == maxPathComponentLen`. That assertion *is* the defect — it is the statement "a component may be 200 characters regardless of how many bytes that is". They passed on exactly the inputs that could not be written to disk, so the fix had to rewrite them rather than satisfy them.

| Test | Before | After |
|---|---|---|
| `CapsComponentLength` | ASCII input, `RuneCount(got) == 200` | ASCII input, `len(got) == 200` **bytes**, plus `RuneCount(got) == 200` retained *as the no-paths-move guarantee* — for ASCII the two must agree, and that equality is what pins the promise that existing libraries do not get re-baselined |
| `CapIsRuneSafe` | one 2-byte rune (`é`), `ValidString(got)` **and** `RuneCount(got) == 200` | table over 2-, 3- and 4-byte scripts (`é`, `щ`, `転`, `📚`). Keeps `ValidString`, keeps the never-split-a-character guarantee and strengthens it (the result must equal a clean `strings.Repeat(unit, n)`), and replaces the rune equality with `len(got) <= 200` bytes plus a floor of `> 200 - len(unit)` so "truncated on a boundary" can't quietly become "truncated to nothing" |

The half that was always right — truncation must not split a character mid-encoding — survives and is now checked on wider runes than `é`.

## The on-disk tests

Two new tests do what no string-length assertion can:

- `TestSanitizePath_ComponentIsCreatableOnDisk` — `os.Create` under `t.TempDir()` on the sanitised value plus `" (999).epub"` (the widest `UniqueDir` suffix and a real extension), across ASCII, accented Latin, Cyrillic, Greek, CJK, Hangul and emoji.
- `TestSanitizePath_DirectoryComponentIsCreatableOnDisk` — `os.MkdirAll` for a CJK author dir containing a Cyrillic title dir, then a file inside it.

The #1982 failure was `ENAMETOOLONG` (errno 36) from the kernel. `utf8.RuneCountInString` cannot observe it; the old tests are the proof, since they were green throughout. Reverting `truncateUTF8` to the rune slice makes both new tests fail with a literal `file name too long`, alongside the byte-budget assertions.

## Mutation proof

Per house style, the regression tests were proven against a deliberate reintroduction of the bug (`string([]rune(p)[:200])`):

```
--- FAIL: TestSanitizePath_CapIsRuneSafe/cjk        component = 600 bytes, want <= 200
--- FAIL: TestSanitizePath_ComponentIsCreatableOnDisk/cjk
    os.Create with sanitised component (600 bytes + 11-byte suffix): ... file name too long
--- FAIL: TestSanitizePath_DirectoryComponentIsCreatableOnDisk
    MkdirAll(600-byte author / 400-byte title): ... file name too long
```

`TestSanitizePath_CapsComponentLength` (ASCII) stays green under the mutation, which is exactly right — it exists to pin that ASCII does not move.

## Callers audited

Every path component the importer builds from metadata goes through `sanitizePath`, so the fix covers them all in one place:

| Path | Route | Capped? |
|---|---|---|
| Ebook dest (`DestPath`) | `apply` → `sanitizePath` per token | yes |
| Audiobook folder (`AudiobookDestDir`) | `apply` → `sanitizePath` | yes |
| **Audiobook per-track names** (`AudiobookFileName`) | `applyWithExtra` → `sanitizePath`, then `filepath.Base` | yes — same cap |
| Drop-folder flat names (`DropEbookName`, `DropAudiobookName`) | `apply` → `sanitizePath` | yes |
| Template default text (`{Genre:Unsorted}`) | `sanitizePath(mod)` at `renamer.go:348` | yes |

Multi-part audiobooks specifically: `scanner.go` builds the per-track namer from `Renamer.AudiobookFileName` and hands it to `flattenAudiobookDirNamed`, so tracks go through the same token cap as everything else. The non-templated audiobook paths (`MoveDirCtx`/`CopyDirCtx`/`HardlinkDir` wholesale folder moves, sidecar carry-over, `Part %03d` fallback) reuse the *source* basenames verbatim, which are already bounded by the source filesystem — this change neither helps nor hurts them.

No other rune-based truncation of a path component exists. `internal/api/backup.go` slices `out[:maxBackupLabelLen]` by bytes, but `sanitizeBackupLabel` reduces the charset to `[A-Za-z0-9_-]` first, so every remaining byte is ASCII — correct as written.

`pathmap` (`internal/pathmap/remap.go`) is length-agnostic: `Apply`/`ApplyInverse` are pure prefix rewrites with no truncation and no length assumptions, and they operate on download-client paths, not importer-generated names. `book_files.path` is `TEXT NOT NULL UNIQUE` (`028_book_files.sql`) — SQLite `TEXT` has no length limit, so storage is not at risk.

## Deliberately left alone (worth follow-ups)

**1. The composed segment is still uncapped — and this one already fails for pure ASCII.** `sanitizePath` caps a *value*; nothing re-checks the assembled component. The **default** template `{Title} - {Author}.{ext}` with a 200-byte title and a 200-byte author produces a 408-byte leaf. Verified on this branch:

```
ASCII leaf = 408 bytes
CREATE FAILED: open /tmp/.../TTT... - AAA....epub: file name too long
```

This is a pre-existing bug independent of #1982 (it does not involve non-ASCII at all) and fixing it is not a one-liner: a naive cap on `renderSegment`'s output would chop the extension off the end, which is worse than the error. It needs extension- and suffix-aware reservation. Related uncapped composition points: `stagingPath` prepends ~34 bytes (`.bindery-stage-<nanos>-`) to the full basename, so a legal 230-byte destination fails during *staging* even though the final name would fit; `UniqueDir` / `uniqueDirExcluding` add `" (N)"` without reserving for it; `sanitizeInline` (conditional-group literals) does not cap at all; and `{ext}`/`{Part}` are substituted raw at `renamer.go:241` and `renamer.go:172` (`ext` comes from the downloaded file's own name — bounded by the source filesystem, so not a traversal or unbounded-length vector, but it does push the composed name up). Happy to file this as its own issue.

**2. Byte truncation raises the collision rate for non-ASCII titles.** Cutting CJK at 200 bytes keeps ~66 characters where the old cap kept 200, so two long, similar CJK titles collapse to the same component more often. Audiobook folders absorb that via `UniqueDir`; ebook filenames are deliberately deterministic with no `UniqueDir` (`scanner.go:1068-1071`), so a collision lands on the `book_files.path` UNIQUE index — swallowed by `INSERT OR IGNORE`, surfaced by `UpdatePath`, and already anticipated by reorganize's `PathOwnedByOtherBook` → `ReorgStatusCollision`. Not made *worse* in any practical sense by this PR, since the alternative for those titles today is a hard import failure, but it is a real trade and should be tracked if disambiguating suffixes are ever added.

**3. The TS preview mirror.** `web/src/pages/settings/namingTemplate.ts` re-implements `sanitizePath` client-side and **has never implemented the length cap at all** (nor the control-character strip), so it was already divergent before this PR and is no more divergent after. It only ever runs against the canned short `SAMPLE_BOOK`, and neither drift guard (`TestRenamerPreviewSampleDriftGuard`, `TestSanitizePathPreviewDriftGuard`) exercises a long value. Mirroring a byte cap in TS is non-trivial — `String.prototype.slice` counts UTF-16 code units, so a naive `p.slice(0, 200)` reproduces neither the byte cap nor a rune cap. Left for a follow-up rather than bolted on here.

**4. Windows.** Orthogonal, not helped in any load-bearing way. Windows caps the *full path* at 260 by default rather than the component, so a per-component byte budget does not address it. NTFS's own limit is 255 UTF-16 code units, which the 200-byte budget always satisfies (200 UTF-8 bytes is at most 200 code units), so this change is safe there — it just isn't the Windows fix. APFS is 255 bytes like ext4 and is fully covered.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no env vars, config, flags, Helm values or user-facing docs touched; the changed symbols are unexported and carry updated godoc explaining the byte budget
- [x] Wiki pages updated if user-facing behaviour changed — n/a
- [x] `changelog.d/` fragment added (leads with the symptom)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./cmd/... ./internal/...`
- [x] `go test -race -timeout 1800s ./internal/importer/`
- [x] Regression tests proven against a deliberate mutation (see above)
- [ ] `cd web && npm ...` — not run; no frontend file is touched by this PR

**Environment note, stated honestly:** `internal/api` and `internal/importer` under `-race` exceed the default per-package timeout on this machine even on unmodified `main`, so `make check` as a single invocation is not a reliable signal here. Those two packages were verified individually with `-timeout 1800s`; CI's sharding is the authority.
