### PR TITLE
docs: record third-party data terms for Hardcover, OpenLibrary and Audible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,4 +108,5 @@ Non-Claude agents that can't auto-load `SKILL.md` files should read the bodies u
 - Deployment / env vars / upgrade path: [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)
 - Roadmap and out-of-scope list: [docs/ROADMAP.md](docs/ROADMAP.md)
 - Auth modes (multiuser / OIDC / proxy): [docs/multi-user.md](docs/multi-user.md), [docs/auth-oidc.md](docs/auth-oidc.md), [docs/auth-proxy.md](docs/auth-proxy.md)
+- Third-party data terms (Hardcover, OpenLibrary, Audible): [docs/third-party-data.md](docs/third-party-data.md)
 - Vulnerability disclosure: [SECURITY.md](SECURITY.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,8 @@ Bindery is **MIT** and statically links its Go dependencies, so every module bec
 - Permissive (MIT, BSD, Apache-2.0, ISC, MPL-2.0) is fine. Apache-2.0 additionally requires shipping the dependency's `NOTICE`.
 - `THIRD_PARTY_LICENSES.md` is generated and **CI fails on drift** — regenerate it when dependencies change instead of editing it by hand.
 
+Dependency licences constrain what the binary may **link**. A separate question is what a deployment may **do with the data** Bindery fetches at runtime — Hardcover, for one, excludes aggregated user ratings from commercial use. That is recorded in [docs/third-party-data.md](docs/third-party-data.md).
+
 The trap worth knowing about: the *arr projects are GPL-3.0, so their dependency choices are safe for them and not for us. `github.com/creditx/go-fuzzywuzzy` (GPL-3.0) reached shipped MIT binaries this way, and the obvious alternative port carries the same licence.
 
 ### Credentials & secrets

--- a/docs/third-party-data.md
+++ b/docs/third-party-data.md
@@ -41,10 +41,12 @@ fine. The setting that controls the sync cadence is `hardcover.sync_interval`.
 
 **Cover images must be self-hosted.** The API Rules permit hot-linking
 Hardcover's images from a personal project but prohibit it for a professional
-one: "download those images and host them on your own." Bindery's web UI already
-does this by routing every cover through `/api/v1/images`, which fetches once
-and caches to `<dataDir>/image-cache/`. The OPDS feed does **not** yet do it and
-still emits Hardcover URLs directly to reading apps.
+one: "download those images and host them on your own." Bindery does this on
+both surfaces: the web UI routes covers through `/api/v1/images` and the OPDS
+feed through `/opds/images`, which are the same handler and the same
+`<dataDir>/image-cache/`. Reading apps and browsers alike fetch covers from
+your instance, and Hardcover is contacted once per cover per 30-day cache
+entry.
 
 > The Hardcover Terms of Service page is unedited template boilerplate whose
 > governing-law, arbitration, and liability clauses are literal blanks, and

--- a/docs/third-party-data.md
+++ b/docs/third-party-data.md
@@ -1,0 +1,66 @@
+# Third-party data terms
+
+Bindery pulls metadata from several public APIs and stores it in your SQLite
+database. This page records the usage terms that constrain what a *deployment*
+may do with that data, as distinct from
+[dependency licences](../CONTRIBUTING.md#dependency-licences), which constrain
+what the *binary* may link.
+
+Nothing here restricts ordinary self-hosted use. It matters if you run Bindery
+as part of something you charge for, incorporate, or run ads against.
+
+## Hardcover
+
+Source: <https://hardcover.app/pages/policies> (section "API Rules"), plus the
+rate limits in <https://docs.hardcover.app/api/getting-started/>. Reviewed
+2026-08-14.
+
+Hardcover asserts no new copyright over the database material and states that
+it carries "the same licensing as OpenLibrary". There is **no attribution
+requirement**, no retention limit, and no expiry clause, so caching Hardcover
+responses in the local database indefinitely is fine. Bindery's list sync runs
+every 1 to 168 hours, well inside the documented 60 requests per minute.
+
+The API Rules draw one line that matters, between a *personal project* and a
+*professional* one (charged for, incorporated, or ad-supported):
+
+- **Personal projects** may use any data from the API.
+- **Professional projects** may use only your own personal data and *facts*
+  about books, editions, and series. Other users' reviews, ratings, lists, and
+  user-generated content are excluded.
+
+Two consequences for anyone running Bindery professionally:
+
+**Aggregated ratings must be excluded.** `books.average_rating` and
+`books.ratings_count` are populated from Hardcover by
+`internal/hardcoverlistsyncer` and are aggregates of other users' ratings, not
+facts about the book. Strip them from any commercial deployment: don't display
+them, don't serve them over the API, and don't re-sync them. Title, author,
+series, edition, publisher, narrator, description, and cover are facts and are
+fine. The setting that controls the sync cadence is `hardcover.sync_interval`.
+
+**Cover images must be self-hosted.** The API Rules permit hot-linking
+Hardcover's images from a personal project but prohibit it for a professional
+one: "download those images and host them on your own." Bindery's web UI already
+does this by routing every cover through `/api/v1/images`, which fetches once
+and caches to `<dataDir>/image-cache/`. The OPDS feed does **not** yet do it and
+still emits Hardcover URLs directly to reading apps.
+
+> The Hardcover Terms of Service page is unedited template boilerplate whose
+> governing-law, arbitration, and liability clauses are literal blanks, and
+> whose §5 read literally would prohibit the API use its own documentation
+> describes. The API Rules section of the policies page is the operative
+> document.
+
+## OpenLibrary
+
+Public domain catalogue data (CC0). Cover images come from
+`covers.openlibrary.org` and are subject to their rate limits; Bindery serves
+them through the same `/api/v1/images` cache.
+
+## Audible
+
+`internal/metadata/audible` calls an unpublished Amazon endpoint, and Amazon's
+Conditions of Use prohibit unauthorised automated access. This is unresolved and
+tracked in [#2015](https://github.com/vavallee/bindery/issues/2015), which
+proposes an operator opt-out.


### PR DESCRIPTION
## What

Adds `docs/third-party-data.md`, recording the runtime *data* terms of the metadata sources, as distinct from the dependency *licence* rules already in CONTRIBUTING.

Source for the Hardcover section: the "API Rules" section of https://hardcover.app/pages/policies, plus the rate limits in the API docs. Reviewed 2026-08-14.

## Why

The licensing sweep answered "what may the binary link". It did not answer "what may a deployment do with the data we fetch". Hardcover's API Rules do answer that, and they draw a line at commercial use:

* **Attribution is not required.** Hardcover asserts no new copyright and states OpenLibrary-equivalent licensing. No retention limit either, so the indefinite SQLite cache is fine.
* **A professional deployment may use facts about books but not other users' UGC.** `books.average_rating` and `books.ratings_count` come from Hardcover and are aggregated user ratings, so they have to be excluded from any commercial deployment. That is the thing an operator cannot work out from the code, hence writing it down.
* **Cover images must be self-hosted professionally.** The web UI already complies via `/api/v1/images`. The OPDS feed does not, and that gets its own issue.

## Notes

* No code change. Nothing here restricts ordinary self-hosted use.
* The Hardcover ToS page is unedited template boilerplate (blank governing law, blank arbitration seat, and a §5 that read literally would prohibit the API use its own docs describe). The doc says so, and treats the API Rules section as operative.
* Pointer added from CONTRIBUTING §Dependency licences and the AGENTS.md reference list.