### PR TITLE
fix(dedup): stop truncating the canonical title key at ": " (#2042)

### DIFF
--- a/changelog.d/2042-dedup-title-key.md
+++ b/changelog.d/2042-dedup-title-key.md
@@ -1,0 +1,16 @@
+### Fixed
+- **Duplicate books from punctuation and subtitle disagreements** (#2042) — the
+  canonical title key now folds apostrophes (`Poseidon's Arrow` and `Poseidons
+  Arrow` are one book) and treats a colon as a separator rather than a
+  truncation point (`Journey of the Pharaohs: Numa Files #17` matches the
+  colon-less spelling), so a provider that punctuates differently from Calibre
+  no longer creates a second `wanted` row beside a book you already own.
+
+### Changed
+- **Books that share a main title are no longer merged** (#2042) — the key used
+  to stop at the first `": "`, so `Star Wars: A New Hope` and `Star Wars: The
+  Empire Strikes Back` were one identity and an import could bind one onto the
+  other. Distinct subtitles now mean distinct books; a subtitle only one source
+  spells out still matches. Keys are recomputed automatically on the next start,
+  so no action is needed; libraries already holding duplicates keep them, as
+  merging existing rows remains a separate piece of work.

--- a/internal/abs/import_upserts.go
+++ b/internal/abs/import_upserts.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/textutil"
 )
@@ -563,17 +564,33 @@ func (i *Importer) lookupUpstreamBook(ctx context.Context, author *models.Author
 	if err != nil {
 		return nil, "", false, err
 	}
+	// Title match against the provider's works. indexer.CompareTitles rather
+	// than raw key equality: the canonical key no longer truncates at ": ", so
+	// an ABS "Pandora's Star: A Novel [Unabridged]" and a provider
+	// "Pandora's Star" hold different keys while still being one work (#2042).
+	// Exact matches shadow subtitle-divergent ones, so a near-miss can never
+	// make an otherwise unambiguous lookup ambiguous.
 	var match *models.Book
-	key := normalizeTitle(item.Title)
+	var exactMatches, nearMatches []*models.Book
 	for idx := range works {
-		if normalizeTitle(works[idx].Title) != key {
-			continue
+		switch indexer.CompareTitles(item.Title, works[idx].Title) {
+		case indexer.TitlesSame:
+			work := works[idx]
+			exactMatches = append(exactMatches, &work)
+		case indexer.TitlesNeedCorroboration:
+			work := works[idx]
+			nearMatches = append(nearMatches, &work)
 		}
-		if match != nil {
-			return nil, "", true, nil
-		}
-		copy := works[idx]
-		match = &copy
+	}
+	candidates := exactMatches
+	if len(candidates) == 0 {
+		candidates = nearMatches
+	}
+	if len(candidates) > 1 {
+		return nil, "", true, nil
+	}
+	if len(candidates) == 1 {
+		match = candidates[0]
 	}
 	if match == nil {
 		return nil, "", false, nil

--- a/internal/abs/import_utils_test.go
+++ b/internal/abs/import_utils_test.go
@@ -3,6 +3,8 @@ package abs
 import (
 	"strings"
 	"testing"
+
+	"github.com/vavallee/bindery/internal/indexer"
 )
 
 func TestNormalizeLibraryIDsPrependsLegacyPrimary(t *testing.T) {
@@ -31,7 +33,9 @@ func TestNormalizeTitle_StripsABSEditionNoise(t *testing.T) {
 		{"trailing hash series parenthetical", "Leviathan Wakes (The Expanse #1)", "leviathan wakes"},
 		{"square-bracket unabridged tag", "The Eye of the World [Unabridged]", "the eye of the world"},
 		{"square-bracket dramatized tag", "The Way of Kings [Dramatized Adaptation]", "the way of kings"},
-		{"colon novel subtitle and bracket tag", "Pandora's Star: A Novel [Unabridged]", "pandora's star"},
+		{"apostrophe deleted, not spaced", "Pandora's Star", "pandoras star"},
+		{"subtitle retained, bracket tag stripped", "Pandora's Star: A Novel [Unabridged]", "pandoras star a novel"},
+		{"colon and no-colon spellings agree", "Journey of the Pharaohs: Numa Files #17", "journey of the pharaohs numa files 17"},
 		{"stacked bracket tags", "Dune [Unabridged] [2021]", "dune"},
 		{"paren edition then bracket tag", "Mistborn (Unabridged) [Audiobook]", "mistborn"},
 	}
@@ -54,7 +58,7 @@ func TestNormalizeTitle_MatchesNoisyABSTitleToCleanProviderTitle(t *testing.T) {
 
 	pairs := [][2]string{
 		{"The Eye of the World (The Wheel of Time, Book 1)", "The Eye of the World"},
-		{"Pandora's Star: A Novel [Unabridged]", "Pandora's Star"},
+		{"Pandora's Star [Unabridged]", "Pandora’s Star"},
 		{"Leviathan Wakes (The Expanse #1)", "Leviathan Wakes"},
 		{"The Way of Kings [Unabridged]", "The Way of Kings"},
 		{"Project Hail Mary [Unabridged]", "Project Hail Mary"},
@@ -66,6 +70,26 @@ func TestNormalizeTitle_MatchesNoisyABSTitleToCleanProviderTitle(t *testing.T) {
 			t.Errorf("titles must share a dedup key:\n  ABS      %q -> %q\n  provider %q -> %q",
 				pair[0], absKey, pair[1], providerKey)
 		}
+	}
+}
+
+// TestNormalizeTitle_OneSidedSubtitleIsACandidateNotAKey records the #2042
+// division of labour. A subtitle one source spells out and the other drops no
+// longer produces the same key — the key stopped truncating, because
+// truncating is what merged "Star Wars: A New Hope" onto "…The Empire Strikes
+// Back". The pair is still matched, one level up, by indexer.CompareTitles.
+func TestNormalizeTitle_OneSidedSubtitleIsACandidateNotAKey(t *testing.T) {
+	t.Parallel()
+
+	const noisy, clean = "Pandora's Star: A Novel [Unabridged]", "Pandora's Star"
+	if normalizeTitle(noisy) == normalizeTitle(clean) {
+		t.Errorf("key must not truncate the subtitle: both sides folded to %q", normalizeTitle(noisy))
+	}
+	if got := indexer.CompareTitles(noisy, clean); got != indexer.TitlesNeedCorroboration {
+		t.Errorf("CompareTitles(%q, %q) = %v, want needs-corroboration", noisy, clean, got)
+	}
+	if got := indexer.CompareTitles(clean, noisy); got != indexer.TitlesNeedCorroboration {
+		t.Errorf("CompareTitles is not symmetric: %v", got)
 	}
 }
 

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1695,10 +1695,10 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// from it rather than merged in: the seenTitles branches UPDATE the row
 	// they match (dual-format upgrades, calibre-stub adoption, ratings), and an
 	// excluded row is one the user wants left alone, not quietly upgraded.
-	excludedKeys := make(map[string]struct{})
+	excludedKeys := indexer.NewTitleIndex[struct{}]()
 	for i := range allBooks {
 		if allBooks[i].Excluded {
-			excludedKeys[indexer.CanonicalDedupKey(allBooks[i].Title)] = struct{}{}
+			excludedKeys.Add(allBooks[i].Title, struct{}{})
 			continue
 		}
 		existingBooks = append(existingBooks, allBooks[i])
@@ -1710,9 +1710,16 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// "X [Unabridged]" did not match OpenLibrary's "X" here — a second row was
 	// created, and both then carried the same books.dedup_key, violating the
 	// invariant from the inside (#1648).
-	seenTitles := make(map[string]*models.Book)
+	//
+	// indexer.TitleIndex, not a plain map: since #2042 the canonical key no
+	// longer truncates at ": ", so a stored "Mistborn: The Final Empire" and a
+	// provider "Mistborn" hash differently. The index probes the main-title
+	// bucket too and adjudicates with indexer.CompareTitles, so subtitle-only
+	// divergence still matches while "Star Wars: A New Hope" no longer matches
+	// "Star Wars: The Empire Strikes Back".
+	seenTitles := indexer.NewTitleIndex[*models.Book]()
 	for i := range existingBooks {
-		seenTitles[indexer.CanonicalDedupKey(existingBooks[i].Title)] = &existingBooks[i]
+		seenTitles.Add(existingBooks[i].Title, &existingBooks[i])
 	}
 
 	// Discovery policy (#1815). A refresh may always UPDATE the books the
@@ -1953,8 +1960,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		//     behaviour — preserves the pre-#442 upgrade path).
 		//   • A duplicate that carries the same media_type as the existing row is
 		//     truly redundant and is silently skipped (no format gain).
-		dedupKey := indexer.CanonicalDedupKey(b.Title) // must match how seenTitles was keyed
-		if existing := seenTitles[dedupKey]; existing != nil {
+		if existing, seen := seenTitles.Lookup(b.Title); seen && existing != nil {
 			hydrateExistingFromMatchedHardcover := false
 			switch {
 			case strings.HasPrefix(existing.ForeignID, "calibre:"):
@@ -2013,7 +2019,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 		// work whose local row carries a different one — a calibre: stub, a
 		// re-ided provider work — would otherwise be created afresh as a
 		// title the exclusion was meant to cover (#1815).
-		if _, excluded := excludedKeys[dedupKey]; excluded {
+		if _, excluded := excludedKeys.Lookup(b.Title); excluded {
 			skippedExcluded++
 			slog.Debug("skipping newly-discovered work: an excluded book under this author has the same title",
 				"title", b.Title, "foreignId", b.ForeignID, "author", author.Name)
@@ -2025,7 +2031,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 				"title", b.Title, "foreignId", b.ForeignID, "author", author.Name)
 			continue
 		}
-		seenTitles[dedupKey] = &b
+		seenTitles.Add(b.Title, &b)
 
 		// Tenancy (#1457): a new book inherits its author's owner so per-user
 		// scoping sees the sync's output. NULL-owned authors stay NULL-owned.

--- a/internal/db/book_dedup_key_test.go
+++ b/internal/db/book_dedup_key_test.go
@@ -141,8 +141,9 @@ func TestBookRepo_FindByAuthorAndDedupKey_EmptyKeyAndWrongAuthor(t *testing.T) {
 }
 
 // TestBookRepo_FindAllByAuthorAndDedupKey_Ambiguous proves the ABS importer's
-// ambiguity signal: two rows under one author sharing a canonical key are both
-// returned so the caller can route to review instead of guessing.
+// ambiguity signal: two rows under one author that both describe the looked-up
+// work are returned together so the caller routes to review instead of
+// guessing.
 func TestBookRepo_FindAllByAuthorAndDedupKey_Ambiguous(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {
@@ -155,15 +156,121 @@ func TestBookRepo_FindAllByAuthorAndDedupKey_Ambiguous(t *testing.T) {
 	bookRepo := NewBookRepo(database)
 	a := mkAuthor(t, authorRepo, ctx, "OL-AM-A")
 
-	_ = mkBook(t, bookRepo, ctx, a.ID, "OL-AM-1", "Foundation", "wanted")
-	_ = mkBook(t, bookRepo, ctx, a.ID, "OL-AM-2", "Foundation: The Empire", "wanted")
+	// Two rows for one work that already duplicate each other: the punctuation
+	// fold makes them share a canonical key, so neither can be preferred.
+	_ = mkBook(t, bookRepo, ctx, a.ID, "OL-AM-1", "Poseidon's Arrow", "wanted")
+	_ = mkBook(t, bookRepo, ctx, a.ID, "OL-AM-2", "Poseidons Arrow", "imported")
 
-	all, err := bookRepo.FindAllByAuthorAndDedupKey(ctx, a.ID, "foundation")
+	all, err := bookRepo.FindAllByAuthorAndDedupKey(ctx, a.ID, "Poseidon’s Arrow")
 	if err != nil {
 		t.Fatalf("FindAllByAuthorAndDedupKey: %v", err)
 	}
 	if len(all) != 2 {
 		t.Fatalf("expected 2 ambiguous rows, got %d", len(all))
+	}
+}
+
+// TestBookRepo_DedupCandidates_ExactMatchShadowsSubtitleVariant pins the
+// preference rule from #2042: a row whose title matches exactly is not made
+// ambiguous by a sibling that merely shares its main title. Before the rule,
+// "Foundation" and "Foundation: The Empire" both collapsed to the key
+// "foundation" and every lookup for either was ambiguous.
+func TestBookRepo_DedupCandidates_ExactMatchShadowsSubtitleVariant(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-SH-A")
+
+	plain := mkBook(t, bookRepo, ctx, a.ID, "OL-SH-1", "Foundation", "wanted")
+	_ = mkBook(t, bookRepo, ctx, a.ID, "OL-SH-2", "Foundation: The Empire", "wanted")
+
+	all, err := bookRepo.FindAllByAuthorAndDedupKey(ctx, a.ID, "Foundation")
+	if err != nil {
+		t.Fatalf("FindAllByAuthorAndDedupKey: %v", err)
+	}
+	if len(all) != 1 || all[0].ID != plain.ID {
+		t.Fatalf("exact match must shadow the subtitle variant, got %d rows %+v", len(all), all)
+	}
+}
+
+// TestBookRepo_DedupCandidates_DistinctSubtitlesNeverMerge is the #2042 false
+// positive. Two named instalments that share a main title are different books
+// and must never be returned for one another, however the lookup is spelled.
+func TestBookRepo_DedupCandidates_DistinctSubtitlesNeverMerge(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-SW-A")
+
+	hope := mkBook(t, bookRepo, ctx, a.ID, "OL-SW-1", "Star Wars: A New Hope", "imported")
+
+	got, err := bookRepo.FindByAuthorAndDedupKey(ctx, a.ID, "Star Wars: The Empire Strikes Back")
+	if err != nil {
+		t.Fatalf("FindByAuthorAndDedupKey: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("distinct instalments must not match: got %q for %q", got.Title, "Star Wars: The Empire Strikes Back")
+	}
+
+	// The row is still findable by its own title.
+	got, err = bookRepo.FindByAuthorAndDedupKey(ctx, a.ID, "Star Wars: A New Hope")
+	if err != nil {
+		t.Fatalf("FindByAuthorAndDedupKey: %v", err)
+	}
+	if got == nil || got.ID != hope.ID {
+		t.Fatalf("self lookup failed: %+v", got)
+	}
+}
+
+// TestBookRepo_DedupCandidates_PunctuationDivergenceBinds is the #2042 false
+// negative, end to end through the repo: the shapes that produced duplicate
+// `wanted` rows next to `imported` ones in production must now bind.
+func TestBookRepo_DedupCandidates_PunctuationDivergenceBinds(t *testing.T) {
+	cases := []struct {
+		name   string
+		stored string
+		lookup string
+	}{
+		{"apostrophe vs none", "Poseidon's Arrow", "Poseidons Arrow"},
+		{"smart apostrophe vs none", "Poseidon’s Arrow", "Poseidons Arrow"},
+		{"colon vs no colon", "Journey of the Pharaohs: Numa Files #17", "Journey of the Pharaohs Numa Files #17"},
+		{"one-sided subtitle", "The Eye of the World: Book One of The Wheel of Time", "The Eye of the World"},
+		{"one-sided subtitle reversed", "The Midnight Line", "The Midnight Line: A Jack Reacher Novel"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			database, err := OpenMemory()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer database.Close()
+			ctx := context.Background()
+
+			authorRepo := NewAuthorRepo(database)
+			bookRepo := NewBookRepo(database)
+			a := mkAuthor(t, authorRepo, ctx, "OL-PD-"+tc.name)
+			b := mkBook(t, bookRepo, ctx, a.ID, "OL-PD-B-"+tc.name, tc.stored, "imported")
+
+			got, err := bookRepo.FindByAuthorAndDedupKey(ctx, a.ID, tc.lookup)
+			if err != nil {
+				t.Fatalf("FindByAuthorAndDedupKey: %v", err)
+			}
+			if got == nil || got.ID != b.ID {
+				t.Fatalf("stored %q not found via lookup %q (got %+v)", tc.stored, tc.lookup, got)
+			}
+		})
 	}
 }
 

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -855,14 +855,11 @@ func (r *BookRepo) FindByAuthorAndTitle(ctx context.Context, authorID int64, tit
 // an author into one. A row whose stored dedup_key is still NULL/empty
 // (pre-backfill) likewise cannot match a non-empty computed key, so it is never
 // falsely merged.
+//
+// When several rows qualify, an exact-key match is returned in preference to a
+// subtitle-divergent one; see dedupCandidates.
 func (r *BookRepo) FindByAuthorAndDedupKey(ctx context.Context, authorID int64, title string) (*models.Book, error) {
-	key := indexer.CanonicalDedupKey(title)
-	if key == "" {
-		return nil, nil
-	}
-	books, err := r.query(ctx,
-		bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE author_id = ? AND books.dedup_key = ?",
-		[]any{authorID, key})
+	books, err := r.dedupCandidates(ctx, authorID, title)
 	if err != nil {
 		return nil, err
 	}
@@ -872,18 +869,78 @@ func (r *BookRepo) FindByAuthorAndDedupKey(ctx context.Context, authorID int64, 
 	return &books[0], nil
 }
 
-// FindAllByAuthorAndDedupKey returns every book under authorID matching the
-// canonical key for `title`. The ABS importer uses it to detect the *ambiguous*
-// case (more than one local row shares the key) and route to review instead of
+// FindAllByAuthorAndDedupKey returns every book under authorID that describes
+// the same work as `title`. The ABS importer uses it to detect the *ambiguous*
+// case (more than one local row qualifies) and route to review instead of
 // guessing which row to bind.
 func (r *BookRepo) FindAllByAuthorAndDedupKey(ctx context.Context, authorID int64, title string) ([]models.Book, error) {
+	return r.dedupCandidates(ctx, authorID, title)
+}
+
+// dedupCandidates is the shared two-tier work-identity lookup behind both
+// FindByAuthorAndDedupKey and FindAllByAuthorAndDedupKey (#2042).
+//
+// The stored dedup_key is lossless — it never truncates a subtitle — so an
+// equality probe alone would miss the very real case where one source spells
+// out a subtitle the other drops ("Mistborn: The Final Empire" from Calibre vs
+// "Mistborn" from an audiobook shelf). Candidates are therefore gathered on
+// three index-friendly predicates against books(author_id, dedup_key):
+//
+//  1. dedup_key = <canonical key>   — the same work, spelled the same way;
+//  2. dedup_key = <main-title key>  — the stored row dropped the subtitle;
+//  3. dedup_key in [main+" ", main+"!") — the stored row carries a subtitle
+//     this title omits. The bound is a prefix range rather than a LIKE so
+//     SQLite uses the index; '!' is the byte after ' ', and keys are
+//     space-normalized, so the range is exactly "main followed by more words".
+//
+// Predicates 2 and 3 are deliberately over-inclusive — "The Eye of the World"
+// prefix-matches "The Eye of the World War". Every candidate is therefore
+// re-adjudicated in Go by indexer.CompareTitles against the stored title, and
+// anything it calls TitlesDifferent is dropped. That is what stops the old
+// truncating key from merging "Star Wars: A New Hope" onto "Star Wars: The
+// Empire Strikes Back".
+//
+// Exact (TitlesSame) matches shadow TitlesNeedCorroboration ones: if any row is
+// an unambiguous match, the weaker candidates are not returned at all. This
+// keeps the ABS ambiguity check honest — one exact match plus one
+// subtitle-divergent near-miss is not an ambiguous pair.
+//
+// Callers that reach the TitlesNeedCorroboration tier are choosing to bind on a
+// one-sided subtitle. The ABS importer corroborates with series name and
+// sequence before accepting (see findBookByNormalizedTitle); callers without a
+// corroborating signal (Calibre, the API add-book path) accept it, which
+// preserves the pre-#2042 behaviour for that case — it is overwhelmingly one
+// work whose publisher subtitle one source omitted.
+func (r *BookRepo) dedupCandidates(ctx context.Context, authorID int64, title string) ([]models.Book, error) {
 	key := indexer.CanonicalDedupKey(title)
 	if key == "" {
 		return nil, nil
 	}
-	return r.query(ctx,
-		bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE author_id = ? AND books.dedup_key = ?",
-		[]any{authorID, key})
+	mainKey := indexer.MainTitleKey(title)
+	if mainKey == "" {
+		mainKey = key
+	}
+	books, err := r.query(ctx,
+		bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+
+			" WHERE author_id = ? AND (books.dedup_key = ? OR books.dedup_key = ?"+
+			" OR (books.dedup_key >= ? AND books.dedup_key < ?))",
+		[]any{authorID, key, mainKey, mainKey + " ", mainKey + "!"})
+	if err != nil {
+		return nil, err
+	}
+	var exact, corroborate []models.Book
+	for i := range books {
+		switch indexer.CompareTitles(title, books[i].Title) {
+		case indexer.TitlesSame:
+			exact = append(exact, books[i])
+		case indexer.TitlesNeedCorroboration:
+			corroborate = append(corroborate, books[i])
+		}
+	}
+	if len(exact) > 0 {
+		return exact, nil
+	}
+	return corroborate, nil
 }
 
 // SetExcluded toggles the excluded flag on a book.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -363,6 +363,23 @@ func backfillAuthorSortKeys(database *sql.DB) error {
 // risky (file ownership, edition links, provenance) and is left as a follow-up.
 // Writing keys is safe: at worst two pre-existing dupes now share a key, which
 // only makes future imports bind to one of them instead of creating a third.
+//
+// #2042 changed the normalizer, so the first boot after that upgrade rewrites
+// most rows. Two shapes are worth knowing about, and neither needs a migration
+// because the key is derived from books.title, which is untouched:
+//
+//   - Rows that duplicate each other today ("Poseidon's Arrow" beside
+//     "Poseidons Arrow") converge onto ONE key. They stay two rows — this
+//     function does not merge — but the ABS importer now sees them as an
+//     ambiguous pair and routes to review rather than compounding the problem,
+//     and no further duplicate is created for that work.
+//   - Rows the old truncating key wrongly merged ("Star Wars: A New Hope" and
+//     "…The Empire Strikes Back" both keyed "star wars") separate onto distinct
+//     keys. That is the correction, not a regression: they were always distinct
+//     books, and the shared key is what let an import bind one onto the other.
+//
+// Repairing libraries already duplicated by the old key is a separate piece of
+// work; the fix here stops new duplicates being created.
 func backfillBookDedupKeys(database *sql.DB) error {
 	type pending struct {
 		id  int64

--- a/internal/indexer/dedup.go
+++ b/internal/indexer/dedup.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"regexp"
 	"strings"
+	"unicode"
 
 	"golang.org/x/text/unicode/norm"
 
@@ -14,29 +15,81 @@ import (
 // deduplication key when comparing book rows. The normalization is applied
 // symmetrically: both when seeding the "already-seen" set from existing DB
 // rows and when keying incoming provider results. This guarantees that two
-// rows for the same work only differ in edition qualifier, whitespace,
-// Unicode form, or umlaut representation are collapsed to the same key.
+// rows for the same work which differ only in edition qualifier, whitespace,
+// punctuation, Unicode form, or umlaut representation are collapsed to the
+// same key.
 //
 // Steps applied (in order):
 //  1. Unicode NFC — composes combining characters into precomposed forms,
-//     so "é" (NFD) and "é" (NFC) produce the same key.
+//     so "é" (NFD) and "é" (NFC) produce the same key.
 //  2. newznab.NormalizeQueryTitle — folds smart quotes to ASCII, strips a
 //     trailing parenthesised edition qualifier ("(German Edition)" etc.),
 //     and collapses internal whitespace.
-//  3. stripSubtitle — drops a ": subtitle" tail so editions that differ
-//     only in whether the subtitle is present (audiobooks often drop it)
-//     produce the same key.
+//  3. foldPunctuation — deletes apostrophes and turns every other
+//     non-alphanumeric into a space (see foldPunctuation for why the two
+//     classes must be treated differently).
 //  4. strings.ToLower — case-insensitive match.
-//  5. transliterateUmlauts — maps ä→ae, ö→oe, ü→ue, ß→ss so that
+//  5. TransliterateUmlauts — maps ä→ae, ö→oe, ü→ue, ß→ss so that
 //     "Geraeusch" from a release title compares equal to "Geräusch" from
 //     the metadata provider.
+//
+// The key is LOSSLESS with respect to word content: it never truncates. An
+// earlier version dropped everything after the first ": " (see #2042), which
+// made the key both over- and under-inclusive at the same time — over,
+// because "Star Wars: A New Hope" and "Star Wars: The Empire Strikes Back"
+// became one key; under, because a provider that omits the colon
+// ("Journey of the Pharaohs Numa Files #17") could never meet the form that
+// keeps it. Subtitle-only divergence is now handled one level up, by
+// CompareTitles, which can say "probably, but corroborate" instead of being
+// forced into a yes/no by a lossy string.
 func NormalizeTitleForDedup(title string) string {
 	title = norm.NFC.String(title)
 	title = newznab.NormalizeQueryTitle(title)
-	title = stripSubtitle(title)
+	title = foldPunctuation(title)
 	title = strings.ToLower(title)
 	title = textutil.TransliterateUmlauts(title)
 	return title
+}
+
+// foldPunctuation removes punctuation disagreements between providers, which
+// are routine and carry no meaning. The two character classes must be handled
+// differently and getting it backwards is silently wrong:
+//
+//   - Apostrophes (ASCII ', backtick, and the U+2018/U+2019/U+02BC curly
+//     forms) are INTRA-word and are DELETED, so "Poseidon's Arrow" folds onto
+//     "Poseidons Arrow". Replacing them with a space instead yields
+//     "poseidon s arrow", which matches neither spelling.
+//   - Every other non-alphanumeric rune (colon, hyphen, comma, '#', em dash,
+//     ampersand, …) is a SEPARATOR and becomes a space. This is what lets
+//     "Journey of the Pharaohs: Numa Files #17" and
+//     "Journey of the Pharaohs Numa Files #17" produce one key: the colon
+//     stops being a distinction rather than becoming a truncation point.
+//
+// Letters and digits are kept as-is, including non-ASCII ones, so accented
+// forms survive to be folded by the NFC and umlaut steps around this call.
+// Runs of whitespace are collapsed and the result trimmed.
+func foldPunctuation(title string) string {
+	var b strings.Builder
+	b.Grow(len(title))
+	for _, r := range title {
+		switch {
+		case isApostrophe(r):
+			// Deleted, not replaced — see the doc comment.
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+		default:
+			b.WriteRune(' ')
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func isApostrophe(r rune) bool {
+	switch r {
+	case '\'', '`', '‘', '’', 'ʼ':
+		return true
+	}
+	return false
 }
 
 // bracketSuffixRe matches one trailing square-bracketed qualifier. Provider
@@ -68,22 +121,197 @@ func StripBracketSuffixes(title string) string {
 // ABS matched on a normalized in-memory key) cannot recur.
 //
 // It strips trailing bracketed qualifiers first (ABS-style "[Unabridged]"),
-// then applies NormalizeTitleForDedup (paren-suffix strip, subtitle strip,
+// then applies NormalizeTitleForDedup (paren-suffix strip, punctuation fold,
 // whitespace/Unicode/umlaut folding, lowercasing). The result is
 // case-insensitive and stable, so it is stored verbatim and compared with =.
+//
+// Key equality means SAME WORK, with no further evidence required. It does NOT
+// mean the converse: two rows for one work can hold different keys when one
+// side carries a subtitle the other omits. That case is a *candidate*, not a
+// match, and belongs to CompareTitles / MainTitleKey — see #2042.
 func CanonicalDedupKey(title string) string {
 	return NormalizeTitleForDedup(StripBracketSuffixes(strings.TrimSpace(title)))
 }
 
-// stripSubtitle removes a trailing ": subtitle" segment when the colon is
-// followed by whitespace. Collapses editions that vary only in whether the
-// subtitle is present (e.g. audiobook drops it, ebook keeps it). Compact
-// titles like "foo:bar" with no whitespace after the colon are left intact.
-func stripSubtitle(title string) string {
-	for i := 0; i < len(title)-1; i++ {
-		if title[i] == ':' && (title[i+1] == ' ' || title[i+1] == '\t') {
-			return strings.TrimSpace(title[:i])
+// MainTitleKey is the canonical key of the title with any ": subtitle" tail
+// removed. It is the BLOCKING key: two rows for the same work always share it,
+// including when one side spells out a subtitle the other drops. It is
+// deliberately weaker than CanonicalDedupKey — "Star Wars: A New Hope" and
+// "Star Wars: The Empire Strikes Back" share a main-title key and are still
+// different books — so it is only ever used to gather candidates that
+// CompareTitles then adjudicates. Never store it as an identity.
+//
+// For a title with no subtitle, MainTitleKey == CanonicalDedupKey.
+func MainTitleKey(title string) string {
+	main, _ := SplitSubtitle(title)
+	return NormalizeTitleForDedup(main)
+}
+
+// SplitSubtitle splits a title into its main part and its subtitle at the
+// first ": " (colon followed by whitespace), after trailing bracketed and
+// parenthesised qualifiers have been removed so that
+// "Mistborn: The Final Empire [Unabridged]" yields ("Mistborn", "The Final
+// Empire") rather than leaking the tag into the subtitle. A compact "foo:bar"
+// with no whitespace after the colon is not a subtitle and is left whole.
+// The returned subtitle is "" when the title carries none.
+func SplitSubtitle(title string) (main, subtitle string) {
+	cleaned := newznab.NormalizeQueryTitle(norm.NFC.String(StripBracketSuffixes(strings.TrimSpace(title))))
+	for i := 0; i < len(cleaned)-1; i++ {
+		if cleaned[i] == ':' && (cleaned[i+1] == ' ' || cleaned[i+1] == '\t') {
+			return strings.TrimSpace(cleaned[:i]), strings.TrimSpace(cleaned[i+1:])
 		}
 	}
-	return title
+	return cleaned, ""
+}
+
+// TitleVerdict is the outcome of comparing two titles for the same author. It
+// is deliberately three-valued: the two-valued question "are these the same
+// book?" cannot be answered from a title pair alone when exactly one side
+// carries a subtitle, and forcing an answer is what produced both bugs in
+// #2042.
+type TitleVerdict int
+
+const (
+	// TitlesDifferent means the pair is positively known to be two works.
+	// Callers must not merge them.
+	TitlesDifferent TitleVerdict = iota
+	// TitlesSame means the canonical keys are equal: one work, no further
+	// evidence needed.
+	TitlesSame
+	// TitlesNeedCorroboration means the pair shares a main title but exactly
+	// one side carries a subtitle ("The Eye of the World" vs "The Eye of the
+	// World: Book One of The Wheel of Time"). That is usually one work with a
+	// publisher subtitle the other source dropped, and occasionally two. A
+	// caller that has a corroborating signal — series name plus sequence,
+	// ISBN, ASIN — MUST use it. A caller with no such signal must make its
+	// choice explicitly and document it; it must never silently treat this as
+	// TitlesSame without saying so.
+	TitlesNeedCorroboration
+)
+
+func (v TitleVerdict) String() string {
+	switch v {
+	case TitlesSame:
+		return "same"
+	case TitlesNeedCorroboration:
+		return "needs-corroboration"
+	default:
+		return "different"
+	}
+}
+
+// CompareTitles decides whether two titles (already known to share an author)
+// describe the same work. It is symmetric: CompareTitles(a, b) always equals
+// CompareTitles(b, a).
+//
+// The rules, in order:
+//
+//	canonical keys equal                    → TitlesSame
+//	main-title keys differ                  → TitlesDifferent
+//	both sides have subtitles, and they
+//	  differ (implied by the first rule)     → TitlesDifferent
+//	exactly one side has a subtitle          → TitlesNeedCorroboration
+//
+// A blank key on either side is never a match: an untitled row must not
+// collapse onto every other untitled row.
+func CompareTitles(a, b string) TitleVerdict {
+	ka, kb := CanonicalDedupKey(a), CanonicalDedupKey(b)
+	if ka == "" || kb == "" {
+		return TitlesDifferent
+	}
+	if ka == kb {
+		return TitlesSame
+	}
+	mainA, subA := SplitSubtitle(a)
+	mainB, subB := SplitSubtitle(b)
+	if NormalizeTitleForDedup(mainA) != NormalizeTitleForDedup(mainB) {
+		return TitlesDifferent
+	}
+	// Main titles agree but the full keys do not, so at least one subtitle is
+	// present. If both are, they must differ — two named instalments of one
+	// series ("Star Wars: A New Hope" / ": The Empire Strikes Back"). That is
+	// the false-positive the old truncating key merged.
+	if subA != "" && subB != "" {
+		return TitlesDifferent
+	}
+	return TitlesNeedCorroboration
+}
+
+// TitleIndex is the in-memory equivalent of the two-tier lookup the book repo
+// performs in SQL: a set of titles that can be probed for "do I already have
+// this work?" without a database round trip.
+//
+// A plain map[CanonicalDedupKey]T is not sufficient any more. The canonical key
+// is lossless, so a stored "Mistborn: The Final Empire" and an incoming
+// "Mistborn" hash to different buckets even though they are one work. The index
+// therefore keeps a second bucket keyed by MainTitleKey and adjudicates
+// collisions with CompareTitles, exactly as dedupCandidates does.
+//
+// Lookup prefers an exact (TitlesSame) hit and only falls back to a
+// TitlesNeedCorroboration one, so a subtitled near-miss can never shadow the
+// row that actually matches. As in SQL, callers reaching the fallback tier are
+// accepting a one-sided subtitle as the same work; that is the pre-#2042
+// behaviour and is right far more often than not.
+type TitleIndex[T any] struct {
+	exact  map[string]T
+	byMain map[string][]titleEntry[T]
+}
+
+type titleEntry[T any] struct {
+	title string
+	value T
+}
+
+// NewTitleIndex returns an empty index.
+func NewTitleIndex[T any]() *TitleIndex[T] {
+	return &TitleIndex[T]{
+		exact:  make(map[string]T),
+		byMain: make(map[string][]titleEntry[T]),
+	}
+}
+
+// Add records title → value. A repeated canonical key overwrites, matching the
+// last-writer-wins semantics of the plain map this type replaces. Titles with
+// an empty canonical key are ignored: an untitled row must not become a match
+// for every other untitled row.
+func (ix *TitleIndex[T]) Add(title string, value T) {
+	key := CanonicalDedupKey(title)
+	if key == "" {
+		return
+	}
+	ix.exact[key] = value
+	if main := MainTitleKey(title); main != "" && main != key {
+		ix.byMain[main] = append(ix.byMain[main], titleEntry[T]{title: title, value: value})
+	}
+}
+
+// Lookup returns the value recorded for a title describing the same work, and
+// whether one was found.
+func (ix *TitleIndex[T]) Lookup(title string) (T, bool) {
+	var zero T
+	key := CanonicalDedupKey(title)
+	if key == "" {
+		return zero, false
+	}
+	if v, ok := ix.exact[key]; ok {
+		return v, true
+	}
+	main := MainTitleKey(title)
+	if main == "" {
+		return zero, false
+	}
+	// The incoming title carries a subtitle the stored row dropped: its main
+	// key is that row's canonical key.
+	if main != key {
+		if v, ok := ix.exact[main]; ok {
+			return v, true
+		}
+	}
+	// The stored row carries a subtitle this title omits.
+	for _, e := range ix.byMain[main] {
+		if CompareTitles(title, e.title) != TitlesDifferent {
+			return e.value, true
+		}
+	}
+	return zero, false
 }

--- a/internal/indexer/dedup_subtitle_test.go
+++ b/internal/indexer/dedup_subtitle_test.go
@@ -1,0 +1,296 @@
+package indexer
+
+import "testing"
+
+// TestCanonicalDedupKey_NeverTruncates is the characterisation test for #2042.
+// It fails loudly if anyone reintroduces subtitle truncation into the canonical
+// key.
+//
+// The old key dropped everything after the first ": ". That single decision
+// produced BOTH reported failure modes at once:
+//
+//   - a false positive — "Star Wars: A New Hope" and "Star Wars: The Empire
+//     Strikes Back" both became "star wars", so two different books shared one
+//     identity and an import bound one onto the other;
+//   - a false negative — "Journey of the Pharaohs: Numa Files #17" became
+//     "journey of the pharaohs" while the colon-less spelling of the same book
+//     kept every word, so the two could never meet and a duplicate `wanted`
+//     row landed beside an `imported` one.
+//
+// If you are here because this test failed, you have made the key lossy again.
+// Subtitle-only divergence is handled by CompareTitles, which can return
+// TitlesNeedCorroboration; the key itself must stay an identity.
+func TestCanonicalDedupKey_NeverTruncates(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Star Wars: A New Hope", "star wars a new hope"},
+		{"Star Wars: The Empire Strikes Back", "star wars the empire strikes back"},
+		{"Journey of the Pharaohs: Numa Files #17", "journey of the pharaohs numa files 17"},
+		{"The Eye of the World: Book One of The Wheel of Time", "the eye of the world book one of the wheel of time"},
+		{"Mistborn: The Final Empire", "mistborn the final empire"},
+		// The tail survives even when a bracketed qualifier follows it.
+		{"Pandora's Star: A Novel [Unabridged]", "pandoras star a novel"},
+	}
+	for _, tc := range cases {
+		if got := CanonicalDedupKey(tc.in); got != tc.want {
+			t.Errorf("CanonicalDedupKey(%q) = %q, want %q\n"+
+				"the canonical key must not truncate at \": \" — see #2042", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestCanonicalDedupKey_FoldsPunctuationDivergence is the false-negative half
+// of #2042, at the level of the key. Both shapes observed in production must
+// now produce one key in both directions.
+func TestCanonicalDedupKey_FoldsPunctuationDivergence(t *testing.T) {
+	pairs := [][2]string{
+		{"Poseidon's Arrow", "Poseidons Arrow"},
+		{"Poseidon’s Arrow", "Poseidons Arrow"},
+		{"Poseidon’s Arrow", "Poseidon's Arrow"},
+		{"Journey of the Pharaohs: Numa Files #17", "Journey of the Pharaohs Numa Files #17"},
+		{"Journey of the Pharaohs: Numa Files #17", "Journey of the Pharaohs — Numa Files 17"},
+	}
+	for _, p := range pairs {
+		a, b := CanonicalDedupKey(p[0]), CanonicalDedupKey(p[1])
+		if a != b {
+			t.Errorf("punctuation divergence not folded:\n  %q → %q\n  %q → %q", p[0], a, p[1], b)
+		}
+		// Symmetry: the fold cannot depend on argument order.
+		if CanonicalDedupKey(p[1]) != b {
+			t.Errorf("CanonicalDedupKey is not deterministic for %q", p[1])
+		}
+	}
+}
+
+// TestCanonicalDedupKey_ApostrophesAreDeletedNotSpaced pins the one detail of
+// the punctuation policy that is easy to get backwards. An apostrophe is
+// intra-word: replacing it with a space yields "poseidon s arrow", which
+// matches neither spelling and would silently make the bug worse.
+func TestCanonicalDedupKey_ApostrophesAreDeletedNotSpaced(t *testing.T) {
+	for _, in := range []string{"Poseidon's Arrow", "Poseidon’s Arrow", "Poseidon`s Arrow", "Poseidonʼs Arrow"} {
+		if got, want := CanonicalDedupKey(in), "poseidons arrow"; got != want {
+			t.Errorf("CanonicalDedupKey(%q) = %q, want %q (apostrophes are deleted, never spaced)", in, got, want)
+		}
+	}
+}
+
+// TestCompareTitles is the decision table. Every case is asserted in both
+// directions, because an asymmetric verdict would make dedup depend on import
+// order — the exact class of bug #940 and #2042 are both instances of.
+func TestCompareTitles(t *testing.T) {
+	cases := []struct {
+		name string
+		a    string
+		b    string
+		want TitleVerdict
+	}{
+		{
+			name: "apostrophe divergence is one work",
+			a:    "Poseidon's Arrow",
+			b:    "Poseidons Arrow",
+			want: TitlesSame,
+		},
+		{
+			name: "smart apostrophe divergence is one work",
+			a:    "Poseidon’s Arrow",
+			b:    "Poseidons Arrow",
+			want: TitlesSame,
+		},
+		{
+			name: "colon vs no colon is one work",
+			a:    "Journey of the Pharaohs: Numa Files #17",
+			b:    "Journey of the Pharaohs Numa Files #17",
+			want: TitlesSame,
+		},
+		{
+			name: "identical titles are one work",
+			a:    "Blue Moon: A Jack Reacher Novel",
+			b:    "Blue Moon: A Jack Reacher Novel",
+			want: TitlesSame,
+		},
+		{
+			// The #2042 false positive. The old key merged these.
+			name: "two named instalments of one series are different",
+			a:    "Star Wars: A New Hope",
+			b:    "Star Wars: The Empire Strikes Back",
+			want: TitlesDifferent,
+		},
+		{
+			name: "different main titles are different",
+			a:    "Cross Fire",
+			b:    "Cross Justice",
+			want: TitlesDifferent,
+		},
+		{
+			name: "one-sided publisher subtitle needs corroboration",
+			a:    "The Eye of the World",
+			b:    "The Eye of the World: Book One of The Wheel of Time",
+			want: TitlesNeedCorroboration,
+		},
+		{
+			name: "one-sided series subtitle needs corroboration",
+			a:    "The Midnight Line: A Jack Reacher Novel",
+			b:    "The Midnight Line",
+			want: TitlesNeedCorroboration,
+		},
+		{
+			name: "bracketed qualifier does not create a subtitle",
+			a:    "The Eye of the World [Unabridged]",
+			b:    "The Eye of the World",
+			want: TitlesSame,
+		},
+		{
+			name: "subtitle plus bracket tag vs bare title",
+			a:    "Pandora's Star: A Novel [Unabridged]",
+			b:    "Pandora’s Star",
+			want: TitlesNeedCorroboration,
+		},
+		{
+			// Without a colon the tail is part of the title, not a
+			// subtitle, so there is no evidence they are one work.
+			name: "extra words with no colon are a different title",
+			a:    "Mistborn",
+			b:    "Mistborn The Final Empire",
+			want: TitlesDifferent,
+		},
+		{
+			name: "a prefix of a longer main title is different",
+			a:    "The Eye of the World",
+			b:    "The Eye of the World War: A History",
+			want: TitlesDifferent,
+		},
+		{
+			name: "blank titles never match",
+			a:    "   ",
+			b:    "   ",
+			want: TitlesDifferent,
+		},
+		{
+			name: "blank never matches a real title",
+			a:    "",
+			b:    "Dune",
+			want: TitlesDifferent,
+		},
+		{
+			name: "umlaut transliteration still folds",
+			a:    "Die Straße: Ein Roman",
+			b:    "Die Strasse: Ein Roman",
+			want: TitlesSame,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CompareTitles(tc.a, tc.b); got != tc.want {
+				t.Errorf("CompareTitles(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+			if got := CompareTitles(tc.b, tc.a); got != tc.want {
+				t.Errorf("CompareTitles(%q, %q) = %v, want %v (asymmetric!)", tc.b, tc.a, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMainTitleKey covers the blocking key used to gather candidates. It is
+// deliberately weaker than the canonical key and must never be stored as an
+// identity — this test documents exactly how weak it is.
+func TestMainTitleKey(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Star Wars: A New Hope", "star wars"},
+		{"Star Wars: The Empire Strikes Back", "star wars"},
+		{"Star Wars", "star wars"},
+		{"Mistborn: The Final Empire [Unabridged]", "mistborn"},
+		{"Poseidon's Arrow", "poseidons arrow"},
+		{"foo:bar", "foo bar"},
+	}
+	for _, tc := range cases {
+		if got := MainTitleKey(tc.in); got != tc.want {
+			t.Errorf("MainTitleKey(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// The whole point: a shared main-title key is NOT an identity.
+	if MainTitleKey("Star Wars: A New Hope") != MainTitleKey("Star Wars: The Empire Strikes Back") {
+		t.Fatal("precondition: the two Star Wars titles must share a main-title key")
+	}
+	if CompareTitles("Star Wars: A New Hope", "Star Wars: The Empire Strikes Back") != TitlesDifferent {
+		t.Error("a shared main-title key must not be treated as a match")
+	}
+}
+
+func TestSplitSubtitle(t *testing.T) {
+	cases := []struct{ in, main, sub string }{
+		{"Mistborn: The Final Empire", "Mistborn", "The Final Empire"},
+		{"Mistborn: The Final Empire [Unabridged]", "Mistborn", "The Final Empire"},
+		{"Mistborn", "Mistborn", ""},
+		{"foo:bar", "foo:bar", ""},
+		{"A: B: C", "A", "B: C"},
+		{"  Dune (Unabridged)  ", "Dune", ""},
+	}
+	for _, tc := range cases {
+		main, sub := SplitSubtitle(tc.in)
+		if main != tc.main || sub != tc.sub {
+			t.Errorf("SplitSubtitle(%q) = (%q, %q), want (%q, %q)", tc.in, main, sub, tc.main, tc.sub)
+		}
+	}
+}
+
+// TestTitleIndex_MirrorsCompareTitles proves the in-memory index reaches the
+// same verdicts as the SQL lookup, so the author-refresh path and the importer
+// path cannot drift apart.
+func TestTitleIndex_MirrorsCompareTitles(t *testing.T) {
+	ix := NewTitleIndex[string]()
+	ix.Add("Poseidon's Arrow", "poseidon")
+	ix.Add("Star Wars: A New Hope", "hope")
+	ix.Add("The Eye of the World: Book One of The Wheel of Time", "eotw")
+	ix.Add("The Midnight Line", "midnight")
+	ix.Add("   ", "blank")
+
+	cases := []struct {
+		lookup string
+		want   string
+		found  bool
+	}{
+		{"Poseidons Arrow", "poseidon", true},
+		{"Poseidon’s Arrow", "poseidon", true},
+		{"Star Wars: A New Hope", "hope", true},
+		// The #2042 false positive must not resolve through the index either.
+		{"Star Wars: The Empire Strikes Back", "", false},
+		// Stored row carries the subtitle, lookup drops it.
+		{"The Eye of the World", "eotw", true},
+		// Stored row drops the subtitle, lookup carries it.
+		{"The Midnight Line: A Jack Reacher Novel", "midnight", true},
+		{"Cross Justice", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := ix.Lookup(tc.lookup)
+		if ok != tc.found || got != tc.want {
+			t.Errorf("Lookup(%q) = (%q, %v), want (%q, %v)", tc.lookup, got, ok, tc.want, tc.found)
+		}
+	}
+}
+
+// TestTitleIndex_ExactMatchWins guards the preference rule: a subtitle-divergent
+// near-miss must never shadow the row that matches exactly, regardless of
+// insertion order.
+func TestTitleIndex_ExactMatchWins(t *testing.T) {
+	for _, order := range []string{"near-first", "exact-first"} {
+		t.Run(order, func(t *testing.T) {
+			ix := NewTitleIndex[string]()
+			if order == "near-first" {
+				ix.Add("Foundation: The Empire", "near")
+				ix.Add("Foundation", "exact")
+			} else {
+				ix.Add("Foundation", "exact")
+				ix.Add("Foundation: The Empire", "near")
+			}
+			if got, ok := ix.Lookup("Foundation"); !ok || got != "exact" {
+				t.Errorf("Lookup(Foundation) = (%q, %v), want exact", got, ok)
+			}
+			if got, ok := ix.Lookup("Foundation: The Empire"); !ok || got != "near" {
+				t.Errorf("Lookup(Foundation: The Empire) = (%q, %v), want near", got, ok)
+			}
+		})
+	}
+}

--- a/internal/indexer/dedup_test.go
+++ b/internal/indexer/dedup_test.go
@@ -19,14 +19,19 @@ func TestNormalizeTitleForDedup(t *testing.T) {
 			want: "dune",
 		},
 		{
-			name: "smart curly quote folded",
+			name: "smart curly apostrophe deleted",
 			in:   "Ender’s Game",
-			want: "ender's game",
+			want: "enders game",
 		},
 		{
-			name: "em-dash folded to hyphen",
+			name: "ascii apostrophe deleted",
+			in:   "Ender's Game",
+			want: "enders game",
+		},
+		{
+			name: "em-dash becomes a separator",
 			in:   "Title — Subtitle",
-			want: "title - subtitle",
+			want: "title subtitle",
 		},
 		{
 			name: "leading and trailing whitespace stripped",
@@ -60,19 +65,26 @@ func TestNormalizeTitleForDedup(t *testing.T) {
 			want: "die stille ist ein geraeusch",
 		},
 		{
-			name: "post-colon subtitle stripped",
+			// #2042: the key no longer truncates. Truncating discarded
+			// exactly the words that tell two instalments apart.
+			name: "post-colon subtitle retained",
 			in:   "Carl's Doomsday Scenario: Dungeon Crawler Carl, Book 2",
-			want: "carl's doomsday scenario",
+			want: "carls doomsday scenario dungeon crawler carl book 2",
 		},
 		{
 			name: "title without colon unchanged",
 			in:   "Carl's Doomsday Scenario",
-			want: "carl's doomsday scenario",
+			want: "carls doomsday scenario",
 		},
 		{
-			name: "colon without trailing whitespace preserved",
+			name: "compact colon is a separator too",
 			in:   "foo:bar",
-			want: "foo:bar",
+			want: "foo bar",
+		},
+		{
+			name: "hash and colon fold to the same spacing",
+			in:   "Journey of the Pharaohs: Numa Files #17",
+			want: "journey of the pharaohs numa files 17",
 		},
 	}
 	for _, tc := range cases {
@@ -96,7 +108,7 @@ func TestCanonicalDedupKey(t *testing.T) {
 	}{
 		{"The Eye of the World [Unabridged]", "the eye of the world"},
 		{"The Eye of the World", "the eye of the world"},
-		{"Mistborn: The Final Empire", "mistborn"},
+		{"Mistborn: The Final Empire", "mistborn the final empire"},
 		{"Mistborn", "mistborn"},
 		{"Dune (Unabridged) [Audiobook]", "dune"},
 		{"Die Straße", "die strasse"},
@@ -114,10 +126,11 @@ func TestCanonicalDedupKey(t *testing.T) {
 // titles for the same work, in either order, produce the same key.
 func TestCanonicalDedupKey_Symmetric(t *testing.T) {
 	pairs := [][2]string{
-		{"Mistborn: The Final Empire", "Mistborn"},
 		{"The Eye of the World [Unabridged]", "the eye of the world"},
 		{"Dune (Unabridged)", "Dune [Audiobook]"},
-		{"Die Straße: Ein Roman", "Die Strasse"},
+		{"Die Straße: Ein Roman", "Die Strasse: Ein Roman"},
+		{"Poseidon's Arrow", "Poseidons Arrow"},
+		{"Journey of the Pharaohs: Numa Files #17", "Journey of the Pharaohs Numa Files #17"},
 	}
 	for _, p := range pairs {
 		if a, b := CanonicalDedupKey(p[0]), CanonicalDedupKey(p[1]); a != b {
@@ -134,7 +147,7 @@ func TestNormalizeTitleForDedup_Symmetric(t *testing.T) {
 		{"Dune (Unabridged)", "Dune"},
 		{"  Moby Dick  ", "Moby Dick"},
 		{"Öde Wälder (German Edition)", "Öde Wälder"},
-		{"Carl's Doomsday Scenario", "Carl's Doomsday Scenario: Dungeon Crawler Carl, Book 2"},
+		{"Carl's Doomsday Scenario", "Carl’s Doomsday Scenario"},
 	}
 	for _, pair := range pairs {
 		k1 := NormalizeTitleForDedup(pair[0])


### PR DESCRIPTION
## Summary

`indexer.CanonicalDedupKey` decided work identity by lowercasing a title and discarding everything after the first `": "`. That one decision produced **both** of #2042's reported duplicates and, unreported, a false *positive* that is arguably worse. Closes #2042.

I reproduced all three against `main` (d14206d) by calling the real `CanonicalDedupKey`:

```
"Poseidon's Arrow"                        -> "poseidon's arrow"
"Poseidons Arrow"                         -> "poseidons arrow"                        MATCH=false
"Journey of the Pharaohs: Numa Files #17" -> "journey of the pharaohs"
"Journey of the Pharaohs Numa Files #17"  -> "journey of the pharaohs numa files #17" MATCH=false
"Star Wars: A New Hope"                   -> "star wars"
"Star Wars: The Empire Strikes Back"      -> "star wars"                              MATCH=true   <-- FALSE POSITIVE
```

**Mechanism.** Two root causes, both in `NormalizeTitleForDedup`:

1. `newznab.NormalizeQueryTitle` folds `U+2019` to ASCII `'` but never removes it, so apostrophe-divergent spellings can never meet.
2. `stripSubtitle` truncates at the first `": "`. Truncation is destructive and asymmetric — it discards exactly the words that distinguish `X: Y` from `X: Z`, so it *over*-merges distinct books while *under*-merging a colon-vs-no-colon pair. The colon-less form keeps every word and the colonised form keeps three; nothing can reconcile them.

The third line is not in the issue. It is the same defect read the other way, and it is the more serious one: two different books sharing an identity means an import binds one onto the other rather than merely adding a row.

## The fix

**The key is now lossless — it never truncates.** Apostrophes (`'`, backtick, `U+2018/2019/02BC`) are **deleted** because they are intra-word; every other non-alphanumeric becomes a **space** because it is a separator. Deleting is load-bearing: replacing an apostrophe with a space yields `poseidon s arrow`, which matches neither spelling. Making the colon a separator rather than a truncation point is what lets `Journey of the Pharaohs: Numa Files #17` and `Journey of the Pharaohs Numa Files #17` produce one key. NFC / `StripBracketSuffixes` / paren-suffix strip / lowercase / `TransliterateUmlauts` are unchanged.

Losing truncation loses the one thing it was right about: a subtitle only one source spells out (audiobooks routinely drop them). That case moves up a level to **`CompareTitles`, which returns three outcomes instead of a boolean**:

| condition | verdict |
|---|---|
| canonical keys equal | `TitlesSame` |
| main titles differ | `TitlesDifferent` |
| both sides have subtitles, and they differ | `TitlesDifferent` |
| exactly one side has a subtitle | `TitlesNeedCorroboration` |

Worked through the cases:

| pair | before | after |
|---|---|---|
| `Poseidon's Arrow` / `Poseidons Arrow` | ✗ two rows | `TitlesSame` |
| `Journey of the Pharaohs: Numa Files #17` / `…Numa Files #17` | ✗ two rows | `TitlesSame` |
| `Star Wars: A New Hope` / `Star Wars: The Empire Strikes Back` | ✗ **merged** | `TitlesDifferent` |
| `Cross Fire` / `Cross Justice` | ok | `TitlesDifferent` |
| `The Eye of the World` / `…: Book One of The Wheel of Time` | merged | `TitlesNeedCorroboration` |
| `The Midnight Line: A Jack Reacher Novel` / `The Midnight Line` | merged | `TitlesNeedCorroboration` |
| `Blue Moon: A Jack Reacher Novel` (identical) | ok | `TitlesSame` |

`CompareTitles` is asserted symmetric in both directions for every row — an order-dependent verdict is the shape of #940.

## Why the key stayed a single string, and how match sites changed

`books.dedup_key` is a persisted, indexed column, so it stays one string and the richer comparison is layered above it at match sites — the less invasive of the two options in the issue. But the key alone is no longer sufficient to *find* candidates: because it is lossless, a stored `Mistborn: The Final Empire` and an incoming `Mistborn` hash differently. So each match site gathers on the weaker `MainTitleKey` and adjudicates with `CompareTitles`.

In SQL (`BookRepo.dedupCandidates`, behind both `FindByAuthorAndDedupKey` and `FindAllByAuthorAndDedupKey`) that is three index-friendly predicates against the existing `books(author_id, dedup_key)` index:

1. `dedup_key = <canonical key>` — same work, same spelling;
2. `dedup_key = <main-title key>` — the stored row dropped the subtitle;
3. `dedup_key IN [main+" ", main+"!")` — the stored row carries a subtitle the lookup omits. A prefix **range**, not a `LIKE`, so SQLite uses the index; `'!'` is the byte after `' '` and keys are space-normalised.

2 and 3 are deliberately over-inclusive (`The Eye of the World` prefix-matches `The Eye of the World War`), so every candidate is re-adjudicated in Go and anything `TitlesDifferent` is dropped. In memory the identical rule lives in `indexer.TitleIndex`, used by the author-refresh path in `internal/api/authors.go` — which was keyed by a plain map and would otherwise have started creating duplicate rows on refresh — so the two paths cannot drift apart.

**An exact match shadows a corroboration-tier one.** If any candidate is `TitlesSame`, the weaker ones are not returned at all, so a subtitled near-miss can no longer make an unambiguous lookup ambiguous. This is a strict improvement: `Foundation` and `Foundation: The Empire` under one author previously made *every* lookup for either ambiguous.

**What each caller does with `TitlesNeedCorroboration`** (the issue asks; I checked each site):

| caller | corroborating signal available | behaviour |
|---|---|---|
| ABS importer (`findBookByNormalizedTitle`) | **yes** — series name + sequence, via the existing `candidateSeriesConflicts` | rejects the candidate when it is a different volume of the same series; this pre-existing mechanism is exactly the corroboration tier, already built |
| ABS `lookupUpstreamBook` | ASIN, tried first on its own path | falls back to the title tier; exact matches shadow near ones |
| Calibre importer, API add-book, hardcover list syncer | **no** | **accept** — documented in `dedupCandidates` |

Accepting where nothing can corroborate is a deliberate choice, not an oversight. It preserves today's behaviour for that case, and a one-sided subtitle is overwhelmingly one work whose publisher subtitle the other source omitted. The net effect is that the change strictly reduces false merges *and* strictly reduces false splits — no case gets worse.

## Migration and existing libraries

No migration. `dedup_key` is derived from `books.title`, which is untouched, and `backfillBookDedupKeys` already exists to recanonicalize every row on the next boot after a normalizer change. Two shapes result, both documented in that function's comment:

- **Rows that duplicate each other today** (`Poseidon's Arrow` beside `Poseidons Arrow`) converge onto one key. They stay two rows — the backfill deliberately does not merge — but the ABS importer now sees an ambiguous pair and routes to review instead of compounding it, and no *further* duplicate is created for that work.
- **Rows the old key wrongly merged** (both Star Wars titles keyed `star wars`) separate onto distinct keys. That is the correction: they were always distinct rows, and the shared key is what let an import bind one onto the other.

Repairing libraries already duplicated by the old key is a separate piece of work, as the issue anticipates.

## Scope: what I deliberately left out

- **No repair pass for existing duplicates.** Merging rows touches file ownership, edition links and provenance.
- **No ISBN/ASIN corroboration for the weak tier.** ABS already tries ASIN before falling to titles; wiring identifiers into `CompareTitles` itself is a larger change with no failure to point at.
- **Series-name matching (`findSeriesByTitle`, `seriesmatch.NormalizeSeriesName`) left on strict equality.** These inherit the punctuation fix but not the subtitle tier. Series names carry subtitles far more rarely than book titles, and loosening series matching risks collapsing distinct series — the opposite bug. `internal/normdrift`'s invariant (dedup-key-share ⟹ series-key-share) still holds and its tests pass unchanged.
- **The issue's premise that `stripSubtitle` is load-bearing for series collapse.** It is not, in the direction feared: `TestImporter_SeriesVolumesWithSharedBaseTitleStayDistinct` and the `authors_series_collapse` tests pass, several of them *more* easily, because distinct volumes now hold distinct keys instead of relying on the series-sequence filter to undo a bad merge.

### A note on shipping only the punctuation half

I tried it first, since it alone fixes both production duplicates and the Star Wars false positive. **It is not safe on its own**: dropping truncation without the corroboration tier fails 13 tests across four independent call sites (ABS↔Calibre cross-source binding, ABS series collapse, the API add-book adoption path, and the repo lookup), because the one-sided-subtitle collapse is real behaviour that several importers depend on. Shipping that half alone would trade one class of duplicate for a commoner one. Hence the single PR.

## Behaviour changes worth a reviewer's eye

- `NormalizeTitleForDedup("foo:bar")` is now `"foo bar"`, not `"foo:bar"`; `"Title — Subtitle"` is `"title subtitle"`, not `"title - subtitle"`. Existing characterisation tests updated with these values.
- `Mistborn` vs `Mistborn The Final Empire` (no colon) is `TitlesDifferent`, while `Mistborn` vs `Mistborn: The Final Empire` needs corroboration. The colon is the evidence that the tail is a subtitle; without it the words are part of the title. The old code had the same property.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed — n/a, no env vars, no migration, no operator action
- [x] Added a changelog fragment under `changelog.d/` — `changelog.d/2042-dedup-title-key.md`
- [x] Wiki pages updated if user-facing behaviour changed — n/a, no documented behaviour describes the key's internals

Tests added: `TestCanonicalDedupKey_NeverTruncates` (characterisation — fails loudly, with a pointer to #2042, if anyone reintroduces truncation), `TestCanonicalDedupKey_FoldsPunctuationDivergence`, `TestCanonicalDedupKey_ApostrophesAreDeletedNotSpaced` (pins delete-vs-space), `TestCompareTitles` (the full decision table, every case asserted in both directions), `TestMainTitleKey`, `TestSplitSubtitle`, `TestTitleIndex_MirrorsCompareTitles`, `TestTitleIndex_ExactMatchWins`, `TestBookRepo_DedupCandidates_{ExactMatchShadowsSubtitleVariant,DistinctSubtitlesNeverMerge,PunctuationDivergenceBinds}` (end-to-end through the repo), `TestNormalizeTitle_OneSidedSubtitleIsACandidateNotAKey`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` (clean)
- [x] `go test ./cmd/... ./internal/...` — passes except `TestRemoveDownload_Rtorrent`, which fails identically on an unmodified `main` checkout on macOS; I captured the baseline on the clean tree before making any change and compared, and the failure and its message are unchanged.
