### PR TITLE
fix(hardcover): merge complementary list media types (#2035)

### DIFF
--- a/changelog.d/2035-hardcover-dual-format-lists.md
+++ b/changelog.d/2035-hardcover-dual-format-lists.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Hardcover list sync** (#2035) — the same work on ebook and audiobook lists now becomes one wanted dual-format book.

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -485,9 +485,32 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 			continue
 		}
 
-		// Skip if already tracked
+		// A work can be on separate ebook and audiobook lists. Reconcile the
+		// effective list formats before skipping the second occurrence so both
+		// lists produce one dual-format wanted book (#2035).
+		effectiveMediaType := book.MediaType
+		if il.MediaType != "" {
+			effectiveMediaType = il.MediaType
+		}
+
+		// Skip if already tracked, except to widen complementary list formats.
 		existing, _ := s.books.GetByForeignID(ctx, book.ForeignID)
 		if existing != nil {
+			if shouldWidenMediaType(existing.MediaType, effectiveMediaType) {
+				existing.MediaType = models.MediaTypeBoth
+				// The ebook-pinned pass clears the audiobook ASIN. Preserve the
+				// audio identifier when the complementary pass supplies it.
+				if (effectiveMediaType == models.MediaTypeAudiobook || effectiveMediaType == models.MediaTypeBoth) && book.ASIN != "" {
+					existing.ASIN = book.ASIN
+				}
+				if err := s.books.Update(ctx, existing); err != nil {
+					slog.Warn("hardcover list sync: failed to widen tracked book media type", "title", book.Title, "error", err)
+					countStat(func(st *SyncStats) { st.Failed++ })
+					continue
+				}
+				s.enrichAudiobook(ctx, existing)
+				slog.Info("widened book media type from hardcover lists", "title", existing.Title, "book_id", existing.ID)
+			}
 			slog.Debug("book already tracked, skipping", "title", book.Title, "foreignID", book.ForeignID)
 			countStat(func(st *SyncStats) { st.Skipped++ })
 			continue
@@ -524,10 +547,10 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 		// Hardcover-derived media type (most works report both editions, so
 		// without this an "Audiobooks" and an "Ebooks" list yield identical
 		// media types). Applied on create only — books that already exist are
-		// skipped above, so two single-format lists never combine into "both"
-		// and a manually-set media type survives re-sync.
+		// except for complementary single-format lists, which are widened above;
+		// a manually-set media type otherwise survives re-sync.
 		if il.MediaType != "" {
-			book.MediaType = il.MediaType
+			book.MediaType = effectiveMediaType
 			// The list response may have carried an audiobook ASIN (#1694).
 			// A list pinned to a non-audio format must not keep it, matching
 			// the pre-existing rule that an ebook-pinned book never takes the
@@ -553,23 +576,32 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 		countStat(func(st *SyncStats) { st.Imported++ })
 		slog.Info("imported book from hardcover list", "title", book.Title, "author_id", authorID)
 
-		// The list response can carry an audiobook ASIN inline (#1694). When
-		// it does, run the same Audnex enrichment the per-book edition
-		// hydration used to trigger on ASIN promotion — narrator, refined
-		// duration, summary — then persist. Failures are logged and skipped:
-		// enrichment is best-effort and must not block the import loop.
-		if s.enricher != nil && book.ASIN != "" {
-			if err := s.enricher.EnrichAudiobook(ctx, &book); err != nil {
-				slog.Debug("audiobook enrichment skipped", "title", book.Title, "asin", book.ASIN, "error", err)
-			} else if err := s.books.Update(ctx, &book); err != nil {
-				slog.Warn("failed to persist enriched book", "title", book.Title, "error", err)
-			}
-		}
+		s.enrichAudiobook(ctx, &book)
 
 		s.linkSeriesRefs(ctx, &book)
 	}
 
 	return nil
+}
+
+// enrichAudiobook applies the best-effort Audnex enrichment for an ASIN that
+// arrived inline from a Hardcover list, then persists its mutations.
+func (s *ListSyncer) enrichAudiobook(ctx context.Context, book *models.Book) {
+	if s.enricher == nil || book.ASIN == "" {
+		return
+	}
+	if err := s.enricher.EnrichAudiobook(ctx, book); err != nil {
+		slog.Debug("audiobook enrichment skipped", "title", book.Title, "asin", book.ASIN, "error", err)
+	} else if err := s.books.Update(ctx, book); err != nil {
+		slog.Warn("failed to persist enriched book", "title", book.Title, "error", err)
+	}
+}
+
+// shouldWidenMediaType reports whether the two list formats request opposite
+// halves of the same work. An already-dual or unknown format is left alone.
+func shouldWidenMediaType(existing, incoming string) bool {
+	return (existing == models.MediaTypeEbook && incoming == models.MediaTypeAudiobook) ||
+		(existing == models.MediaTypeAudiobook && incoming == models.MediaTypeEbook)
 }
 
 // linkSeriesRefs persists each Hardcover SeriesRef into the series table and

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -237,6 +237,74 @@ func TestSyncOne_ListMediaTypeOverridesDerived(t *testing.T) {
 	}
 }
 
