### PR TITLE
fix(opds): serve cover images from the local cache instead of hot-linking

### DIFF
--- a/changelog.d/opds-cover-selfhost.md
+++ b/changelog.d/opds-cover-selfhost.md
@@ -1,0 +1,8 @@
+**OPDS reading apps now fetch covers from Bindery, not from the metadata
+provider.** The catalogue feed emitted the provider's own image URL, so every
+KOReader or Moon+ Reader client hot-linked Hardcover's CDN directly, once per
+client, with none of the local caching the web UI has had since v1.5. Covers
+now come from `/opds/images`, the same handler and the same
+`<dataDir>/image-cache/` the browser uses, which is also what Hardcover's API
+rules require of any deployment that isn't a personal one. See
+`docs/third-party-data.md`.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -1087,11 +1087,22 @@ func main() {
 	// OPDS 1.2 catalogue — KOReader / Moon+ Reader / Aldiko speak this
 	// natively. Sits on its own auth path (Basic + API key + session) so
 	// headless reading devices don't need cookies.
-	opdsBuilder := opds.NewBuilder(opds.Config{Title: "Bindery", PageSize: 50}, bookRepo, authorRepo, seriesRepo)
+	opdsBuilder := opds.NewBuilder(opds.Config{
+		Title:    "Bindery",
+		PageSize: 50,
+		// Serve covers from this instance rather than hot-linking the
+		// metadata provider's CDN — see api.OPDSImageURL and
+		// docs/third-party-data.md.
+		CoverURL: api.OPDSImageURL,
+	}, bookRepo, authorRepo, seriesRepo)
 	opdsHandler := api.NewOPDSHandler(opdsBuilder, bookRepo, fileHandler)
 	r.Route("/opds", func(r chi.Router) {
 		r.Use(api.OPDSAuth(authProvider, userRepo, loginLimiter))
 		r.Get("/", opdsHandler.Root)
+		// Cover images, same handler and same <dataDir>/image-cache as
+		// /api/v1/images. Mounted here so it inherits OPDSAuth (Basic), which
+		// is the only credential a reading app has.
+		r.Get("/images", imageProxyHandler.Serve)
 		r.Get("/authors", opdsHandler.Authors)
 		r.Get("/authors/{id}", opdsHandler.Author)
 		r.Get("/series", opdsHandler.Series)

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -312,6 +312,24 @@ func ProxyImageURL(raw string) string {
 	return imageProxyBase + "/api/v1/images?url=" + url.QueryEscape(raw)
 }
 
+// OPDSImageURL is ProxyImageURL for the OPDS catalogue: same handler, same
+// on-disk cache, different mount point.
+//
+// The feed cannot use /api/v1/images. That route sits behind auth.Middleware,
+// which accepts a session cookie or the global API key but not HTTP Basic —
+// and Basic is how reading apps authenticate. Pointing the feed at it would
+// 401 every KOReader on a password-protected install, and the workaround
+// (embedding ?apikey= in every cover link) would publish an unconditionally
+// admin credential to every device that caches the feed. /opds/images is the
+// same ImageProxyHandler mounted inside the OPDS group so it inherits
+// OPDSAuth instead.
+func OPDSImageURL(raw string) string {
+	if raw == "" || strings.HasPrefix(raw, "/") {
+		return raw
+	}
+	return imageProxyBase + "/opds/images?url=" + url.QueryEscape(raw)
+}
+
 // proxyAuthorImages rewrites ImageURL on an author and all its embedded books.
 // Mutates in place — callers own the struct and it is not shared with the DB layer.
 func proxyAuthorImages(a *models.Author) {

--- a/internal/api/imageproxy_test.go
+++ b/internal/api/imageproxy_test.go
@@ -335,3 +335,37 @@ func TestProxyImageURL(t *testing.T) {
 		}
 	}
 }
+
+// TestOPDSImageURL covers the OPDS variant of the same helper. It must produce
+// the /opds mount rather than /api/v1, because the API route is behind
+// auth.Middleware, which does not accept the HTTP Basic credentials reading
+// apps use.
+func TestOPDSImageURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"/already/relative", "/already/relative"},
+		{"https://assets.hardcover.app/covers/x.png", "/opds/images?url=https%3A%2F%2Fassets.hardcover.app%2Fcovers%2Fx.png"},
+	}
+	for _, tc := range cases {
+		if got := OPDSImageURL(tc.in); got != tc.want {
+			t.Errorf("OPDSImageURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// The URL-base prefix (BINDERY_URL_BASE) applies to OPDS cover links too —
+// #974 was exactly this class of bug for the web UI, where a subpath deploy
+// produced links that resolved above the mount point and 404'd.
+func TestOPDSImageURL_HonoursURLBase(t *testing.T) {
+	SetImageProxyBase("/bindery")
+	t.Cleanup(func() { SetImageProxyBase("") })
+
+	got := OPDSImageURL("https://assets.hardcover.app/covers/x.png")
+	want := "/bindery/opds/images?url=https%3A%2F%2Fassets.hardcover.app%2Fcovers%2Fx.png"
+	if got != want {
+		t.Errorf("OPDSImageURL under /bindery = %q, want %q", got, want)
+	}
+}

--- a/internal/opds/builder.go
+++ b/internal/opds/builder.go
@@ -52,6 +52,18 @@ type Config struct {
 	// PageSize is the number of entries per page on paginated feeds
 	// (authors list, series list). Defaults to 50 when ≤ 0.
 	PageSize int
+	// CoverURL rewrites a book's stored cover URL into the URL the OPDS
+	// client should fetch instead. Bindery caches covers locally and serves
+	// them from /opds/images, so reading apps fetch from this instance rather
+	// than hot-linking the metadata provider's CDN — which Hardcover's API
+	// rules require of any non-personal deployment (docs/third-party-data.md).
+	//
+	// nil leaves cover URLs untouched, which is what the builder's own tests
+	// and any embedder without an HTTP layer want. The link's MIME type is
+	// always derived from the *original* URL, since the rewritten one carries
+	// the file extension in a query parameter where guessImageType can't see
+	// it.
+	CoverURL func(string) string
 }
 
 // Builder assembles OPDS feeds from the three repositories. It has no
@@ -411,9 +423,16 @@ func (b *Builder) bookEntry(base string, bk models.Book, author *models.Author) 
 		}}
 	}
 	if bk.ImageURL != "" {
+		href := bk.ImageURL
+		if b.cfg.CoverURL != nil {
+			href = b.cfg.CoverURL(bk.ImageURL)
+		}
+		// Typed from the stored URL, not from href: the proxied form ends in
+		// /opds/images and hides the real extension inside ?url=.
+		mime := guessImageType(bk.ImageURL)
 		e.Links = append(e.Links,
-			Link{Rel: RelImage, Href: bk.ImageURL, Type: guessImageType(bk.ImageURL)},
-			Link{Rel: RelThumbnail, Href: bk.ImageURL, Type: guessImageType(bk.ImageURL)},
+			Link{Rel: RelImage, Href: href, Type: mime},
+			Link{Rel: RelThumbnail, Href: href, Type: mime},
 		)
 	}
 	if bk.FilePath != "" && bk.Status == models.BookStatusImported {

--- a/internal/opds/builder_test.go
+++ b/internal/opds/builder_test.go
@@ -468,3 +468,84 @@ func mustHaveRel(t *testing.T, links []Link, rel, href string) {
 		t.Errorf("rel=%s href = %q, want %q", rel, l.Href, href)
 	}
 }
