### PR TITLE
fix(indexer): sign grab URLs without an indexer ID

### DIFF
--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -857,15 +857,14 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 		}
 	}
 	// Re-attach the indexer apikey the search/queue responses strip out
-	// (SEC: the shared credential must not reach non-admin clients). The client
-	// hands back an apikey-less download URL plus the indexer id; sign it
-	// server-side here. No-op when the URL already carries a key (scheduler /
-	// retry paths) or its host does not match the indexer.
+	// (SEC: the shared credential must not reach non-admin clients). Most
+	// callers send the indexer ID, but API clients may only have the redacted
+	// URL returned by search. Recover that ID by exact host match when it is
+	// absent or stale; never sign a direct-from-uploader URL.
 	nzbURL := req.NZBURL
-	if indexerID != nil && h.indexers != nil {
-		if idx, err := h.indexers.GetByID(ctx, *indexerID); err == nil && idx != nil {
-			nzbURL = newznab.SignDownloadURLFor(req.NZBURL, idx.URL, idx.APIKey)
-		}
+	if idx, resolvedID := h.indexerForDownloadURL(ctx, indexerID, req.NZBURL); idx != nil {
+		indexerID = resolvedID
+		nzbURL = newznab.SignDownloadURLFor(req.NZBURL, idx.URL, idx.APIKey)
 	}
 	dl := &models.Download{
 		GUID:             req.GUID,
@@ -941,6 +940,32 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 		h.notif.Send(ctx, notifier.EventGrabbed, map[string]any{"title": req.Title, "size": req.Size})
 	}
 	return dl, nil
+}
+
+// indexerForDownloadURL resolves an explicitly supplied indexer ID first. If
+// it is absent or refers to a deleted indexer, it falls back to matching the
+// download URL's host against configured indexers. This restores redacted URLs
+// returned by search without trusting a client to provide a database ID.
+func (h *QueueHandler) indexerForDownloadURL(ctx context.Context, id *int64, rawURL string) (*models.Indexer, *int64) {
+	if h.indexers == nil {
+		return nil, id
+	}
+	if id != nil {
+		idx, err := h.indexers.GetByID(ctx, *id)
+		if err == nil && idx != nil {
+			return idx, id
+		}
+	}
+	indexers, err := h.indexers.List(ctx)
+	if err != nil {
+		return nil, id
+	}
+	for i := range indexers {
+		if newznab.IsDownloadURLFor(rawURL, indexers[i].URL) {
+			return &indexers[i], &indexers[i].ID
+		}
+	}
+	return nil, id
 }
 
 // recordHistory is a helper to write a history event, swallowing errors.

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -68,6 +68,64 @@ func TestQueueGrab_NoDownloadClient(t *testing.T) {
 	}
 }
 
