### PR TITLE
docs: document the OPDS cover route and link the data-terms page

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,12 @@ Apache-2.0 dependencies carry, and is included in the release archives and at
 dependency set, so run it in the same PR whenever you add, drop, or bump a
 dependency.
 
+Dependency licences govern what the binary may link. What a deployment may do
+with the *data* Bindery fetches at runtime is a separate question, and
+**[docs/third-party-data.md](docs/third-party-data.md)** records it per source —
+including that a commercial deployment has to exclude the aggregated Hardcover
+ratings. Self-hosting for yourself is unaffected.
+
 ## Disclaimer
 
 Bindery is not affiliated with or endorsed by Readarr, Audible, Amazon, Goodreads, Calibre, or Prowlarr. All trademarks are the property of their respective owners.

--- a/docs/API.md
+++ b/docs/API.md
@@ -238,6 +238,15 @@ Bindery serves an OPDS 1.2 catalogue at `/opds/`:
 - `/opds/series` and `/opds/series/{id}` — by series
 - `/opds/book/{id}` — book entry
 - `/opds/book/{id}/file` — download the book file
+- `/opds/images?url=<encoded>` — cover images, cached locally
+
+Cover links in the feed point at `/opds/images` rather than at the metadata
+provider, so reading apps fetch every cover from your instance. It is the same
+handler and the same `<dataDir>/image-cache/` the web UI uses via
+`/api/v1/images`, mounted a second time inside `/opds` because that route
+requires a session cookie or the API key and reading apps authenticate with
+HTTP Basic. See [third-party-data.md](third-party-data.md) for why covers are
+served this way.
 
 OPDS authenticates via HTTP Basic — any username, API key as the password. KOReader, Moon+ Reader, Aldiko, and other OPDS-capable apps work out of the box.
 


### PR DESCRIPTION
Two gaps found while auditing whether the docs cover what v1.31.0 shipped.

* `docs/API.md` lists the OPDS endpoints but not `/opds/images`, which every cover link in the feed now points at (#2020). Adds it, with a sentence on why it exists as a second mount of the same handler.
* `docs/third-party-data.md` (#2018) was linked only from CONTRIBUTING and AGENTS.md. An operator deciding whether they can run Bindery commercially reads neither. Adds a pointer from the README's licence section.

Everything else in the release was already documented by the PR that shipped it: rTorrent in README/QUICKSTART/DEPLOYMENT, log download and `importBlocked` in Troubleshooting-Wiki, the Hardcover sync interval and background sync in User-Guide-Wiki, dual-format scanning and per-file unmatched reasons in User-Guide-Wiki.