### PR TITLE
docs(security): state supported versions as the latest minor, not a pinned 1.15.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,10 +7,10 @@ services, and writes to the local filesystem. We take reports seriously.
 
 Only the latest minor release receives security fixes. Older minors do not.
 
-| Version | Supported |
-| ------- | --------- |
-| 1.15.x  | Yes       |
-| < 1.15  | No        |
+| Version                                                              | Supported |
+| -------------------------------------------------------------------- | --------- |
+| Latest minor ([Releases](https://github.com/vavallee/bindery/releases)) | Yes       |
+| Anything older                                                         | No        |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Summary

`SECURITY.md`'s supported-versions table claimed `1.15.x`. Bindery is on 1.31.0, so it has been wrong for sixteen minors — on the page a reporter reads before deciding whether their finding is worth filing.

Rather than bump it to `1.31.x` and have it drift again at the next release, the rows now name the latest minor and link to Releases. That matches the sentence immediately above the table ("Only the latest minor release receives security fixes") and needs no maintenance.

Noticed while deciding whether the indexer-apikey exposures fixed in #2038 warranted an advisory for v1.31.1.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated (not applicable, docs only)
- [x] Added a changelog fragment under `changelog.d/` (not applicable, no user-visible behaviour change)

## Test plan

- [x] Rendered the table on GitHub to confirm the link and column alignment survive