### PR TITLE
fix(api): restore the indexer apikey on grabs that carry no indexer id

### DIFF
--- a/changelog.d/2039-grab-apikey-without-indexer-id.md
+++ b/changelog.d/2039-grab-apikey-without-indexer-id.md
@@ -8,3 +8,12 @@
   indexer answered `401` — surfaced as `failed to send to downloader: fetch nzb:
   indexer returned HTTP 401`. The key is now also recoverable from the
   configured indexer whose host matches the download URL.
+
+### Security
+
+- **The grab response no longer echoes the indexer apikey back to the caller**
+  (#2039) — the queue listing already stripped the shared indexer credential out
+  of `nzbUrl`, but the grab response handed back the download URL that had just
+  been signed, so a non-admin who grabbed a release read the key straight out of
+  the reply. Indexer credentials are admin-only settings. The stored row keeps
+  the key, so retries still reach the indexer authenticated.

--- a/changelog.d/2039-grab-apikey-without-indexer-id.md
+++ b/changelog.d/2039-grab-apikey-without-indexer-id.md
@@ -17,3 +17,8 @@
   been signed, so a non-admin who grabbed a release read the key straight out of
   the reply. Indexer credentials are admin-only settings. The stored row keeps
   the key, so retries still reach the indexer authenticated.
+- **The pending releases list no longer exposes the indexer apikey** (#2039) —
+  a release held back by a delay profile is stored as the raw indexer result,
+  whose `nzbUrl` was already signed, and `GET /api/v1/pending` returned that
+  blob verbatim in `releaseJson`. It is redacted now. The stored blob keeps the
+  key so force-grab still re-sends a signed URL.

--- a/changelog.d/2039-grab-apikey-without-indexer-id.md
+++ b/changelog.d/2039-grab-apikey-without-indexer-id.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Grabs from API clients no longer fail with the indexer's 401** (#2039) —
+  search and queue responses strip the indexer apikey out of `nzbUrl` and the
+  grab handler puts it back from the `indexerId` the web UI sends along. A
+  client that posts only `{guid, nzbUrl}` (scripts, `curl`, other API consumers)
+  has no id to send, so the unsigned URL went to the download client and the
+  indexer answered `401` — surfaced as `failed to send to downloader: fetch nzb:
+  indexer returned HTTP 401`. The key is now also recoverable from the
+  configured indexer whose host matches the download URL.

--- a/internal/api/pending.go
+++ b/internal/api/pending.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/indexer/newznab"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -47,6 +48,12 @@ func (h *PendingHandler) List(w http.ResponseWriter, r *http.Request) {
 	out := make([]pendingItem, len(items))
 	bookIDs := make([]int64, 0, len(items))
 	for i, it := range items {
+		// The stored release blob is the raw indexer SearchResult, whose nzbUrl
+		// the newznab client signed with the indexer apikey. The queue and
+		// search responses strip that credential before it reaches a client
+		// (it is an admin-only setting); this list has to do the same. The DB
+		// copy keeps the key so force-grab can still re-send the signed URL.
+		it.ReleaseJSON = redactReleaseJSON(it.ReleaseJSON)
 		out[i] = pendingItem{PendingRelease: it}
 		if it.BookID != 0 {
 			bookIDs = append(bookIDs, it.BookID)
@@ -63,6 +70,35 @@ func (h *PendingHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+// redactReleaseJSON removes the indexer apikey from the nzbUrl inside a stored
+// pending-release blob. The blob is decoded into a generic map rather than into
+// newznab.SearchResult so that a field the struct does not know about survives
+// the round-trip; anything that fails to decode is returned untouched, since a
+// blob we cannot parse is also one we cannot vouch for editing.
+func redactReleaseJSON(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	var release map[string]any
+	if err := json.Unmarshal([]byte(raw), &release); err != nil {
+		return raw
+	}
+	rawURL, ok := release["nzbUrl"].(string)
+	if !ok {
+		return raw
+	}
+	redacted := newznab.RedactDownloadURL(rawURL)
+	if redacted == rawURL {
+		return raw
+	}
+	release["nzbUrl"] = redacted
+	out, err := json.Marshal(release)
+	if err != nil {
+		return raw
+	}
+	return string(out)
 }
 
 func (h *PendingHandler) listForCaller(r *http.Request) ([]models.PendingRelease, error) {

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -130,6 +130,50 @@ func (h *QueueHandler) resolveSeedRatio(ctx context.Context, indexerID *int64) *
 	return idx.SeedRatio
 }
 
+// signNZBURL restores the indexer apikey that the search and queue responses
+// strip out of a download URL, so the grab reaches the indexer authenticated.
+//
+// The web UI sends the release's indexer id back on grab, which names the
+// credential directly. API clients post only {guid, nzbUrl} — nothing carries
+// the id — so with no id (or one that no longer resolves) the key is taken from
+// the configured indexer whose host matches the URL: only an indexer on that
+// host could have produced it, and SignDownloadURLFor's host guard keeps the
+// credential from travelling anywhere else. Several indexers on one host (the
+// usual Prowlarr layout) are usable while they agree on the key; when they
+// disagree there is nothing to choose between them and the URL is left alone.
+//
+// Returns rawURL unchanged when it already carries an apikey (scheduler and
+// retry paths), when no indexer matches its host, or when there is no indexer
+// repo attached.
+func (h *QueueHandler) signNZBURL(ctx context.Context, rawURL string, indexerID *int64) string {
+	if h.indexers == nil || rawURL == "" {
+		return rawURL
+	}
+	if indexerID != nil {
+		if idx, err := h.indexers.GetByID(ctx, *indexerID); err == nil && idx != nil {
+			return newznab.SignDownloadURLFor(rawURL, idx.URL, idx.APIKey)
+		}
+	}
+	idxs, err := h.indexers.List(ctx)
+	if err != nil {
+		return rawURL
+	}
+	signed := rawURL
+	for _, idx := range idxs {
+		candidate := newznab.SignDownloadURLFor(rawURL, idx.URL, idx.APIKey)
+		if candidate == rawURL {
+			continue
+		}
+		if signed != rawURL && candidate != signed {
+			slog.Warn("cannot restore indexer apikey: several indexers share the download URL host with different keys",
+				"url", newznab.RedactDownloadURL(rawURL))
+			return rawURL
+		}
+		signed = candidate
+	}
+	return signed
+}
+
 // WithStoragePaths attaches the process-level download roots used when sending
 // torrent clients an explicit save path.
 func (h *QueueHandler) WithStoragePaths(downloadDir, audiobookDownloadDir string) *QueueHandler {
@@ -861,12 +905,7 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 	// hands back an apikey-less download URL plus the indexer id; sign it
 	// server-side here. No-op when the URL already carries a key (scheduler /
 	// retry paths) or its host does not match the indexer.
-	nzbURL := req.NZBURL
-	if indexerID != nil && h.indexers != nil {
-		if idx, err := h.indexers.GetByID(ctx, *indexerID); err == nil && idx != nil {
-			nzbURL = newznab.SignDownloadURLFor(req.NZBURL, idx.URL, idx.APIKey)
-		}
-	}
+	nzbURL := h.signNZBURL(ctx, req.NZBURL, indexerID)
 	dl := &models.Download{
 		GUID:             req.GUID,
 		BookID:           bookID,

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -979,6 +979,15 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 	if h.notif != nil {
 		h.notif.Send(ctx, notifier.EventGrabbed, map[string]any{"title": req.Title, "size": req.Size})
 	}
+	// Strip the apikey back off before the record leaves this function. The row
+	// in the DB and the URL handed to the download client keep the credential;
+	// what callers get back must not, because every caller of grab() writes the
+	// returned record straight into an HTTP response (QueueHandler.Grab,
+	// PendingHandler.Grab) and the indexer apikey is an admin-only setting.
+	// Redacting here rather than at each writeJSON keeps a handler added later
+	// alongside these from reintroducing the leak by simply echoing the record,
+	// and makes the grab response agree with List, which redacts the same field.
+	dl.NZBURL = newznab.RedactDownloadURL(dl.NZBURL)
 	return dl, nil
 }
 

--- a/internal/api/queue_grab_sign_test.go
+++ b/internal/api/queue_grab_sign_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -121,5 +123,130 @@ func TestSignNZBURL(t *testing.T) {
 	// The explicit indexer id still resolves it.
 	if got := h.signNZBURL(ctx, dl, &first.ID); got != signed {
 		t.Errorf("ambiguous host with indexer id: got %q, want %q", got, signed)
+	}
+}
+
+// leakedAPIKey is deliberately distinctive: when one of the assertions below
+// trips, the failure message points at the indexer credential itself rather
+// than at an anonymous "unexpected substring".
+const leakedAPIKey = "SECRET-APIKEY-MUST-NOT-LEAK"
+
+// assertNoIndexerAPIKey fails when the credential appears anywhere in a
+// response body. It checks the raw bytes rather than a decoded nzbUrl field on
+// purpose: a handler that grows a second field carrying the same URL, or embeds
+// the download record inside a new envelope, is caught by this just the same.
+func assertNoIndexerAPIKey(t *testing.T, surface string, body []byte) {
+	t.Helper()
+	if strings.Contains(string(body), leakedAPIKey) {
+		t.Errorf("%s leaked the indexer apikey to the caller: %s", surface, body)
+	}
+}
+
+// TestQueueGrab_ResponseAndListNeverCarryIndexerAPIKey pins the security
+// boundary the signing fallback sits on. signNZBURL puts the shared indexer
+// apikey back onto the download URL so the download client can fetch the NZB,
+// and the URL is persisted in that form — but the indexer apikey is an
+// admin-only setting, while the queue is readable by the non-admin user who
+// owns the download. So nothing that travels back out to an HTTP caller may
+// carry it.
+//
+// The grab here goes through the new fallback (no indexerId in the request
+// body), so it asserts the signing happened — the indexer only answers 200 to
+// an authenticated fetch — and then that neither the grab response nor the
+// queue listing echoes the key back. The stored row is checked too, to show the
+// redaction is a response-shaping step and has not quietly undone the fix.
+func TestQueueGrab_ResponseAndListNeverCarryIndexerAPIKey(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
+
+	var signedFetch atomic.Bool
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("apikey") != leakedAPIKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		signedFetch.Store(true)
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><nzb></nzb>`))
+	}))
+	defer indexerSrv.Close()
+
+	sab := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": true, "nzo_ids": []string{"nzo-1"}})
+	}))
+	defer sab.Close()
+
+	h, database, downloads, clients, _, ctx := queueFixture(t)
+	host, port := testServerHostPort(t, sab.URL)
+	if err := clients.Create(ctx, &models.DownloadClient{
+		Name: "sab", Type: "sabnzbd", Host: host, Port: port, Enabled: true,
+	}); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	indexers := db.NewIndexerRepo(database)
+	if err := indexers.Create(ctx, &models.Indexer{
+		Name: "prowlarr", Type: "newznab", URL: indexerSrv.URL + "/3/api", APIKey: leakedAPIKey, Enabled: true,
+	}); err != nil {
+		t.Fatalf("create indexer: %v", err)
+	}
+	h.WithIndexers(indexers)
+
+	// No indexerId: the request an API client (script, curl) actually sends, so
+	// the apikey can only come from signNZBURL's host-match fallback.
+	unsigned := indexerSrv.URL + "/3/download?file=Lee+Child&link=abc"
+	body := bytes.NewBufferString(`{"guid":"guid-redact","title":"One Shot","nzbUrl":"` + unsigned + `"}`)
+	rec := httptest.NewRecorder()
+	h.Grab(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/grab", body))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !signedFetch.Load() {
+		t.Fatal("indexer never saw an authenticated fetch: the URL was not signed, so this test would pass vacuously")
+	}
+
+	// 1. The grab response itself — the surface this PR newly puts a signed URL
+	//    behind, and the one the review asked about.
+	assertNoIndexerAPIKey(t, "grab response", rec.Body.Bytes())
+	var grabbed models.Download
+	if err := json.Unmarshal(rec.Body.Bytes(), &grabbed); err != nil {
+		t.Fatalf("decode grab response: %v (body=%s)", err, rec.Body.String())
+	}
+	if grabbed.NZBURL != unsigned {
+		t.Errorf("grab response nzbUrl = %q, want the redacted form %q", grabbed.NZBURL, unsigned)
+	}
+
+	// 2. The queue listing, which the owning non-admin user polls every few
+	//    seconds.
+	listRec := httptest.NewRecorder()
+	h.List(listRec, httptest.NewRequest(http.MethodGet, "/api/v1/queue", nil))
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from list, got %d: %s", listRec.Code, listRec.Body.String())
+	}
+	assertNoIndexerAPIKey(t, "queue listing", listRec.Body.Bytes())
+	var listed queueListResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode queue list: %v (body=%s)", err, listRec.Body.String())
+	}
+	found := false
+	for _, item := range listed.Items {
+		if item.GUID == "guid-redact" {
+			found = true
+			if item.NZBURL != unsigned {
+				t.Errorf("queue listing nzbUrl = %q, want the redacted form %q", item.NZBURL, unsigned)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("grabbed download missing from the queue listing, so the redaction assertion proved nothing: %s", listRec.Body.String())
+	}
+
+	// 3. The stored row must still hold the signed URL — retries and the
+	//    importer re-send it, and redacting it at rest would trade this leak for
+	//    the 401 the PR set out to fix.
+	stored, err := downloads.GetByGUID(ctx, "guid-redact")
+	if err != nil || stored == nil {
+		t.Fatalf("read back stored download: %v", err)
+	}
+	if !strings.Contains(stored.NZBURL, leakedAPIKey) {
+		t.Errorf("stored nzbUrl = %q, want it to keep the apikey for retries", stored.NZBURL)
 	}
 }

--- a/internal/api/queue_grab_sign_test.go
+++ b/internal/api/queue_grab_sign_test.go
@@ -250,3 +250,70 @@ func TestQueueGrab_ResponseAndListNeverCarryIndexerAPIKey(t *testing.T) {
 		t.Errorf("stored nzbUrl = %q, want it to keep the apikey for retries", stored.NZBURL)
 	}
 }
+
+// TestPendingList_RedactsIndexerAPIKey covers the sibling surface the audit for
+// the review turned up: the scheduler stores a delay-rejected release as the
+// raw indexer SearchResult, whose nzbUrl the newznab client had already signed,
+// and the pending list handed that blob back to the caller verbatim.
+func TestPendingList_RedactsIndexerAPIKey(t *testing.T) {
+	h, database, _, _, _, ctx := queueFixture(t)
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	a := &models.Author{ForeignID: "OL-A", Name: "Lee Child", SortName: "child lee", MetadataProvider: "openlibrary"}
+	if err := authors.Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	b := &models.Book{
+		ForeignID: "OL-B", AuthorID: a.ID, Title: "One Shot", SortTitle: "one shot",
+		Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+
+	signed := "http://prowlarr:9696/3/download?apikey=" + leakedAPIKey + "&link=abc"
+	pending := db.NewPendingReleaseRepo(database)
+	if err := pending.Upsert(ctx, &models.PendingRelease{
+		BookID: b.ID, MediaType: models.MediaTypeEbook, Title: "One Shot", GUID: "guid-pending",
+		Protocol: "usenet", Reason: "delay",
+		ReleaseJSON: `{"guid":"guid-pending","title":"One Shot","nzbUrl":"` + signed + `","size":123}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ph := NewPendingHandler(pending, h, db.NewDownloadRepo(database), books)
+	rec := httptest.NewRecorder()
+	ph.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/pending", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	assertNoIndexerAPIKey(t, "pending listing", rec.Body.Bytes())
+
+	// The entry must survive redaction intact — dropping releaseJson would also
+	// pass the assertion above while breaking the UI.
+	var got []pendingItem
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode pending list: %v (body=%s)", err, rec.Body.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 pending release, got %d", len(got))
+	}
+	var release map[string]any
+	if err := json.Unmarshal([]byte(got[0].ReleaseJSON), &release); err != nil {
+		t.Fatalf("decode releaseJson: %v", err)
+	}
+	if release["nzbUrl"] != "http://prowlarr:9696/3/download?link=abc" {
+		t.Errorf("releaseJson nzbUrl = %v, want the redacted form", release["nzbUrl"])
+	}
+	if release["guid"] != "guid-pending" || release["title"] != "One Shot" {
+		t.Errorf("redaction dropped fields from the release blob: %v", release)
+	}
+	// The stored blob keeps the key: force-grab re-sends this URL.
+	stored, err := pending.List(ctx)
+	if err != nil || len(stored) != 1 {
+		t.Fatalf("read back pending: %v", err)
+	}
+	if !strings.Contains(stored[0].ReleaseJSON, leakedAPIKey) {
+		t.Errorf("stored releaseJson lost the apikey, breaking force-grab: %s", stored[0].ReleaseJSON)
+	}
+}

--- a/internal/api/queue_grab_sign_test.go
+++ b/internal/api/queue_grab_sign_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/httpsec"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestQueueGrab_SignsDownloadURLWithoutIndexerID replays the Prowlarr grab
+// failure: the search response strips the apikey from nzbUrl, so an API client
+// that posts only {guid, nzbUrl} — no indexerId — hands back a URL the indexer
+// answers with 401, and the grab dies as
+// "failed to send to downloader: fetch nzb: indexer returned HTTP 401".
+// The apikey must be restored from the configured indexer whose host matches
+// the download URL.
+func TestQueueGrab_SignsDownloadURLWithoutIndexerID(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
+
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("apikey") != "SECRET" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><nzb></nzb>`))
+	}))
+	defer indexerSrv.Close()
+
+	sab := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": true, "nzo_ids": []string{"nzo-1"}})
+	}))
+	defer sab.Close()
+
+	h, database, _, clients, _, ctx := queueFixture(t)
+	host, port := testServerHostPort(t, sab.URL)
+	if err := clients.Create(ctx, &models.DownloadClient{
+		Name: "sab", Type: "sabnzbd", Host: host, Port: port, Enabled: true,
+	}); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	indexers := db.NewIndexerRepo(database)
+	if err := indexers.Create(ctx, &models.Indexer{
+		Name: "prowlarr", Type: "newznab", URL: indexerSrv.URL + "/3/api", APIKey: "SECRET", Enabled: true,
+	}); err != nil {
+		t.Fatalf("create indexer: %v", err)
+	}
+	h.WithIndexers(indexers)
+
+	body := bytes.NewBufferString(`{"guid":"guid-1","title":"One Shot","nzbUrl":"` +
+		indexerSrv.URL + `/3/download?file=Lee+Child&link=abc"}`)
+	rec := httptest.NewRecorder()
+	h.Grab(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/grab", body))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSignNZBURL covers the paths around that restore: the indexer id names the
+// credential when the client sends one, the host match stands in when it does
+// not, and neither may hand the key to a host that is not the indexer's.
+func TestSignNZBURL(t *testing.T) {
+	h, database, _, _, _, ctx := queueFixture(t)
+	indexers := db.NewIndexerRepo(database)
+	h.WithIndexers(indexers)
+
+	first := &models.Indexer{Name: "prowlarr-1", Type: "newznab", URL: "http://prowlarr:9696/3/api", APIKey: "SECRET", Enabled: true}
+	if err := indexers.Create(ctx, first); err != nil {
+		t.Fatalf("create indexer: %v", err)
+	}
+
+	const dl = "http://prowlarr:9696/3/download?file=Lee+Child&link=abc"
+	const signed = "http://prowlarr:9696/3/download?apikey=SECRET&file=Lee+Child&link=abc"
+
+	if got := h.signNZBURL(ctx, dl, &first.ID); got != signed {
+		t.Errorf("with indexer id: got %q, want %q", got, signed)
+	}
+	if got := h.signNZBURL(ctx, dl, nil); got != signed {
+		t.Errorf("without indexer id: got %q, want %q", got, signed)
+	}
+	// A stale id must not lose the key either: the host match still resolves it.
+	stale := int64(9999)
+	if got := h.signNZBURL(ctx, dl, &stale); got != signed {
+		t.Errorf("stale indexer id: got %q, want %q", got, signed)
+	}
+	// Already signed (scheduler / retry paths) and direct-from-uploader links on
+	// a foreign host are both returned untouched.
+	if got := h.signNZBURL(ctx, signed, nil); got != signed {
+		t.Errorf("already signed: got %q, want it unchanged", got)
+	}
+	const foreign = "http://uploader.example.com/dl?id=abc"
+	if got := h.signNZBURL(ctx, foreign, nil); got != foreign {
+		t.Errorf("foreign host: got %q, want it unchanged", got)
+	}
+
+	// A second indexer on the same host with the same key stays unambiguous.
+	if err := indexers.Create(ctx, &models.Indexer{
+		Name: "prowlarr-2", Type: "newznab", URL: "http://prowlarr:9696/4/api", APIKey: "SECRET", Enabled: true,
+	}); err != nil {
+		t.Fatalf("create indexer: %v", err)
+	}
+	if got := h.signNZBURL(ctx, dl, nil); got != signed {
+		t.Errorf("two indexers, one key: got %q, want %q", got, signed)
+	}
+
+	// A third with a different key makes the host ambiguous — guessing would
+	// only trade one 401 for another, so the URL is left as it came in.
+	if err := indexers.Create(ctx, &models.Indexer{
+		Name: "prowlarr-3", Type: "newznab", URL: "http://prowlarr:9696/5/api", APIKey: "OTHER", Enabled: true,
+	}); err != nil {
+		t.Fatalf("create indexer: %v", err)
+	}
+	if got := h.signNZBURL(ctx, dl, nil); got != dl {
+		t.Errorf("ambiguous host: got %q, want it unchanged", got)
+	}
+	// The explicit indexer id still resolves it.
+	if got := h.signNZBURL(ctx, dl, &first.ID); got != signed {
+		t.Errorf("ambiguous host with indexer id: got %q, want %q", got, signed)
+	}
+}


### PR DESCRIPTION
## Summary

A grab issued by an API client that posts only `{guid, nzbUrl}` sends the download client a URL with no `apikey`, so the indexer rejects the NZB fetch with `401`. This restores the key from the configured indexer whose host matches the download URL when the request carries no usable `indexerId`. Closes #2039.

## Observed symptom

Bindery v1.31.0 (`18ac850`), Newznab indexer pointing at Prowlarr (`http://prowlarr.internal:9696/3/api`), apikey stored on the indexer. Search works; grabbing does not:

```
POST /api/v1/queue/grab   {"guid":"…","nzbUrl":"…"}
HTTP 502
{"error":"failed to send to downloader: fetch nzb: indexer returned HTTP 401: "}
```

## Evidence

Prowlarr's `<enclosure>` carries the key:

```
http://prowlarr.internal:9696/3/download?apikey=REDACTEDKEY&link=cXEyK0Ez…&file=Lee+Child+-+One+Shot
```

The `nzbUrl` Bindery hands back from its own search endpoint does not (params re-sorted by the `url.Values.Encode()` round-trip in `RedactDownloadURL`):

```
http://prowlarr.internal:9696/3/download?file=Lee+Child+-+One+Shot&link=cXEyK0Ez…
```

Fetching that URL by hand returns `401`; appending `&apikey=REDACTEDKEY` returns `200 application/x-nzb`. The apikey is the only missing piece.

## Root cause

`internal/api/queue.go`. Since #1766 the search and queue responses strip the shared indexer apikey out of `nzbUrl` (`newznab.RedactDownloadURL`) and `grab()` re-attaches it server-side — but only when the request carries an indexer id:

```go
if indexerID != nil && h.indexers != nil {
    if idx, err := h.indexers.GetByID(ctx, *indexerID); err == nil && idx != nil {
        nzbURL = newznab.SignDownloadURLFor(req.NZBURL, idx.URL, idx.APIKey)
    }
}
```

The web UI was updated in that PR to send `indexerId`, so the UI path is fine. Anything else that grabs — scripts, `curl`, other API consumers — has no id to send (and `GET /api/v1/indexer/search` results are redacted the same way), so nothing re-signs the URL. The unsigned URL goes to SABnzbd/NZBGet, the indexer answers `401`, and `nzbfetch.Error` renders it as the message above. A grab whose stored `indexerId` no longer resolves fails the same way.

## The fix

`grab()` now calls a new `QueueHandler.signNZBURL`. The indexer id still takes precedence when it resolves; when it is absent or stale, the key comes from the configured indexer whose host matches the download URL — only an indexer on that host could have produced it, and `SignDownloadURLFor`'s existing host guard keeps the credential off foreign hosts (direct-from-uploader links stay untouched). Several indexers on the same host — the usual Prowlarr layout — are usable while they agree on the key; when they disagree there is nothing to choose between them, so the URL is left as it came in and the disagreement is logged (with the URL redacted). Already-signed URLs are unchanged, so the scheduler and retry paths are unaffected.

No change to the #1766 guarantee: the apikey is still never in a client-facing response.

## Checklist

- [x] Tests added or updated — `internal/api/queue_grab_sign_test.go`: an end-to-end grab against a fake indexer that 401s without an apikey (fails on `main` with exactly the reported 502), plus a unit table over `signNZBURL` covering explicit id, stale id, missing id, already-signed, foreign host, and the ambiguous multi-key host.
- [x] Doc-update gate cleared — no env vars, config, or exported-surface changes; changelog fragment added under `changelog.d/`.
- [ ] Wiki pages updated if user-facing behaviour changed — not applicable (failure mode removed, no new behaviour to document).

## Test plan

- [x] `go test ./cmd/... ./internal/...` — all pass except a pre-existing, environment-dependent failure in `TestRemoveDownload_Rtorrent` (macOS `/var` → `/private/var` symlink makes the guard refuse to delete the payload); it fails identically on unmodified `main` on this machine.
- [x] `go build ./...`, `go vet ./internal/api/`, `gofmt -l internal/api/` (clean)
- [ ] `cd web && npm run build` — not run; no frontend files touched.
- [ ] `golangci-lint run` — not run locally (tool not installed); CI covers it.
