### PR TITLE
feat(web): make the pager ellipsis a page-jump dropdown (#2010)

### DIFF
--- a/changelog.d/2010-page-jump-dropdown.md
+++ b/changelog.d/2010-page-jump-dropdown.md
@@ -1,0 +1,5 @@
+**Jump straight to a page in long lists.** The `…` in the pager was inert, so
+reaching page 30 of a 40-page Books or Authors list meant clicking Next thirty
+times. Each `…` is now a dropdown listing exactly the pages it hides, so any
+page is one click away. Every paginated screen shares the component, so Wanted,
+History, Queue, Blocklist and the Logs tab get it too. (#2010)

--- a/web/src/components/Pagination.test.tsx
+++ b/web/src/components/Pagination.test.tsx
@@ -4,7 +4,12 @@ import Pagination from './Pagination'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => ({ 'pagination.previous': 'Previous', 'pagination.next': 'Next' }[key] ?? key),
+    t: (key: string) => ({
+      'pagination.previous': 'Previous',
+      'pagination.next': 'Next',
+      'pagination.jumpToPage': 'Jump to page',
+      'pagination.perPage': 'Per page',
+    }[key] ?? key),
   }),
 }))
 
@@ -80,15 +85,45 @@ describe('Pagination', () => {
     expect(onPageChange).toHaveBeenCalledWith(5)
   })
 
