### PR TITLE
fix(api): scope last search debug to its caller (#1859)

### DIFF
--- a/changelog.d/1859-scope-last-search-debug.md
+++ b/changelog.d/1859-scope-last-search-debug.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Multi-user search debug** (#1859) — users can now access only their own most recent search details.

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -19,25 +19,27 @@ import (
 	"github.com/vavallee/bindery/internal/telemetry"
 )
 
-// lastDebugStore holds the audit trail from the most recent SearchBook run.
-// Only the single latest entry is kept — the debug panel surfaces "what
-// happened on the last search", not a history. Handler calls come from
-// different goroutines, so access is mutex-guarded.
+// lastDebugStore holds each caller's most recent SearchBook audit trail. The
+// debug panel surfaces "what happened on my last search", not a history.
+// Handler calls come from different goroutines, so access is mutex-guarded.
 type lastDebugStore struct {
-	mu  sync.RWMutex
-	dbg *indexer.SearchDebug
+	mu     sync.RWMutex
+	byUser map[int64]*indexer.SearchDebug
 }
 
-func (s *lastDebugStore) set(d *indexer.SearchDebug) {
+func (s *lastDebugStore) set(userID int64, d *indexer.SearchDebug) {
 	s.mu.Lock()
-	s.dbg = d
+	if s.byUser == nil {
+		s.byUser = make(map[int64]*indexer.SearchDebug)
+	}
+	s.byUser[userID] = d
 	s.mu.Unlock()
 }
 
-func (s *lastDebugStore) get() *indexer.SearchDebug {
+func (s *lastDebugStore) get(userID int64) *indexer.SearchDebug {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.dbg
+	return s.byUser[userID]
 }
 
 // indexerSearcher is the subset of indexer.Searcher used by IndexerHandler.
@@ -515,7 +517,7 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 	// Remember the most recent debug payload so the UI can re-fetch it
 	// (e.g. after a page reload) without having to re-run the search.
 	if dbg != nil {
-		h.lastDebug.set(dbg)
+		h.lastDebug.set(auth.UserIDFromContext(r.Context()), dbg)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -524,11 +526,11 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// LastSearchDebug returns the audit trail captured during the most recent
-// SearchBook invocation on this bindery instance, or 404 if no search has
-// run yet.
+// LastSearchDebug returns the caller's most recent SearchBook audit trail, or
+// 404 if that caller has not run a search yet. User ID 0 retains the shared
+// behavior for API-key, disabled-auth, and local-only requests.
 func (h *IndexerHandler) LastSearchDebug(w http.ResponseWriter, r *http.Request) {
-	dbg := h.lastDebug.get()
+	dbg := h.lastDebug.get(auth.UserIDFromContext(r.Context()))
 	if dbg == nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no search has run yet"})
 		return

--- a/internal/api/indexers_test.go
+++ b/internal/api/indexers_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/indexer"
@@ -605,6 +606,36 @@ func (debugSearcher) SearchBookWithDebug(_ context.Context, _ []models.Indexer, 
 
 func (debugSearcher) SearchQuery(_ context.Context, _ []models.Indexer, _ string) []newznab.SearchResult {
 	return nil
+}
+
+// TestLastSearchDebug_IsScopedToCaller verifies one authenticated user cannot
+// read another user's search audit trail (#1859).
+func TestLastSearchDebug_IsScopedToCaller(t *testing.T) {
+	h := &IndexerHandler{lastDebug: &lastDebugStore{}}
+	const (
+		aliceID int64 = 101
+		bobID   int64 = 202
+	)
+	h.lastDebug.set(aliceID, &indexer.SearchDebug{Query: indexer.SearchQueryDebug{Title: "Alice's private search"}})
+
+	aliceRec := httptest.NewRecorder()
+	aliceReq := httptest.NewRequest(http.MethodGet, "/search/last-debug", nil).
+		WithContext(auth.WithUserID(context.Background(), aliceID))
+	h.LastSearchDebug(aliceRec, aliceReq)
+	if aliceRec.Code != http.StatusOK || !strings.Contains(aliceRec.Body.String(), "Alice's private search") {
+		t.Fatalf("alice response = %d %s, want her debug payload", aliceRec.Code, aliceRec.Body.String())
+	}
+
+	bobRec := httptest.NewRecorder()
+	bobReq := httptest.NewRequest(http.MethodGet, "/search/last-debug", nil).
+		WithContext(auth.WithUserID(context.Background(), bobID))
+	h.LastSearchDebug(bobRec, bobReq)
+	if bobRec.Code != http.StatusNotFound {
+		t.Fatalf("bob response = %d %s, want 404 without Bob debug", bobRec.Code, bobRec.Body.String())
+	}
+	if strings.Contains(bobRec.Body.String(), "Alice's private search") {
+		t.Fatalf("bob response leaked Alice's debug payload: %s", bobRec.Body.String())
+	}
 }
 
 // TestSearchBook_DualFormat_DebugReportsBothMediaType covers the reporting


### PR DESCRIPTION
## Summary

Store each authenticated caller’s latest indexer-search debug snapshot separately, so `/search/last-debug` cannot disclose another user’s query. API-key and unauthenticated contexts retain their existing shared snapshot behavior. Closes #1859.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated
- [x] Doc-update gate cleared (no public configuration or behavior documentation changed)
- [x] Added a changelog fragment under `changelog.d/`
- [x] Wiki pages updated if user-facing behaviour changed (not applicable)

## Test plan

- [x] `go test -run TestLastSearchDebug_IsScopedToCaller -count=1 ./internal/api`
- [x] `go vet ./internal/api/...`
- [ ] `make check` (not run)