+
+// --- cover links ---------------------------------------------------------------
+
+const hardcoverCover = "https://assets.hardcover.app/covers/9781473/xyz.png"
+
+// coverLinks returns the image and thumbnail hrefs of the first entry in the
+// feed for book 11, which the tests below give a remote cover URL.
+func coverLinks(t *testing.T, cfg Config) (image, thumb Link) {
+	t.Helper()
+	books, authors, series := fixture()
+	for i := range books.all {
+		if books.all[i].ID == 11 {
+			books.all[i].ImageURL = hardcoverCover
+		}
+	}
+	b := NewBuilder(cfg, books, authors, series)
+	f, err := b.BuildBook(context.Background(), "http://host:8787", 11, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Entries) != 1 {
+		t.Fatalf("entries = %d", len(f.Entries))
+	}
+	for _, l := range f.Entries[0].Links {
+		switch l.Rel {
+		case RelImage:
+			image = l
+		case RelThumbnail:
+			thumb = l
+		}
+	}
+	if image.Href == "" || thumb.Href == "" {
+		t.Fatalf("no cover links in entry: %+v", f.Entries[0].Links)
+	}
+	return image, thumb
+}
+
+// The feed used to emit the provider's CDN URL directly, so every reading app
+// hot-linked Hardcover. Their API rules require a non-personal deployment to
+// host cover images itself, and Bindery already caches them on disk for the
+// web UI. CoverURL is how the OPDS half reaches that cache.
+func TestBookEntry_CoverURLRewritesBothImageLinks(t *testing.T) {
+	rewrite := func(raw string) string { return "/opds/images?url=" + raw }
+	image, thumb := coverLinks(t, Config{CoverURL: rewrite})
+
+	want := "/opds/images?url=" + hardcoverCover
+	if image.Href != want {
+		t.Errorf("image href = %q, want %q", image.Href, want)
+	}
+	if thumb.Href != want {
+		t.Errorf("thumbnail href = %q, want %q", thumb.Href, want)
+	}
+}
+
+// The MIME type has to come from the stored URL. The rewritten form ends in
+// /opds/images and carries the real extension inside a query parameter, where
+// guessImageType cannot see it — typing off the rewritten URL would report
+// every cover as image/jpeg, including this PNG.
+func TestBookEntry_CoverTypeComesFromTheOriginalURL(t *testing.T) {
+	image, thumb := coverLinks(t, Config{CoverURL: func(string) string { return "/opds/images?url=encoded" }})
+
+	if image.Type != "image/png" {
+		t.Errorf("image type = %q, want image/png", image.Type)
+	}
+	if thumb.Type != "image/png" {
+		t.Errorf("thumbnail type = %q, want image/png", thumb.Type)
+	}
+}
+
+// A nil CoverURL is the zero-value Config, which embedders without an HTTP
+// layer use. It must leave the stored URL alone rather than panicking.
+func TestBookEntry_NilCoverURLLeavesTheStoredURL(t *testing.T) {
+	image, thumb := coverLinks(t, Config{})
+
+	if image.Href != hardcoverCover {
+		t.Errorf("image href = %q, want the stored URL %q", image.Href, hardcoverCover)
+	}
+	if thumb.Href != hardcoverCover {
+		t.Errorf("thumbnail href = %q, want the stored URL %q", thumb.Href, hardcoverCover)
+	}
+}


