### PR TITLE
fix(importer): don't spend rTorrent retry attempts when the files are absent (#1884)

### DIFF
--- a/changelog.d/1884-rtorrent-readiness.md
+++ b/changelog.d/1884-rtorrent-readiness.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **rTorrent downloads no longer burn their retry budget while the files are
+  absent** (#1884) — every other download client stopped counting a retry
+  attempt against a download whose files are not on this host, but rTorrent's
+  retry branch was added without that guard, so the one client that missed it
+  spent all five attempts on polls that could not have imported anything and
+  then blocked the download terminally. It now waits like the others and
+  imports the moment the files appear.

--- a/internal/importer/scanner_import_readiness_test.go
+++ b/internal/importer/scanner_import_readiness_test.go
@@ -606,3 +606,94 @@ func TestCheckQbittorrentDownloads_ManualRetryResetsTheSkipStreak(t *testing.T) 
 			"after %d polls (%q)", importSkipLimit-1, got.ErrorMessage)
 	}
 }
+
+// TestCheckRtorrentDownloads_MissingPayloadDoesNotExhaustRetries is the
+// rTorrent half of the #1884 readiness rule.
+//
+// Every other poller already refused to spend a retry attempt on a download
+// whose files are not on disk; rTorrent's retry branch was added without the
+// guard, so the one client that missed it burned all five attempts on polls
+// that could not have imported anything, then blocked the download terminally.
+//
+// The shape here is the reporter's: the client is healthy and honest — the
+// torrent is complete and f.multicall enumerates its file — and the file simply
+// is not there.
+func TestCheckRtorrentDownloads_MissingPayloadDoesNotExhaustRetries(t *testing.T) {
+	const (
+		hash     = "7c1d2e3f405162738495a6b7c8d9e0f1a2b3c4d5"
+		guid     = "guid-readiness-rtorrent"
+		fileName = "the-book.epub"
+	)
+	// rtorrentMatrixHandler serves this directory as both base_path and
+	// directory, and enumerates fileName inside it. The directory exists and
+	// stays empty, which is the case the guard is about: a path Bindery can
+	// resolve, with nothing importable at it.
+	directory := t.TempDir()
+
+	f := newDispatchFixture(t)
+	srv := httptest.NewServer(rtorrentMatrixHandler(t, hash, directory))
+	t.Cleanup(srv.Close)
+
+	client := f.createClient(t, &models.DownloadClient{
+		Name: "rtorrent-readiness", Type: "rtorrent", Username: "u", Password: "p", Category: "books",
+	}, srv.URL)
+	torrentHash := hash
+	f.createDownload(t, &models.Download{
+		GUID: guid, Title: "the-book", Status: models.StateImportFailed,
+		Protocol: "torrent", TorrentID: &torrentHash, DownloadClientID: &client.ID,
+	})
+
+	// More polls than the retry budget. Under the old branch every one of them
+	// counted, and the download was out of attempts before this loop ended.
+	for i := 0; i < importRetryLimit+3; i++ {
+		f.scanner.CheckDownloads(f.ctx)
+	}
+
+	got, err := f.downloads.GetByGUID(f.ctx, guid)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.ImportRetryCount != 0 {
+		t.Errorf("#1884: %d retry attempts spent on a download with nothing on disk to import, want 0",
+			got.ImportRetryCount)
+	}
+	if got.Status == models.StateImportBlocked {
+		t.Fatalf("download terminally blocked after %d polls with status %q (%q); "+
+			"importSkipLimit is %d, so it must stay retryable this early",
+			importRetryLimit+3, got.Status, got.ErrorMessage, importSkipLimit)
+	}
+	if got.Status != models.StateImportFailed {
+		t.Fatalf("status = %q, want %q — the download must stay retryable",
+			got.Status, models.StateImportFailed)
+	}
+	if h := f.allHandoffs(); len(h) != 0 {
+		t.Errorf("importer boundary called %d times for a download with no source on disk: %+v", len(h), h)
+	}
+
+	// The file appears — re-downloaded, or a remap corrected. The skipped polls
+	// must have cost nothing: the next one imports, spending the first attempt.
+	if err := os.WriteFile(filepath.Join(directory, fileName), []byte("epub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f.scanner.CheckDownloads(f.ctx)
+
+	got, err = f.downloads.GetByGUID(f.ctx, guid)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.ImportRetryCount != 1 {
+		t.Errorf("ImportRetryCount = %d after the file returned, want exactly the one real retry",
+			got.ImportRetryCount)
+	}
+	handoffs := f.allHandoffs()
+	if len(handoffs) != 1 {
+		t.Fatalf("importer boundary called %d times once the file was present, want 1: %+v",
+			len(handoffs), handoffs)
+	}
+	if handoffs[0].clientType != "rtorrent" {
+		t.Errorf("handoff came from the %q poller, want rtorrent", handoffs[0].clientType)
+	}
+	if want := filepath.Join(directory, fileName); len(handoffs[0].files) != 1 || handoffs[0].files[0] != want {
+		t.Errorf("handoff files = %v, want [%s]", handoffs[0].files, want)
+	}
+}

--- a/internal/importer/scanner_poll.go
+++ b/internal/importer/scanner_poll.go
@@ -852,6 +852,10 @@ func (s *Scanner) checkRtorrentDownloads(ctx context.Context, client *models.Dow
 			s.tryImportRtorrent(ctx, &dl, downloadPath, bookFiles)
 		case t.Complete && dl.Status == models.StateImportFailed && dl.ImportRetryCount < importRetryLimit:
 			downloadPath, bookFiles := s.rtorrentImportSources(ctx, rt, client, t)
+			if !importSourcePresent(downloadPath, bookFiles) {
+				s.skipImportRetry(ctx, &dl, downloadPath)
+				continue
+			}
 			slog.Info("retrying failed import", "title", dl.Title, "path", downloadPath,
 				"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit, "files", len(bookFiles))
 			if err := s.downloads.IncrementImportRetryCount(ctx, dl.ID); err != nil {


### PR DESCRIPTION
## What

`checkRtorrentDownloads` is missing the import-readiness guard that #1976 added to every other client for #1884.

```go
case t.Complete && dl.Status == models.StateImportFailed && dl.ImportRetryCount < importRetryLimit:
    downloadPath, bookFiles := s.rtorrentImportSources(ctx, rt, client, t)
+   if !importSourcePresent(downloadPath, bookFiles) {
+       s.skipImportRetry(ctx, &dl, downloadPath)
+       continue
+   }
    slog.Info("retrying failed import", ...)
    if err := s.downloads.IncrementImportRetryCount(ctx, dl.ID); err != nil {
```

Same two calls, same order, as `scanner_poll.go:62`, `:132`, `:272`, `:639` and `:721`.

## Why it matters

On rTorrent the original #1884 bug is still live. A download whose files are not on this host spends all five attempts in about 75 seconds and lands in `importBlocked` with *import retry limit reached* — the wrong reason, and it happens well inside any real download. With the guard it waits, and the skip streak still ends at `importSkipLimit` (120 polls, roughly 30 minutes), so a download whose files genuinely never arrive is blocked with the message that names the path it checked.

Given rTorrent shipped in v1.31.0 and seedbox setups are the case most likely to need a path remap, this is the client most exposed to it.

## Testing

`TestCheckRtorrentDownloads_MissingPayloadDoesNotExhaustRetries` uses the reporter's shape: the client is healthy and honest, the torrent is complete, `f.multicall` enumerates its file, and the file is not there.

Verified it fails against unfixed code rather than passing vacuously:

```
--- FAIL: TestCheckRtorrentDownloads_MissingPayloadDoesNotExhaustRetries
    #1884: 5 retry attempts spent on a download with nothing on disk to import, want 0
    download terminally blocked after 8 polls with status "importBlocked"
```

Full `./internal/importer` package green, `golangci-lint` clean.