### PR TITLE
fix(scanner): match audiobook files against audiobook root, not ebook root (#2033)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -259,6 +259,20 @@ func (s *Scanner) effectiveAudiobookDir(ctx context.Context, author *models.Auth
 	return s.audiobookDir
 }
 
+// effectiveRootForFormat picks the correct root (ebook or audiobook) to
+// gate a reconcile match against, based on the detected format of the file
+// being matched. Reconcile tiers used to always check effectiveLibraryDir
+// (the ebook root), which silently rejected correctly-placed audiobook
+// files whenever BINDERY_AUDIOBOOK_DIR differed from the ebook root (#2033)
+// — the same class of bug already fixed for the import-placement path
+// under #421.
+func (s *Scanner) effectiveRootForFormat(ctx context.Context, author *models.Author, detectedFmt string) string {
+	if detectedFmt == models.MediaTypeAudiobook {
+		return s.effectiveAudiobookDir(ctx, author)
+	}
+	return s.effectiveLibraryDir(ctx, author)
+}
+
 // WithCalibre attaches the Calibre integration. The mode resolver is consulted
 // on every import so the operator can switch modes in the UI without restarting.
 func (s *Scanner) WithCalibre(mode func() calibre.Mode, adder calibreAdder) *Scanner {
@@ -2599,7 +2613,7 @@ func (s *Scanner) scanLibrary(ctx context.Context) {
 		}
 		// File must live under the candidate book's effective library root to
 		// prevent cross-author mismapping after delete+rescan (#343).
-		effDir := s.effectiveLibraryDir(ctx, authorMap[b.AuthorID])
+		effDir := s.effectiveRootForFormat(ctx, authorMap[b.AuthorID], detectedFmt)
 		if !pathUnderDir(path, effDir) {
 			slog.Debug("library scan: title+author match rejected (outside library root)",
 				"title", b.Title, "path", path, "root", effDir)
@@ -2718,7 +2732,7 @@ func (s *Scanner) scanLibrary(ctx context.Context) {
 					continue
 				}
 				// File must live under the candidate book's effective library root.
-				effDir := s.effectiveLibraryDir(ctx, authorMap[b.AuthorID])
+				effDir := s.effectiveRootForFormat(ctx, authorMap[b.AuthorID], detectedFmt)
 				if !pathUnderDir(path, effDir) {
 					slog.Debug("library scan: ASIN match rejected (outside library root)",
 						"asin", parsed.ASIN, "path", path, "root", effDir)
@@ -2778,7 +2792,7 @@ func (s *Scanner) scanLibrary(ctx context.Context) {
 				slog.Warn("library scan: series position lookup error",
 					"series", parsed.Series, "position", parsed.SeriesNumber, "error", seriesErr)
 			} else if book != nil && !reconciledBooks[bookFormatClaim{book.ID, detectedFmt}] {
-				effDir := s.effectiveLibraryDir(ctx, authorMap[book.AuthorID])
+				effDir := s.effectiveRootForFormat(ctx, authorMap[book.AuthorID], detectedFmt)
 				if pathUnderDir(path, effDir) {
 					if err := s.books.AddBookFile(ctx, book.ID, detectedFmt, path); err != nil {
 						slog.Error("library scan: failed to update book via series match", "id", book.ID, "error", err)

--- a/internal/importer/scanner_extra_test.go
+++ b/internal/importer/scanner_extra_test.go
@@ -649,6 +649,112 @@ func TestScanLibrary_AudiobookMatchesByEmbeddedTitleAuthor(t *testing.T) {
 	}
 }
 
+// TestScanLibrary_AudiobookASINMatchUsesAudiobookRoot is a regression test
+// for #2033. When BINDERY_AUDIOBOOK_DIR differs from the ebook library dir,
+// the ASIN reconcile tier must check the file against the audiobook root
+// (effectiveAudiobookDir), not the ebook root (effectiveLibraryDir). Before
+// the fix, a correctly ASIN-tagged audiobook living under the audiobook root
+// was rejected as "outside library root" because the ebook root was checked
+// instead.
+func TestScanLibrary_AudiobookASINMatchUsesAudiobookRoot(t *testing.T) {
+	libDir := t.TempDir()       // ebook root — deliberately unrelated
+	audiobookDir := t.TempDir() // BINDERY_AUDIOBOOK_DIR
+
+	abDir := filepath.Join(audiobookDir, "Audible Download")
+	if err := os.MkdirAll(abDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	audioPath := filepath.Join(abDir, "part1.mp3")
+	if err := os.WriteFile(audioPath, buildID3v23("The Way of Kings", "Brandon Sanderson", "B003P2WO5E"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	s := NewScanner(db.NewDownloadRepo(database), db.NewDownloadClientRepo(database),
+		books, authors, db.NewHistoryRepo(database), libDir, audiobookDir, "", "", "")
+	ctx := context.Background()
+
+	author := &models.Author{ForeignID: "OLA-asin-root", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OLB-asin-root", AuthorID: author.ID,
+		Title: "The Way of Kings", ASIN: "B003P2WO5E",
+		Status: models.BookStatusWanted,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AudiobookFilePath != audioPath {
+		t.Errorf("expected ASIN-matched audiobook FilePath=%q, got AudiobookFilePath=%q (audiobook root ignored, #2033)",
+			audioPath, got.AudiobookFilePath)
+	}
+}
+
+// TestScanLibrary_AudiobookTitleMatchUsesAudiobookRoot is a regression test
+// for #2033, covering the fuzzy title+author reconcile tier: a well-tagged
+// audiobook with no ASIN, living under BINDERY_AUDIOBOOK_DIR, must reconcile
+// via title match without being rejected for sitting outside the ebook root.
+func TestScanLibrary_AudiobookTitleMatchUsesAudiobookRoot(t *testing.T) {
+	libDir := t.TempDir()
+	audiobookDir := t.TempDir()
+
+	audioPath := filepath.Join(audiobookDir, "opaque.mp3")
+	if err := os.WriteFile(audioPath, buildID3v23("Mistborn", "Brandon Sanderson", ""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	s := NewScanner(db.NewDownloadRepo(database), db.NewDownloadClientRepo(database),
+		books, authors, db.NewHistoryRepo(database), libDir, audiobookDir, "", "", "")
+	ctx := context.Background()
+
+	author := &models.Author{ForeignID: "OLA-title-root", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OLB-title-root", AuthorID: author.ID,
+		Title: "Mistborn", Status: models.BookStatusWanted,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AudiobookFilePath != audioPath {
+		t.Errorf("expected title-matched audiobook FilePath=%q, got AudiobookFilePath=%q (audiobook root ignored, #2033)",
+			audioPath, got.AudiobookFilePath)
+	}
+}
+
 // TestScanLibrary_AudiobookTagReadFailureFallsBack — when an audio file's
 // tags cannot be read (truncated / unrecognised), the scan must fall back
 // to filename parsing rather than crashing or skipping the file entirely.


### PR DESCRIPTION
## Summary

Library scan's reconcile tiers (ASIN, fuzzy title, series+position) always checked a candidate match against `effectiveLibraryDir` (the ebook root), never `effectiveAudiobookDir` (the audiobook root), regardless of the file's detected format. When `BINDERY_AUDIOBOOK_DIR` differs from the ebook root, every correctly ASIN/title-matched audiobook file was silently rejected as "outside library root", falling through to the default `no_title_match` reason — misleading, since the title/ASIN actually matched fine.

Closes #2033.

## Implementation notes

Added `effectiveRootForFormat(ctx, author, detectedFmt)` in `internal/importer/scanner.go`, which picks `effectiveAudiobookDir` for `models.MediaTypeAudiobook` files and `effectiveLibraryDir` otherwise. Swapped in at the three reconcile gate call sites (title tier, ASIN tier, series tier). Mirrors the format-aware root resolution already applied to the import-placement path under #421 (`TestAudiobookImport_UsesAudiobookDirNotEbookRoot`) — that fix was never back-ported to the scan reconcile loop.

## Checklist

- [x] Tests added or updated
- [ ] Doc-update gate cleared — pure bugfix, no config/behaviour surface change, no doc touch needed
- [ ] Wiki pages updated if user-facing behaviour changed — n/a, fixes existing documented behaviour

## Test plan

- [x] `go test ./internal/importer/...` — all pass, including two new regression tests (`TestScanLibrary_AudiobookASINMatchUsesAudiobookRoot`, `TestScanLibrary_AudiobookTitleMatchUsesAudiobookRoot`) that fail without the fix and pass with it (verified via `git stash` on `scanner.go`)
- [x] `go vet ./...`, `gofmt -l`, `golangci-lint run ./internal/importer/...` — clean
- [x] `go test -race ./cmd/... ./internal/...` — `internal/importer` package passes clean; two unrelated pre-existing failures elsewhere (`internal/downloader` rtorrent test, macOS temp-dir symlink quirk; `internal/api` package timeout) confirmed present on `main` without this diff, not caused by this change (diff touches only `internal/importer/scanner.go`)