+// TestSyncOne_ComplementaryListMediaTypesMerge verifies that the same
+// Hardcover work on an ebook list and an audiobook list becomes one wanted
+// dual-format book rather than the second list being silently skipped (#2035).
+func TestSyncOne_ComplementaryListMediaTypesMerge(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+	enricher := &recordingEnricher{}
+	s.WithAudiobookEnricher(enricher)
+
+	ebookList := testImportList("Ebooks", "hardcover", true)
+	ebookList.URL = "ebooks"
+	ebookList.MediaType = models.MediaTypeEbook
+	if err := repo.Create(ctx, &ebookList); err != nil {
+		t.Fatalf("seed ebook list: %v", err)
+	}
+	audiobookList := testImportList("Audiobooks", "hardcover", true)
+	audiobookList.URL = "audiobooks"
+	audiobookList.MediaType = models.MediaTypeAudiobook
+	if err := repo.Create(ctx, &audiobookList); err != nil {
+		t.Fatalf("seed audiobook list: %v", err)
+	}
+
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{
+				{ID: 1, Slug: ebookList.URL, Name: ebookList.Name},
+				{ID: 2, Slug: audiobookList.URL, Name: audiobookList.Name},
+			},
+			books: []models.Book{{
+				ForeignID:        "hc:dual-format",
+				Title:            "Dual Format Book",
+				MetadataProvider: "hardcover",
+				MediaType:        models.MediaTypeBoth,
+				ASIN:             "B123DUAL",
+				Author: &models.Author{
+					ForeignID:        "hc:dual-author",
+					Name:             "Dual Author",
+					MetadataProvider: "hardcover",
+				},
+			}},
+		}
+	})
+
+	if err := s.SyncOne(ctx, ebookList.ID); err != nil {
+		t.Fatalf("sync ebook list: %v", err)
+	}
+	if err := s.SyncOne(ctx, audiobookList.ID); err != nil {
+		t.Fatalf("sync audiobook list: %v", err)
+	}
+
+	got, err := s.books.GetByForeignID(ctx, "hc:dual-format")
+	if err != nil || got == nil {
+		t.Fatalf("merged book not found: %v", err)
+	}
+	if got.MediaType != models.MediaTypeBoth {
+		t.Fatalf("media type = %q, want both", got.MediaType)
+	}
+	if got.Status != models.BookStatusWanted || !got.Monitored {
+		t.Fatalf("merged book = %+v, want monitored wanted book", got)
+	}
+	if got.ASIN != "B123DUAL" {
+		t.Fatalf("ASIN = %q, want audiobook ASIN from the complementary list", got.ASIN)
+	}
+	if got.Narrator != "Recorded Narrator" || len(enricher.calls) != 1 {
+		t.Fatalf("merged book narrator = %q, enrichment calls = %v; want persisted audio enrichment", got.Narrator, enricher.calls)
+	}
+}
+
 // TestSyncOne_ListMediaTypeUnsetKeepsDerived confirms an unset list MediaType
 // leaves the source-derived media type untouched (backwards compatible).
 func TestSyncOne_ListMediaTypeUnsetKeepsDerived(t *testing.T) {


### PR DESCRIPTION
## Summary

When the same Hardcover work appears on ebook and audiobook import lists, sync now widens the existing wanted book to `both` instead of silently skipping the second list. The audiobook ASIN and its best-effort enrichment are retained when the audiobook list supplies them. Closes #2035.

## Checklist

- [x] Commits signed off with `git commit -s` — see [Sign your work](../CONTRIBUTING.md#sign-your-work-dco)
- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (not applicable)
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`) — see [changelog.d/README.md](../changelog.d/README.md)
- [x] Wiki pages updated if user-facing behaviour changed (not applicable; existing import-list behaviour corrected)

## Test plan

- [x] `go test -count=1 ./internal/...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./internal/hardcoverlistsyncer/...`
- [ ] `make check` (not run; frontend and unrelated full-suite checks are unchanged)