+// TestQueueGrab_SignsDownloadURLWithoutIndexerID covers API consumers that
+// replay the redacted URL returned from search without carrying indexerId.
+// A stale ID must recover in the same way, since deleted indexers can leave
+// old clients with an ID that no longer resolves.
+func TestQueueGrab_SignsDownloadURLWithoutIndexerID(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("apikey") != "indexer-secret" {
+			http.Error(w, "missing indexer credential", http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><nzb></nzb>`))
+	}))
+	defer indexerSrv.Close()
+
+	sabSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("mode") != "addfile" {
+			t.Fatalf("expected SAB addfile request, got %q", r.URL.Query().Get("mode"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": true, "nzo_ids": []string{"nzo-signed"}})
+	}))
+	defer sabSrv.Close()
+
+	for name, indexerID := range map[string]string{
+		"missing": "",
+		"stale":   `,"indexerId":999`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			h, database, downloads, clients, _, ctx := queueFixture(t)
+			indexers := db.NewIndexerRepo(database)
+			idx := &models.Indexer{Name: "Prowlarr", Type: "newznab", URL: indexerSrv.URL + "/api", APIKey: "indexer-secret", Categories: []int{7000}, Enabled: true, SupportsSearch: true}
+			if err := indexers.Create(ctx, idx); err != nil {
+				t.Fatalf("create indexer: %v", err)
+			}
+			h.WithIndexers(indexers)
+
+			host, port := testServerHostPort(t, sabSrv.URL)
+			if err := clients.Create(ctx, &models.DownloadClient{Name: "sab", Type: "sabnzbd", Host: host, Port: port, Enabled: true}); err != nil {
+				t.Fatalf("create download client: %v", err)
+			}
+
+			body := fmt.Sprintf(`{"guid":"sign-%s","nzbUrl":"%s/download?link=release","title":"Signed release"%s}`, name, indexerSrv.URL, indexerID)
+			rec := httptest.NewRecorder()
+			h.Grab(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/grab", bytes.NewBufferString(body)))
+			if rec.Code != http.StatusAccepted {
+				t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+			}
+			dl, err := downloads.GetByGUID(ctx, "sign-"+name)
+			if err != nil || dl == nil {
+				t.Fatalf("load download: %v", err)
+			}
+			if dl.IndexerID == nil || *dl.IndexerID != idx.ID {
+				t.Fatalf("expected recovered indexer ID %d, got %v", idx.ID, dl.IndexerID)
+			}
+		})
+	}
+}
+
 // TestQueueGrab_ProtocolMismatchNamesUsenet verifies the actionable error when
 // a usenet (NZB) release is grabbed but the user's only enabled client is a
 // torrent client. The message must name the missing protocol (usenet) AND tell

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -178,11 +178,29 @@ func signDownloadURL(raw, baseHost, apiKey string) string {
 // the indexer is returned untouched (never signed with a foreign host). Passing
 // an already-signed URL is a no-op.
 func SignDownloadURLFor(rawURL, indexerURL, apiKey string) string {
-	baseHost := ""
-	if u, err := url.Parse(normalizeEndpointURL(indexerURL)); err == nil {
-		baseHost = strings.ToLower(u.Host)
-	}
+	baseHost := indexerHost(indexerURL)
 	return signDownloadURL(rawURL, baseHost, apiKey)
+}
+
+// IsDownloadURLFor reports whether rawURL targets the configured indexer's
+// host. It uses the same normalized-host comparison as SignDownloadURLFor, so
+// callers can recover an omitted indexer ID without ever matching a
+// direct-from-uploader URL to an unrelated indexer.
+func IsDownloadURLFor(rawURL, indexerURL string) bool {
+	baseHost := indexerHost(indexerURL)
+	if baseHost == "" {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	return err == nil && strings.EqualFold(u.Host, baseHost)
+}
+
+func indexerHost(indexerURL string) string {
+	u, err := url.Parse(normalizeEndpointURL(indexerURL))
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Host)
 }
 
 // RedactDownloadURL removes the apikey query parameter from a download URL so it

--- a/internal/indexer/newznab/download_url_test.go
+++ b/internal/indexer/newznab/download_url_test.go
@@ -49,6 +49,16 @@ func TestSignDownloadURLFor(t *testing.T) {
 	}
 }
 
+func TestIsDownloadURLFor(t *testing.T) {
+	const indexerURL = "https://idx.example.com/api"
+	if !IsDownloadURLFor("https://idx.example.com/dl?id=abc", indexerURL) {
+		t.Fatal("expected same-host download URL to match")
+	}
+	if IsDownloadURLFor("https://cdn.other.net/file.nzb", indexerURL) {
+		t.Fatal("foreign download URL must not match")
+	}
+}
+
 // The client redacts a signed URL for the response, and the grab handler
 // restores exactly the original signed URL — the round trip a real grab makes.
 func TestRedactThenReSign_RoundTrips(t *testing.T) {


### PR DESCRIPTION
## Summary

Restores the indexer API key for redacted download URLs when an API caller omits indexerId, and recovers from stale IDs by matching the configured indexer host. Direct-from-uploader URLs remain unsigned.

Adds end-to-end queue-grab coverage for both missing and stale IDs. Closes #2039.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (internal behavior only; no user-facing documentation changes required)
- [x] Wiki pages updated if user-facing behaviour changed (not applicable)

## Test plan

- [x] go test ./internal/api ./internal/indexer/newznab (passed in the authenticated runtime)
- [ ] go test -race ./cmd/... ./internal/... (attempted; sandbox loopback restrictions prevent httptest from binding)
- [ ] cd web && npm run build (web untouched)