### PR TITLE
fix(db): repair legacy missing excluded column (#1932)

### DIFF
--- a/changelog.d/1932-repair-legacy-excluded-column.md
+++ b/changelog.d/1932-repair-legacy-excluded-column.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Database upgrades** (#1932) — automatically restore the legacy-missing `books.excluded` column at startup.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -453,6 +453,14 @@ Where the orphans come from: before [#1727](https://github.com/vavallee/bindery/
 
 ## Upgrading
 
+### Legacy migration-marker repair
+
+Some databases written by an older positional migration runner can report every
+migration as applied while missing `books.excluded`. On startup, Bindery now
+checks the live schema and restores that additive column automatically. Take a
+normal SQLite backup before upgrading; no manual SQL is required for this
+specific repair.
+
 ### ABS import deployment note
 
 **Schema:** ABS import uses migrations `029` through `033`. They create five ABS tables: `abs_import_runs`, `abs_provenance`, `abs_metadata_conflicts`, `abs_import_run_entities`, and `abs_review_queue`. Migration `031` also adds `dry_run`, `source_config_json`, and `checkpoint_json` to `abs_import_runs`; migration `033` is currently a no-op compatibility migration. Take a normal SQLite backup before upgrading, then let Bindery apply the migrations on startup.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -266,6 +266,15 @@ func migrate(database *sql.DB) error {
 		slog.Info("applied migration", "version", v, "file", entry.Name())
 	}
 
+	// Older index-based migration runners could mark migration 014 as applied
+	// while applying the next file in the sorted list instead. The later 010
+	// no-op makes that marker set look filename-valid, so version reconciliation
+	// cannot distinguish it safely. Repair the affected column directly; this
+	// is idempotent and avoids rewriting ambiguous historical markers (#1932).
+	if err := ensureBooksExcludedColumn(database); err != nil {
+		return fmt.Errorf("repair legacy books.excluded column: %w", err)
+	}
+
 	// Post-migration Go-side backfill. Migration 051's SQL backfill is a coarse
 	// approximation of indexer.CanonicalDedupKey (SQLite cannot run the Go
 	// normalizer); recompute the exact key for any row whose stored key is
@@ -284,6 +293,39 @@ func migrate(database *sql.DB) error {
 		return fmt.Errorf("backfill author sort keys: %w", err)
 	}
 
+	return nil
+}
+
+// ensureBooksExcludedColumn restores the column migration 014 introduced when
+// an old positional migration runner recorded its version without applying its
+// SQL. It deliberately checks the live schema instead of schema_migrations:
+// the marker alone is ambiguous after the 010 no-op filled the former gap.
+func ensureBooksExcludedColumn(database *sql.DB) error {
+	rows, err := database.Query("PRAGMA table_info(books)")
+	if err != nil {
+		return fmt.Errorf("inspect books columns: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue sql.NullString
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return fmt.Errorf("scan books column: %w", err)
+		}
+		if name == "excluded" {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate books columns: %w", err)
+	}
+
+	if _, err := database.Exec("ALTER TABLE books ADD COLUMN excluded INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return fmt.Errorf("add books.excluded: %w", err)
+	}
+	slog.Warn("repaired missing books.excluded column from legacy migration history")
 	return nil
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2342,6 +2342,47 @@ func TestReconcileMigrationVersionsLeavesFreshDB(t *testing.T) {
 	}
 }
 
+// TestMigrate_RepairsLegacyMissingExcludedColumn covers the ambiguous legacy
+// marker state from #1932: migration 014 is marked applied even though the
+// old positional runner skipped its SQL. The 010 no-op means marker-only
+// reconciliation cannot identify this state, so migrate repairs the schema.
+func TestMigrate_RepairsLegacyMissingExcludedColumn(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	if _, err := database.Exec("ALTER TABLE books DROP COLUMN excluded"); err != nil {
+		t.Fatalf("simulate legacy missing column: %v", err)
+	}
+
+	if err := migrate(database); err != nil {
+		t.Fatalf("migrate repair: %v", err)
+	}
+
+	rows, err := database.Query("PRAGMA table_info(books)")
+	if err != nil {
+		t.Fatalf("inspect repaired books schema: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue sql.NullString
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatalf("scan repaired books column: %v", err)
+		}
+		if name == "excluded" {
+			return
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate repaired books schema: %v", err)
+	}
+	t.Fatal("books.excluded was not restored")
+}
+
 func sortEntriesForTest(entries []os.DirEntry) {
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Name() < entries[j].Name()

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2383,6 +2383,18 @@ func TestMigrate_RepairsLegacyMissingExcludedColumn(t *testing.T) {
 	t.Fatal("books.excluded was not restored")
 }
 
+func TestEnsureBooksExcludedColumn_IsIdempotent(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	if err := ensureBooksExcludedColumn(database); err != nil {
+		t.Fatalf("ensure existing excluded column: %v", err)
+	}
+}
+
 func sortEntriesForTest(entries []os.DirEntry) {
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Name() < entries[j].Name()


### PR DESCRIPTION
## Summary

Repair the ambiguous legacy migration state where `schema_migrations` marks migration 014 as applied but `books.excluded` is absent. Startup now checks the live schema and adds the missing additive column without rewriting uncertain historic markers. Closes #1932.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated for upgrade behaviour
- [x] Added a changelog fragment under `changelog.d/`
- [x] Wiki pages updated if user-facing behaviour changed (not applicable)

## Test plan

- [x] `go test -run "TestMigrate_RepairsLegacyMissingExcludedColumn|TestReconcileMigrationVersions" -count=1 ./internal/db`
- [x] `go vet ./internal/db/...`
- [ ] `make check` (not run)
