### PR TITLE
docs(changelog): add the fragment #2034 landed without (#2033)

### DIFF
--- a/changelog.d/2033-audiobook-root-match.md
+++ b/changelog.d/2033-audiobook-root-match.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Library scan no longer rejects audiobooks when `BINDERY_AUDIOBOOK_DIR`
+  differs from the ebook root** (#2033) — the scan's reconcile tiers matched a
+  file by ASIN, fuzzy title, or series position and then checked the candidate
+  against the ebook root regardless of the file's format. With a separate
+  audiobook root, every correctly matched audiobook failed that containment
+  check and fell through to the generic `no_title_match` reason, so the scan
+  reported that it could not identify files it had in fact identified. Each
+  file is now checked against the root for its own format.


### PR DESCRIPTION
## Summary

#2034 fixed library scan rejecting audiobooks whenever `BINDERY_AUDIOBOOK_DIR` differs from the ebook root, but merged without a `changelog.d/` fragment. Without this the fix is missing from the v1.31.1 release notes, and it is one of the more visible ones in that release for anyone running split roots.

Fragment text only, no code.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated (not applicable)
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `make changelog` renders it under **Fixed** alongside the other v1.31.1 fragments