-  it('shows ellipsis when totalPages > 7 and page is in the middle', () => {
+  it('shows a jump dropdown on each side when totalPages > 7 and page is in the middle', () => {
     render(<Pagination {...defaults} page={5} totalPages={10} />)
-    const ellipses = screen.getAllByText('…')
-    expect(ellipses.length).toBe(2) // one before, one after
+    const gaps = screen.getAllByRole('combobox', { name: 'Jump to page' })
+    expect(gaps.length).toBe(2) // one before, one after
+    expect(gaps[0].querySelector('option')?.textContent).toBe('…')
   })
 
-  it('shows no ellipsis when totalPages <= 7', () => {
+  // #2010: the gap used to be a dead "…", so reaching page 3 of 40 meant
+  // stepping through Next one page at a time. Each gap now lists exactly the
+  // pages it hides — the left one covers 2..(page-2), the right one
+  // (page+2)..(totalPages-1).
+  it('lists every hidden page in the gap it belongs to', () => {
+    render(<Pagination {...defaults} page={10} totalPages={40} />)
+    const [left, right] = screen.getAllByRole('combobox', { name: 'Jump to page' })
+    const values = (el: HTMLElement) =>
+      Array.from(el.querySelectorAll('option')).map(o => o.value).filter(Boolean).map(Number)
+    expect(values(left)).toEqual([2, 3, 4, 5, 6, 7, 8])
+    expect(values(right)).toEqual(Array.from({ length: 28 }, (_, i) => i + 12))
+  })
+
+  it('calls onPageChange with the page picked from a gap dropdown', () => {
+    const onPageChange = vi.fn()
+    render(<Pagination {...defaults} page={10} totalPages={40} onPageChange={onPageChange} />)
+    const [, right] = screen.getAllByRole('combobox', { name: 'Jump to page' })
+    fireEvent.change(right, { target: { value: '27' } })
+    expect(onPageChange).toHaveBeenCalledWith(27)
+  })
+
+  it('ignores the placeholder option without changing page', () => {
+    const onPageChange = vi.fn()
+    render(<Pagination {...defaults} page={10} totalPages={40} onPageChange={onPageChange} />)
+    const [left] = screen.getAllByRole('combobox', { name: 'Jump to page' })
+    fireEvent.change(left, { target: { value: '' } })
+    expect(onPageChange).not.toHaveBeenCalled()
+  })
+
+  it('shows no gap dropdown when totalPages <= 7', () => {
     render(<Pagination {...defaults} page={4} totalPages={7} />)
-    expect(screen.queryByText('…')).toBeNull()
+    expect(screen.queryByRole('combobox', { name: 'Jump to page' })).toBeNull()
     // All 7 page buttons present
     for (let i = 1; i <= 7; i++) {
       expect(screen.getByRole('button', { name: String(i) })).toBeInTheDocument()
@@ -98,13 +133,13 @@ describe('Pagination', () => {
   it('calls onPageSizeChange when page size selector changes', () => {
     const onPageSizeChange = vi.fn()
     render(<Pagination {...defaults} onPageSizeChange={onPageSizeChange} />)
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: '50' } })
+    fireEvent.change(screen.getByRole('combobox', { name: 'Per page' }), { target: { value: '50' } })
     expect(onPageSizeChange).toHaveBeenCalledWith(50)
   })
 
   it('renders custom pageSizeOptions', () => {
     render(<Pagination {...defaults} pageSizeOptions={[10, 20, 30]} />)
-    const select = screen.getByRole('combobox')
+    const select = screen.getByRole('combobox', { name: 'Per page' })
     const options = Array.from(select.querySelectorAll('option')).map(o => o.value)
     expect(options).toEqual(['10', '20', '30'])
   })

--- a/web/src/components/Pagination.tsx
+++ b/web/src/components/Pagination.tsx
@@ -21,23 +21,30 @@ export default function Pagination({
   const start = (page - 1) * pageSize + 1
   const end = Math.min(page * pageSize, totalItems)
 
-  // Compute visible page numbers (with ellipsis for large ranges)
-  const pages: (number | 'ellipsis')[] = []
+  // Compute visible page numbers. Large ranges collapse into gaps, each of
+  // which renders as a dropdown of the pages it hides (#2010) rather than a
+  // dead "…" that forces you to step through one page at a time.
+  type Gap = { gapFrom: number; gapTo: number }
+  const pages: (number | Gap)[] = []
   if (totalPages <= 7) {
     for (let i = 1; i <= totalPages; i++) pages.push(i)
   } else {
     pages.push(1)
-    if (page > 3) pages.push('ellipsis')
     const startP = Math.max(2, page - 1)
     const endP = Math.min(totalPages - 1, page + 1)
+    if (page > 3) pages.push({ gapFrom: 2, gapTo: startP - 1 })
     for (let i = startP; i <= endP; i++) pages.push(i)
-    if (page < totalPages - 2) pages.push('ellipsis')
+    if (page < totalPages - 2) pages.push({ gapFrom: endP + 1, gapTo: totalPages - 1 })
     pages.push(totalPages)
   }
 
   const btnBase = 'px-2.5 py-1 rounded text-xs font-medium transition-colors'
   const btn = `${btnBase} text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-not-allowed`
   const btnActive = `${btnBase} bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white`
+  const selectBase = 'bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-2 py-1 text-xs text-slate-800 dark:text-zinc-200 focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
+  // The gap select is styled to read as the "…" it replaces: no chrome until
+  // you hover or focus it, at which point it is visibly a control.
+  const gapSelect = `${btnBase} appearance-none cursor-pointer bg-transparent text-center text-slate-500 dark:text-zinc-600 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-zinc-800 focus:outline-none focus:ring-1 focus:ring-slate-400 dark:focus:ring-zinc-600`
 
   return (
     <div className="flex flex-col items-center gap-3 mt-6 pt-4 border-t border-slate-200 dark:border-zinc-800 sm:flex-row sm:justify-between">
@@ -48,8 +55,22 @@ export default function Pagination({
         <button onClick={() => onPageChange(1)} disabled={page === 1} className={btn}>«</button>
         <button onClick={() => onPageChange(page - 1)} disabled={page === 1} className={btn}>‹ {t('pagination.previous')}</button>
         {pages.map((p, i) =>
-          p === 'ellipsis' ? (
-            <span key={`e${i}`} className="px-1 text-xs text-slate-500 dark:text-zinc-600">…</span>
+          typeof p === 'object' ? (
+            <select
+              key={`gap${i}`}
+              aria-label={t('pagination.jumpToPage')}
+              value=""
+              onChange={e => {
+                const target = Number(e.target.value)
+                if (target) onPageChange(target)
+              }}
+              className={gapSelect}
+            >
+              <option value="">…</option>
+              {Array.from({ length: p.gapTo - p.gapFrom + 1 }, (_, n) => p.gapFrom + n).map(n => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
           ) : (
             <button key={p} onClick={() => onPageChange(p)} className={p === page ? btnActive : btn}>
               {p}
@@ -60,11 +81,12 @@ export default function Pagination({
         <button onClick={() => onPageChange(totalPages)} disabled={page === totalPages} className={btn}>»</button>
       </div>
       <div className="flex items-center gap-2">
-        <span className="text-xs text-slate-600 dark:text-zinc-500">Per page:</span>
+        <span className="text-xs text-slate-600 dark:text-zinc-500">{t('pagination.perPage')}:</span>
         <select
+          aria-label={t('pagination.perPage')}
           value={pageSize}
           onChange={e => onPageSizeChange(Number(e.target.value))}
-          className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-2 py-1 text-xs text-slate-800 dark:text-zinc-200 focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+          className={selectBase}
         >
           {pageSizeOptions.map(n => (
             <option key={n} value={n}>{n}</option>

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -486,7 +486,9 @@
   "pagination": {
     "previous": "Zurück",
     "next": "Weiter",
-    "pageOf": "Seite {{page}} von {{total}}"
+    "pageOf": "Seite {{page}} von {{total}}",
+    "jumpToPage": "Zu Seite springen",
+    "perPage": "Pro Seite"
   },
   "bulkActionBar": {
     "selected": "{{count}} ausgewählt",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -841,7 +841,7 @@
       "hardcoverNotSelected": "Not selected",
       "hardcoverBooksCount": "{{count}} books",
       "hardcoverSyncNow": "Sync now",
-      "hardcoverSyncing": "Syncing...",
+      "hardcoverSyncing": "Syncing…",
       "hardcoverTokenOverride": "Token override",
       "hardcoverMediaType": "Media type",
       "hardcoverMediaTypeHint": "Format synced books are created as. Auto uses what Hardcover reports.",
@@ -862,8 +862,6 @@
       "hardcoverEmpty": "No Hardcover import lists configured.",
       "hardcoverLastSync": "Last sync: {{date}}",
       "hardcoverNeverSynced": "Never synced",
-      "hardcoverSyncNow": "Sync now",
-      "hardcoverSyncing": "Syncing…",
       "hardcoverSyncFailed": "Sync failed",
       "hardcoverSyncDone": "Sync finished — {{imported}} imported, {{skipped}} already tracked, {{failed}} failed",
       "manualImportHeading": "Manual file import",
@@ -1013,7 +1011,9 @@
   "pagination": {
     "previous": "Previous",
     "next": "Next",
-    "pageOf": "Page {{page}} of {{total}}"
+    "pageOf": "Page {{page}} of {{total}}",
+    "jumpToPage": "Jump to page",
+    "perPage": "Per page"
   },
   "bulkActionBar": {
     "selected": "{{count}} selected",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -529,7 +529,9 @@
   "pagination": {
     "previous": "Anterior",
     "next": "Siguiente",
-    "pageOf": "Página {{page}} de {{total}}"
+    "pageOf": "Página {{page}} de {{total}}",
+    "jumpToPage": "Ir a la página",
+    "perPage": "Por página"
   },
   "bulkActionBar": {
     "selected": "{{count}} seleccionado(s)",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -486,7 +486,9 @@
   "pagination": {
     "previous": "Précédent",
     "next": "Suivant",
-    "pageOf": "Page {{page}} sur {{total}}"
+    "pageOf": "Page {{page}} sur {{total}}",
+    "jumpToPage": "Aller à la page",
+    "perPage": "Par page"
   },
   "bulkActionBar": {
     "selected": "{{count}} sélectionné(s)",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -529,7 +529,9 @@
   "pagination": {
     "previous": "Sebelumnya",
     "next": "Berikutnya",
-    "pageOf": "Halaman {{page}} dari {{total}}"
+    "pageOf": "Halaman {{page}} dari {{total}}",
+    "jumpToPage": "Lompat ke halaman",
+    "perPage": "Per halaman"
   },
   "bulkActionBar": {
     "selected": "{{count}} dipilih",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -810,7 +810,9 @@
   "pagination": {
     "previous": "이전",
     "next": "다음",
-    "pageOf": "{{total}}페이지 중 {{page}}"
+    "pageOf": "{{total}}페이지 중 {{page}}",
+    "jumpToPage": "페이지로 이동",
+    "perPage": "페이지당"
   },
   "bulkActionBar": {
     "selected": "{{count}}개 선택됨",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -486,7 +486,9 @@
   "pagination": {
     "previous": "Vorige",
     "next": "Volgende",
-    "pageOf": "Pagina {{page}} van {{total}}"
+    "pageOf": "Pagina {{page}} van {{total}}",
+    "jumpToPage": "Ga naar pagina",
+    "perPage": "Per pagina"
   },
   "bulkActionBar": {
     "selected": "{{count}} geselecteerd",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -529,7 +529,9 @@
   "pagination": {
     "previous": "Nakaraan",
     "next": "Susunod",
-    "pageOf": "Pahina {{page}} ng {{total}}"
+    "pageOf": "Pahina {{page}} ng {{total}}",
+    "jumpToPage": "Pumunta sa pahina",
+    "perPage": "Bawat pahina"
   },
   "bulkActionBar": {
     "selected": "{{count}} napili",


### PR DESCRIPTION
Closes #2010.

## Problem

The `…` in the pager was a plain `<span>` with no behaviour. On a long Books or Authors list the only way to reach page 30 of 40 was clicking Next twenty-seven times, since the pager only ever exposes the first page, the last page, and the two either side of where you are.

## Change

Each collapsed range now carries the pages it hides and renders as a `<select>` listing exactly those pages:

* left gap covers `2..(page-2)`
* right gap covers `(page+2)..(totalPages-1)`

Picking one calls `onPageChange` directly. The placeholder option still reads `…` and the control has no chrome until hover or focus, so the pager looks the same until you use it.

`Pagination.tsx` is shared, so this lands on Wanted, History, Queue, Blocklist and the Logs tab as well as the two pages in the report.

## Also in the diff

* Both selects get an `aria-label`. Without it there is no way for a screen reader or a test to tell the three comboboxes apart.
* The visible `Per page:` label was hardcoded English; it now goes through `useTranslation` like everything else in the component. `pagination.jumpToPage` and `pagination.perPage` added to all eight locales.
* `en.json` had duplicate `hardcoverSyncNow` / `hardcoverSyncing` keys in one object. Rewriting the file dropped the earlier pair. No behaviour change, since `JSON.parse` already kept the later value.

## Not in scope

The reporter also mentioned losing list position when using the browser back button during an author merge. That is a routing-state problem rather than a pagination one and wants its own issue.

## Testing

`vitest run` green, 579 tests across 61 files. Four new cases in `Pagination.test.tsx`: gap contents on both sides, jumping from a gap, the placeholder being a no-op, and no gap select below the eight-page threshold. `tsc --noEmit` and `eslint` clean.

Not verified in a browser; the select styling is asserted only through class names.