### PR DESCRIPTION
## What was wrong

`internal/opds/builder.go` put `books.image_url` straight into each entry's image and thumbnail links, so every KOReader, Moon+ Reader or Aldiko client fetched covers from the metadata provider's CDN directly, once per client, forever.

The web UI has not done this since #112. `ProxyImageURL` routes browser covers through `/api/v1/images`, which fetches once, validates, and caches under `<dataDir>/image-cache/` with a 30 day TTL and a 10 MB cap. OPDS was the one surface never wired to it.

## Why it matters beyond caching

Hardcover's API rules (the "API Rules" section of https://hardcover.app/pages/policies) allow hot-linking their images from a personal project and prohibit it for anything charged for, incorporated, or ad-supported: "download those images and host them on your own." A sync fanned out across many self-hosted instances, each serving an unbounded number of reading devices, is also just the shape that turns into a load problem for a small project. Recorded in `docs/third-party-data.md` (#2018).

## Why a second mount and not a URL rewrite

The feed cannot point at `/api/v1/images`. That route sits behind `auth.Middleware`, which accepts a session cookie, the global API key, the local-only bypass, or nothing when auth is disabled. It does not accept HTTP Basic, and Basic is what reading apps send. Every OPDS client on a password-protected install would get 401.

The workaround would be embedding `?apikey=` in every cover link, but the API key is unconditionally admin (`middleware.go:421`), while the OPDS Basic credential is an ordinary user. That writes an admin credential into a feed cached on every reading device.

So the same `ImageProxyHandler` is mounted at `/opds/images`, inside the group that already runs `OPDSAuth`. Same handler, same cache directory, same SSRF guard, redirect revalidation and size cap.

## Diff

* `opds.Config` grows a `CoverURL func(string) string` hook. `internal/api` imports `internal/opds` (`api.NewOPDSHandler` takes the builder), so the dependency cannot run the other way. `nil` leaves URLs untouched, which is what the builder's own tests want.
* `api.OPDSImageURL` produces `<urlbase>/opds/images?url=...`.
* `main.go` mounts the route and passes the hook.

One subtlety worth flagging for review: the link's MIME type is still derived from the **stored** URL. `guessImageType` splits on `?` and reads the extension off the path, and the proxied form's path is `/opds/images` with the real extension inside the query string, so typing off the rewritten URL would report every cover as `image/jpeg`. There is a test pinning this.

## Testing

* `go test ./internal/opds/... ./internal/api/...` green. Three new builder cases (rewrite applied to both links, MIME from the original URL, `nil` hook passes through) and two new `OPDSImageURL` cases including `BINDERY_URL_BASE`, since #974 was this exact class of bug for the web UI.
* `golangci-lint` clean, `gofmt` clean.
* Route wiring lives in `main.go`, which has no test harness and no OPDS coverage in `tests/smoke`, so I verified it against a running binary: `/opds/images` with no `url` returns the handler's own 400, a bogus sibling path returns 404, and a seeded book renders

  ```
  <link rel="http://opds-spec.org/image"
        href="/opds/images?url=https%3A%2F%2Fassets.hardcover.app%2Fcovers%2Fabc.png"
        type="image/png">
  ```

  which also demonstrates the MIME type surviving the rewrite.
* Not verified against a real reading app.