### PR TITLE
fix(api): scope folder deletes to the requested format (#2052)

### DIFF
--- a/changelog.d/2052-format-scoped-folder-delete.md
+++ b/changelog.d/2052-format-scoped-folder-delete.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **Deleting one format no longer destroys the other format's file when both
+  live in the same folder** (#2052) — audiobook imports register the destination
+  *folder* in `book_files`, so a `?format=audiobook` delete lands on a directory.
+  That branch was an unconditional `os.RemoveAll`, which discarded the format
+  filter every other part of the delete path honours, and took the ebook sitting
+  beside the audio files with it. The ebook's `book_files` row survived, so the
+  book kept advertising a file that was no longer on disk and downloading it
+  returned an error. The directory branch now walks the folder and removes only
+  the files belonging to the format being deleted; cover art and other sidecars
+  are removed once no book file of any format is left, and the folder itself
+  only when nothing remains in it.
+- **A folder delete can no longer unlink a file another book still tracks**
+  (#1368, surfaced by #2052) — the `book_files` ownership guard was applied only
+  to the tracked path handed to the delete, so any file nested under a deleted
+  folder was unguarded. The same check now runs for every file the sweep
+  reaches, including same-stem siblings.

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -861,22 +862,26 @@ func (h *BookHandler) deregisterBookFile(w http.ResponseWriter, r *http.Request,
 // removeBookPathScoped deletes a file or directory at p. Audiobooks are stored
 // as folders (multi-part mp3/m4b + cover + cue); ebooks are single files.
 //
-// For single files it also sweeps sibling files in the same directory that
-// share the same basename (stem) — this handles dual-format downloads where
-// epub + mobi land in one folder. The sweep is scoped by `format`:
+// Both branches are scoped by `format`:
 //
-//   - format == ""         — sweep every same-stem recognised book file
+//   - format == ""         — remove every recognised book file
 //     (used for full-book deletes where every format goes anyway).
-//   - format == "ebook"    — sweep only same-stem *ebook* siblings; the
-//     audiobook sibling (.m4b/.mp3/...) is left intact.
-//   - format == "audiobook"— sweep only same-stem *audiobook* siblings; the
-//     ebook sibling is left intact.
+//   - format == "ebook"    — remove only *ebook* files; audiobook files
+//     (.m4b/.mp3/...) are left intact.
+//   - format == "audiobook"— remove only *audiobook* files; ebook files are
+//     left intact.
 //
-// This prevents a `?format=ebook` delete from also destroying the audiobook
-// that happens to share a stem in the same folder.
+// For single files the scope is a same-stem sibling sweep of the parent
+// directory — this handles dual-format downloads where epub + mobi land in one
+// folder. For directories it is a recursive walk (see removeBookDirScoped).
+//
+// `ownedByOther`, when non-nil, reports that a path is still registered in
+// book_files to a different book and must not be unlinked (#1368). It is
+// consulted for every file this function touches, not only the tracked path
+// the caller passed in.
 //
 // Returns nil if the path no longer exists — the net state is the same.
-func removeBookPathScoped(p, format string) error {
+func removeBookPathScoped(p, format string, ownedByOther func(string) bool) error {
 	info, err := os.Stat(p)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -885,7 +890,7 @@ func removeBookPathScoped(p, format string) error {
 		return err
 	}
 	if info.IsDir() {
-		return os.RemoveAll(p)
+		return removeBookDirScoped(p, format, ownedByOther)
 	}
 
 	// Sweep sibling book files with the same stem in the parent directory.
@@ -911,8 +916,12 @@ func removeBookPathScoped(p, format string) error {
 			if !strings.EqualFold(s, stem) {
 				continue
 			}
-			if rmErr := os.Remove(filepath.Join(parent, n)); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- parent + stem both from importer-sanitized DB row; #865 plans defense-in-depth root-check
-				slog.Warn("book delete: failed to remove sibling file", "path", filepath.Join(parent, n), "error", rmErr)
+			sibling := filepath.Join(parent, n)
+			if ownedByOther != nil && ownedByOther(sibling) {
+				continue
+			}
+			if rmErr := os.Remove(sibling); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- parent + stem both from importer-sanitized DB row; #865 plans defense-in-depth root-check
+				slog.Warn("book delete: failed to remove sibling file", "path", sibling, "error", rmErr)
 			}
 		}
 	} else {
@@ -928,6 +937,86 @@ func removeBookPathScoped(p, format string) error {
 		_ = os.Remove(parent) // #nosec G304 G703 -- parent = filepath.Dir of importer-sanitized DB row; #865 plans defense-in-depth root-check
 	}
 	return nil
+}
+
+// removeBookDirScoped removes the book files under dir that belong to `format`,
+// leaving anything of the other format in place.
+//
+// This used to be an unconditional os.RemoveAll(dir), which silently ignored
+// the format filter. Audiobook imports register the destination *folder* in
+// book_files (importer.Scanner, SetFormatFilePath with destDir), so deleting
+// the audiobook of a book whose ebook lived in the same folder destroyed the
+// ebook too — and left the ebook's book_files row behind, so it kept showing in
+// the UI and 404'd on download (#2052). The unconditional sweep could also take
+// a *different* book's file that happened to sit under the folder, which is the
+// failure #1368 was written to prevent.
+//
+// Sidecars (cover art, .cue, .opf, .nfo) are not book files and are only
+// removed once no book file survives anywhere under dir — while a book of the
+// other format is still there, its artwork is still wanted. The directory tree
+// itself is removed only when nothing is left in it.
+func removeBookDirScoped(dir, format string, ownedByOther func(string) bool) error {
+	// Pass 1: format-matching book files.
+	kept := 0
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !importer.IsBookFile(d.Name()) {
+			return nil // sidecar — pass 2 decides
+		}
+		if !sweepMatchesFormat(d.Name(), format) {
+			kept++ // a book file of the format we were told not to touch
+			return nil
+		}
+		if ownedByOther != nil && ownedByOther(path) {
+			kept++
+			return nil
+		}
+		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- path is under an importer-sanitized DB row; #865 plans defense-in-depth root-check
+			slog.Warn("book delete: failed to remove file in book folder", "path", path, "error", rmErr)
+			kept++
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	if kept > 0 {
+		// Something in here still belongs to somebody. Leave the sidecars and
+		// the folder alone.
+		return nil
+	}
+
+	// Pass 2: no book file survives, so the leftovers are this book's sidecars.
+	walkErr = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if ownedByOther != nil && ownedByOther(path) {
+			kept++
+			return nil
+		}
+		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- path is under an importer-sanitized DB row; #865 plans defense-in-depth root-check
+			slog.Warn("book delete: failed to remove sidecar in book folder", "path", path, "error", rmErr)
+			kept++
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	if kept > 0 {
+		return nil
+	}
+	// Only (possibly nested) empty directories remain.
+	return os.RemoveAll(dir)
 }
 
 // sweepMatchesFormat reports whether the sibling file `name` belongs to the

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -746,6 +746,187 @@ func TestBookDeleteFile_FormatScopedAudiobookKeepsEbook(t *testing.T) {
 	}
 }
 
+// TestBookDeleteFile_AudiobookFolderKeepsEbookInside is the #2052 data-loss
+// guard. Audiobook imports register the destination *folder* in book_files, so
+// the format-scoped delete lands on a directory. That branch used to be an
+// unconditional os.RemoveAll, which took the ebook sitting in the same folder
+// with it — and left the ebook's book_files row behind, so it still showed in
+// the UI and 404'd on download.
+func TestBookDeleteFile_AudiobookFolderKeepsEbookInside(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+
+	// One shared folder, the layout #1959 asks to make the default.
+	dir := filepath.Join(t.TempDir(), "Test Author", "Shared Book")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	m4b := filepath.Join(dir, "Shared Book.m4b")
+	epub := filepath.Join(dir, "Shared Book.epub")
+	cover := filepath.Join(dir, "cover.jpg")
+	for _, p := range []string{m4b, epub, cover} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	book := &models.Book{
+		ForeignID: "B-SHAREDDIR", AuthorID: author.ID, Title: "Shared Book", SortTitle: "shared book",
+		Status: models.BookStatusImported, Genres: []string{}, MediaType: models.MediaTypeBoth,
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	// The audiobook row is the folder — what importer.Scanner records via
+	// SetFormatFilePath(destDir).
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, dir); err != nil {
+		t.Fatalf("AddBookFile(audiobook dir): %v", err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, epub); err != nil {
+		t.Fatalf("AddBookFile(epub): %v", err)
+	}
+
+	req := withURLParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/book/"+strconv.FormatInt(book.ID, 10)+"/file?format=audiobook", nil),
+		"id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.DeleteFile(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := os.Stat(epub); err != nil {
+		t.Fatalf("ebook inside the audiobook folder was destroyed — data loss (#2052): %v", err)
+	}
+	if _, err := os.Stat(m4b); !os.IsNotExist(err) {
+		t.Errorf("audiobook file should be removed, stat err=%v", err)
+	}
+	// The ebook is still there, so its artwork is still wanted.
+	if _, err := os.Stat(cover); err != nil {
+		t.Errorf("cover should survive while a book file remains in the folder, stat err=%v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("folder should survive while it still holds the ebook, stat err=%v", err)
+	}
+
+	// The ebook row must still be registered, and it must still point at a
+	// file that exists — the two halves that disagreed in the report.
+	files, err := books.ListFiles(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0].Format != models.MediaTypeEbook || files[0].Path != epub {
+		t.Errorf("expected the ebook row to survive alone, got %+v", files)
+	}
+}
+
+// TestBookDeleteFile_AudiobookFolderRemovedWhenAloneInIt is the other half of
+// #2052: scoping the delete must not turn a whole-folder audiobook delete into
+// a partial one that strands the folder and its artwork.
+func TestBookDeleteFile_AudiobookFolderRemovedWhenAloneInIt(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+
+	dir := filepath.Join(t.TempDir(), "Test Author", "Audio Only")
+	if err := os.MkdirAll(filepath.Join(dir, "Disc 1"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{
+		filepath.Join(dir, "cover.jpg"),
+		filepath.Join(dir, "Audio Only.cue"),
+		filepath.Join(dir, "Disc 1", "01.mp3"),
+		filepath.Join(dir, "Disc 1", "02.mp3"),
+	} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	book := &models.Book{
+		ForeignID: "B-AUDIOONLY", AuthorID: author.ID, Title: "Audio Only", SortTitle: "audio only",
+		Status: models.BookStatusImported, Genres: []string{}, MediaType: models.MediaTypeAudiobook,
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, dir); err != nil {
+		t.Fatalf("AddBookFile(audiobook dir): %v", err)
+	}
+
+	req := withURLParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/book/"+strconv.FormatInt(book.ID, 10)+"/file?format=audiobook", nil),
+		"id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.DeleteFile(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("audiobook folder should be gone when nothing else was in it, stat err=%v", err)
+	}
+}
+
+// TestBookDeleteFile_AudiobookFolderKeepsAnotherBooksFile is the #1368 guard
+// applied to the directory branch. safeRemoveBookPath only ever checked the
+// tracked path itself for other-book ownership, so a RemoveAll could take a
+// different book's file that happened to live under the folder.
+func TestBookDeleteFile_AudiobookFolderKeepsAnotherBooksFile(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+
+	dir := filepath.Join(t.TempDir(), "Test Author", "Omnibus")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	mine := filepath.Join(dir, "Omnibus.m4b")
+	theirs := filepath.Join(dir, "Book Two.m4b")
+	for _, p := range []string{mine, theirs} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	other := &models.Book{
+		ForeignID: "B-OTHER", AuthorID: author.ID, Title: "Book Two", SortTitle: "book two",
+		Status: models.BookStatusImported, Genres: []string{}, MediaType: models.MediaTypeAudiobook,
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, other); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, other.ID, models.MediaTypeAudiobook, theirs); err != nil {
+		t.Fatalf("AddBookFile(other): %v", err)
+	}
+
+	book := &models.Book{
+		ForeignID: "B-OMNIBUS", AuthorID: author.ID, Title: "Omnibus", SortTitle: "omnibus",
+		Status: models.BookStatusImported, Genres: []string{}, MediaType: models.MediaTypeAudiobook,
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, dir); err != nil {
+		t.Fatalf("AddBookFile(audiobook dir): %v", err)
+	}
+
+	req := withURLParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/book/"+strconv.FormatInt(book.ID, 10)+"/file?format=audiobook", nil),
+		"id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.DeleteFile(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := os.Stat(theirs); err != nil {
+		t.Fatalf("another book's file under the folder was destroyed (#1368): %v", err)
+	}
+	if _, err := os.Stat(mine); !os.IsNotExist(err) {
+		t.Errorf("this book's audiobook file should be removed, stat err=%v", err)
+	}
+}
+
 // TestListWanted returns only wanted-status books — the Wanted page query.
 func TestListWanted(t *testing.T) {
 	h, books, _, author, ctx := bookFixture(t)

--- a/internal/api/path_safety.go
+++ b/internal/api/path_safety.go
@@ -262,20 +262,32 @@ func safeRemoveBookPath(ctx context.Context, roots *LibraryRoots, owner bookFile
 	// file. Fail safe — if ownership can't be determined, skip the disk delete
 	// (the DB row is going away regardless; a stranded path is recoverable, a
 	// deleted file is not).
-	if owner != nil {
-		otherOwns, ownErr := owner.PathOwnedByOtherBook(ctx, p, excludeBookID)
+	//
+	// The same predicate is handed to removeBookPathScoped so it applies to
+	// every file that sweep reaches — same-stem siblings, and the contents of an
+	// audiobook folder — not only the tracked path passed in here. Checking p
+	// alone left the children of a directory delete unguarded (#2052).
+	ownedByOther := func(path string) bool {
+		if owner == nil {
+			return false
+		}
+		otherOwns, ownErr := owner.PathOwnedByOtherBook(ctx, path, excludeBookID)
 		if ownErr != nil {
-			fields := append([]any{"path", p, "operation", "book_file_delete", "error", ownErr}, logFields...)
+			fields := append([]any{"path", path, "operation", "book_file_delete", "error", ownErr}, logFields...)
 			slog.Warn("path ownership: could not verify book_files ownership; skipping disk delete", fields...)
-			return true, nil
+			return true
 		}
 		if otherOwns {
-			fields := append([]any{"path", p, "operation", "book_file_delete"}, logFields...)
+			fields := append([]any{"path", path, "operation", "book_file_delete"}, logFields...)
 			slog.Warn("path ownership: file still tracked by another book; skipping disk delete", fields...)
-			return true, nil
+			return true
 		}
+		return false
 	}
-	return false, removeBookPathScoped(p, format)
+	if ownedByOther(p) {
+		return true, nil
+	}
+	return false, removeBookPathScoped(p, format, ownedByOther)
 }
 
 // bookFileOwner reports whether an on-disk path is still registered in

--- a/internal/api/path_safety_test.go
+++ b/internal/api/path_safety_test.go
@@ -246,6 +246,16 @@ func TestRemoveBookDirScoped(t *testing.T) {
 			kept:   []string{"Other Book.m4b", "cover.jpg"},
 		},
 		{
+			// The guard must hold on the whole-book/author-delete path too,
+			// where sweepMatchesFormat matches everything.
+			name:   "an unscoped delete still leaves another book's file alone",
+			files:  []string{"Book.epub", "Book.m4b", "Other Book.m4b", "cover.jpg"},
+			format: "",
+			owned:  map[string]bool{"Other Book.m4b": true},
+			gone:   []string{"Book.epub", "Book.m4b"},
+			kept:   []string{"Other Book.m4b", "cover.jpg"},
+		},
+		{
 			name:   "an unknown format filter removes nothing",
 			files:  []string{"Book.m4b", "Book.epub"},
 			format: "graphicnovel",

--- a/internal/api/path_safety_test.go
+++ b/internal/api/path_safety_test.go
@@ -178,3 +178,182 @@ func TestLibraryRoots_NoConfigurationFallsOpen(t *testing.T) {
 		t.Error("no roots configured: Contains must fall open to preserve legacy behaviour")
 	}
 }
+
+// mustWrite creates path (and its parents) with placeholder contents.
+func mustWrite(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// TestRemoveBookDirScoped drives the directory branch directly. Handler-level
+// tests cover the reported #2052 flow; this covers the decision table without
+// building a database fixture per case.
+func TestRemoveBookDirScoped(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []string // relative to the book folder
+		format  string
+		owned   map[string]bool // relative paths another book still tracks
+		gone    []string
+		kept    []string
+		dirGone bool
+	}{
+		{
+			name:   "audiobook delete keeps the ebook and its cover",
+			files:  []string{"Book.m4b", "Book.epub", "cover.jpg"},
+			format: "audiobook",
+			gone:   []string{"Book.m4b"},
+			kept:   []string{"Book.epub", "cover.jpg"},
+		},
+		{
+			name:   "ebook delete keeps the audio files and their cover",
+			files:  []string{"Book.epub", "Book.mobi", "Disc 1/01.mp3", "cover.jpg"},
+			format: "ebook",
+			gone:   []string{"Book.epub", "Book.mobi"},
+			kept:   []string{"Disc 1/01.mp3", "cover.jpg"},
+		},
+		{
+			name:    "audiobook delete clears sidecars and the folder when nothing else is in it",
+			files:   []string{"Disc 1/01.mp3", "Disc 2/01.mp3", "cover.jpg", "Book.cue"},
+			format:  "audiobook",
+			gone:    []string{"Disc 1/01.mp3", "Disc 2/01.mp3", "cover.jpg", "Book.cue"},
+			dirGone: true,
+		},
+		{
+			name:    "unscoped delete takes everything",
+			files:   []string{"Book.epub", "Book.m4b", "cover.jpg"},
+			format:  "",
+			gone:    []string{"Book.epub", "Book.m4b", "cover.jpg"},
+			dirGone: true,
+		},
+		{
+			name:   "a file another book tracks is left behind, and keeps the folder alive",
+			files:  []string{"Book.m4b", "Other Book.m4b", "cover.jpg"},
+			format: "audiobook",
+			owned:  map[string]bool{"Other Book.m4b": true},
+			gone:   []string{"Book.m4b"},
+			kept:   []string{"Other Book.m4b", "cover.jpg"},
+		},
+		{
+			name:   "an unknown format filter removes nothing",
+			files:  []string{"Book.m4b", "Book.epub"},
+			format: "graphicnovel",
+			kept:   []string{"Book.m4b", "Book.epub"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "Author", "Book")
+			for _, rel := range tc.files {
+				mustWrite(t, filepath.Join(dir, filepath.FromSlash(rel)))
+			}
+			ownedByOther := func(p string) bool {
+				rel, err := filepath.Rel(dir, p)
+				if err != nil {
+					return false
+				}
+				return tc.owned[filepath.ToSlash(rel)]
+			}
+
+			if err := removeBookDirScoped(dir, tc.format, ownedByOther); err != nil {
+				t.Fatalf("removeBookDirScoped: %v", err)
+			}
+
+			for _, rel := range tc.gone {
+				if exists(filepath.Join(dir, filepath.FromSlash(rel))) {
+					t.Errorf("%s should have been removed", rel)
+				}
+			}
+			for _, rel := range tc.kept {
+				if !exists(filepath.Join(dir, filepath.FromSlash(rel))) {
+					t.Errorf("%s should have survived", rel)
+				}
+			}
+			if got := exists(dir); got == tc.dirGone {
+				t.Errorf("folder exists = %v, want %v", got, !tc.dirGone)
+			}
+		})
+	}
+}
+
+// TestRemoveBookDirScoped_NilPredicate covers the callers that have no
+// book_files repo to consult: with no ownership predicate the sweep proceeds.
+func TestRemoveBookDirScoped_NilPredicate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "Book")
+	mustWrite(t, filepath.Join(dir, "Book.m4b"))
+
+	if err := removeBookDirScoped(dir, "audiobook", nil); err != nil {
+		t.Fatalf("removeBookDirScoped: %v", err)
+	}
+	if exists(dir) {
+		t.Error("folder should be gone")
+	}
+}
+
+// stubOwner lets the ownership guard be driven without a database.
+type stubOwner struct {
+	owned map[string]bool
+	err   error
+}
+
+func (s stubOwner) PathOwnedByOtherBook(_ context.Context, path string, _ int64) (bool, error) {
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.owned[path], nil
+}
+
+// TestSafeRemoveBookPath_OwnershipErrorFailsSafe covers the deliberate
+// fail-closed branch: if ownership can't be established, the disk delete is
+// skipped. A stranded path is recoverable; a deleted file is not.
+func TestSafeRemoveBookPath_OwnershipErrorFailsSafe(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "Book")
+	m4b := mustWrite(t, filepath.Join(dir, "Book.m4b"))
+
+	skipped, err := safeRemoveBookPath(context.Background(), nil,
+		stubOwner{err: os.ErrPermission}, 1, dir, "audiobook")
+	if err != nil {
+		t.Fatalf("safeRemoveBookPath: %v", err)
+	}
+	if !skipped {
+		t.Error("expected skipped=true when ownership can't be verified")
+	}
+	if !exists(m4b) {
+		t.Error("file should survive an unverifiable ownership check")
+	}
+}
+
+// TestSafeRemoveBookPath_SiblingOwnedByAnotherBook is the file branch of the
+// same guard: the same-stem sweep must not take a sibling another book tracks.
+func TestSafeRemoveBookPath_SiblingOwnedByAnotherBook(t *testing.T) {
+	dir := t.TempDir()
+	target := mustWrite(t, filepath.Join(dir, "Book.epub"))
+	sibling := mustWrite(t, filepath.Join(dir, "Book.mobi"))
+
+	skipped, err := safeRemoveBookPath(context.Background(), nil,
+		stubOwner{owned: map[string]bool{sibling: true}}, 1, target, "ebook")
+	if err != nil {
+		t.Fatalf("safeRemoveBookPath: %v", err)
+	}
+	if skipped {
+		t.Error("the targeted file was not owned by another book; expected skipped=false")
+	}
+	if exists(target) {
+		t.Error("targeted file should be removed")
+	}
+	if !exists(sibling) {
+		t.Error("a sibling another book tracks must survive the stem sweep")
+	}
+}


### PR DESCRIPTION
Closes #2052.

## What happened

flaevers deleted an audiobook and lost the ebook that lived in the same folder. The UI kept showing the ebook; downloading it failed.

## Why

`removeBookPathScoped` (`internal/api/books.go`) has two branches. The file branch is carefully format-scoped — `sweepMatchesFormat`, and a comment explaining that it exists so `?format=ebook` cannot destroy the audiobook. The directory branch was:

```go
if info.IsDir() {
    return os.RemoveAll(p)   // format is never read
}
```

Audiobooks are always directories. `internal/importer/scanner.go:1488` registers `destDir` in `book_files` for `MediaTypeAudiobook`, so `DELETE /book/{id}/file?format=audiobook` resolves to a folder and hits that branch. Everything inside went, ebook included.

Only the audiobook's `book_files` row was then deregistered, which is why the ebook stayed visible and 404'd — the DB and the disk disagreed.

This gets worse, not better, with #1959 (share one book folder), which would make the collision the default layout rather than an accident.

## Second defect in the same place

`safeRemoveBookPath` checks `PathOwnedByOtherBook` on the path it is handed and nothing else. With `RemoveAll` on a directory, every file nested under it was unguarded — so a folder delete could unlink a different book's file. That is the exact failure #1368 was written to prevent, reintroduced through a path that guard never covered.

## Fix

`removeBookDirScoped` replaces the `RemoveAll`:

1. Walk the tree, removing book files whose extension matches the requested format. A book file of the other format, or one owned by another book, is left and counted.
2. If nothing was left, clear the sidecars (cover art, `.cue`, `.opf`) and remove the now-empty tree. If something was left, the sidecars stay — the surviving book still wants its artwork.

The ownership check becomes a predicate built in `safeRemoveBookPath` and threaded through the sweep, so it applies per file rather than only to the tracked path. The same-stem sibling sweep in the file branch now consults it too.

`format == ""` (whole-book delete, author delete) still clears everything, with the ownership guard now covering children.

## Tests

Three new guards in `internal/api/books_test.go`, each verified to fail against the old `os.RemoveAll`:

- `TestBookDeleteFile_AudiobookFolderKeepsEbookInside` — the reported case, including the assertion that the surviving `book_files` row points at a file that exists
- `TestBookDeleteFile_AudiobookFolderRemovedWhenAloneInIt` — scoping must not strand the folder when the audiobook was the only thing in it (multi-disc subfolder, cover, cue)
- `TestBookDeleteFile_AudiobookFolderKeepsAnotherBooksFile` — the #1368 guard applied to children

`internal/api` and `internal/importer` suites pass; `golangci-lint` clean.