### PR TITLE
fix(api): let bulk monitor mode set monitor_new_items (#2065)

### DIFF
--- a/changelog.d/2065-bulk-monitor-new-items.md
+++ b/changelog.d/2065-bulk-monitor-new-items.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Bulk "Set monitor mode" can now set whether authors accept newly
+  discovered books** (#2065) — the dialog wrote `monitor_mode` and nothing
+  else, so setting a whole library to *None* left every author still pulling in
+  its back-catalogue on the next refresh. The two settings are independent
+  (monitor mode decides what gets monitored, monitor new items decides whether a
+  refresh may create the rows at all), and the field was only reachable from the
+  single-author edit form. The bulk dialog now carries a **Monitor newly
+  discovered books** control alongside monitor mode, defaulting to *Leave
+  unchanged* so an existing bulk action behaves as before. Mode *None* still
+  does not imply it: that pairing is the supported "list the whole catalogue,
+  monitor none of it" setup.

--- a/docs/User-Guide-Wiki.md
+++ b/docs/User-Guide-Wiki.md
@@ -154,6 +154,12 @@ Two settings decide whether an author add stays a trickle or becomes a flood:
   have. Library imports (Calibre, ABS) set *Don't add them* on the authors they
   create, because those catalogues are partial by design.
 
+These two are independent, and monitor mode *None* is not a substitute for the
+second one: it means "list the catalogue, monitor none of it", so a refresh
+still adds the discovered books, just unmonitored. To stop them arriving at
+all, set **Monitor new items** to *Don't add them*. Both settings can be
+changed for many authors at once from Authors → select → **Set monitor mode**.
+
 The Books page shows the **whole catalogue** — monitored or not. "Why are
 there books here I never asked for?" is rule 2: unmonitored means "won't
 grab", not "won't list". Select the ones you never want and **Exclude** them.

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -178,6 +178,9 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 		MonitorMode                string  `json:"monitorMode"`
 		MonitorLatestCount         *int    `json:"monitorLatestCount"`
 		ApplyMonitorModeToExisting bool    `json:"applyMonitorModeToExisting"`
+		// Optional. Omitted leaves each author's existing value alone, so the
+		// bulk action stays additive for callers that predate it (#2065).
+		MonitorNewItems *string `json:"monitorNewItems"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -224,6 +227,14 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 		if req.MonitorLatestCount != nil && *req.MonitorLatestCount <= 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "monitorLatestCount must be a positive integer"})
 			return
+		}
+		if req.MonitorNewItems != nil {
+			v := strings.TrimSpace(*req.MonitorNewItems)
+			if !models.IsAuthorMonitorNewItemsValid(v) {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "monitorNewItems must be 'all' or 'none'"})
+				return
+			}
+			req.MonitorNewItems = &v
 		}
 	}
 
@@ -314,7 +325,7 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 		case "set_monitor_mode":
-			if err := h.setAuthorMonitorMode(r.Context(), id, req.MonitorMode, req.MonitorLatestCount, req.ApplyMonitorModeToExisting); err != nil {
+			if err := h.setAuthorMonitorMode(r.Context(), id, req.MonitorMode, req.MonitorLatestCount, req.MonitorNewItems, req.ApplyMonitorModeToExisting); err != nil {
 				resp.Results[key] = bulkItemResult{Error: err.Error()}
 				continue
 			}
@@ -528,7 +539,19 @@ func (h *BulkHandler) setAuthorMonitored(ctx context.Context, id int64, monitore
 	return h.authors.Update(ctx, author)
 }
 
-func (h *BulkHandler) setAuthorMonitorMode(ctx context.Context, id int64, mode string, latestCount *int, applyExisting bool) error {
+// setAuthorMonitorMode writes the author's monitor mode and, when the caller
+// supplied one, its monitor-new-items policy.
+//
+// The two are deliberately independent fields, not one derived from the other.
+// MonitorMode decides which books get monitored; MonitorNewItems decides
+// whether a refresh may create rows for books it has just discovered
+// (authorAcceptsDiscoveredBooks). Mode "none" with new items allowed is the
+// supported "list the whole catalogue, monitor none of it" setup that #1290's
+// Hardcover-list authors rely on, so setting mode alone must not imply either
+// value for the other field. Before #2065 the bulk path had no way to write
+// MonitorNewItems at all, which is why a library-wide "None" still pulled in
+// back-catalogues on the next refresh.
+func (h *BulkHandler) setAuthorMonitorMode(ctx context.Context, id int64, mode string, latestCount *int, newItems *string, applyExisting bool) error {
 	author, err := h.authors.GetByID(ctx, id)
 	if err != nil {
 		return err
@@ -543,6 +566,12 @@ func (h *BulkHandler) setAuthorMonitorMode(ctx context.Context, id int64, mode s
 			return fmt.Errorf("monitorLatestCount must be a positive integer")
 		}
 		author.MonitorLatestCount = *latestCount
+	}
+	if newItems != nil {
+		if !models.IsAuthorMonitorNewItemsValid(*newItems) {
+			return fmt.Errorf("monitorNewItems must be 'all' or 'none'")
+		}
+		author.MonitorNewItems = *newItems
 	}
 	if err := h.authors.Update(ctx, author); err != nil {
 		return err

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -568,6 +568,8 @@ func (h *BulkHandler) setAuthorMonitorMode(ctx context.Context, id int64, mode s
 		author.MonitorLatestCount = *latestCount
 	}
 	if newItems != nil {
+		// Already validated at the request boundary for the only current
+		// caller; kept so a future one can't write an unvalidated value.
 		if !models.IsAuthorMonitorNewItemsValid(*newItems) {
 			return fmt.Errorf("monitorNewItems must be 'all' or 'none'")
 		}

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -317,6 +317,9 @@ func TestAuthorsBulk_SetMonitorMode(t *testing.T) {
 func TestAuthorsBulk_SetMonitorNewItems(t *testing.T) {
 	h, authors, _, author, ctx := bulkFixture(t)
 
+	// The fixture author starts on the defaults (mode "all", new items "all"),
+	// so both assertions below are real transitions rather than no-ops.
+	author.MonitorMode = models.AuthorMonitorModeAll
 	author.MonitorNewItems = models.AuthorMonitorNewItemsAll
 	if err := authors.Update(ctx, author); err != nil {
 		t.Fatal(err)

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -311,6 +311,77 @@ func TestAuthorsBulk_SetMonitorMode(t *testing.T) {
 	}
 }
 
+// TestAuthorsBulk_SetMonitorNewItems covers #2065: the bulk dialog had no way
+// to write monitor_new_items, so a library-wide "None" left every author still
+// accepting newly-discovered books on the next refresh.
+func TestAuthorsBulk_SetMonitorNewItems(t *testing.T) {
+	h, authors, _, author, ctx := bulkFixture(t)
+
+	author.MonitorNewItems = models.AuthorMonitorNewItemsAll
+	if err := authors.Update(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"set_monitor_mode","monitorMode":"none","monitorNewItems":"none"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := authors.GetByID(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MonitorNewItems != models.AuthorMonitorNewItemsNone {
+		t.Errorf("monitorNewItems = %q, want none — the author still accepts discovered books (#2065)", got.MonitorNewItems)
+	}
+	if got.MonitorMode != models.AuthorMonitorModeNone {
+		t.Errorf("monitorMode = %q, want none", got.MonitorMode)
+	}
+	if authorAcceptsDiscoveredBooks(got) {
+		t.Error("author still accepts newly-discovered books after a bulk set to none")
+	}
+}
+
+// TestAuthorsBulk_SetMonitorModeLeavesNewItemsAlone is the compatibility half:
+// omitting monitorNewItems must not change it. Monitor mode "none" with new
+// items allowed is the supported "list the catalogue, monitor none of it"
+// setup (#1290), so writing one field must never imply the other.
+func TestAuthorsBulk_SetMonitorModeLeavesNewItemsAlone(t *testing.T) {
+	h, authors, _, author, ctx := bulkFixture(t)
+
+	author.MonitorNewItems = models.AuthorMonitorNewItemsAll
+	if err := authors.Update(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"set_monitor_mode","monitorMode":"none"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := authors.GetByID(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MonitorNewItems != models.AuthorMonitorNewItemsAll {
+		t.Errorf("monitorNewItems = %q, want all — an omitted field must not be rewritten", got.MonitorNewItems)
+	}
+}
+
+// TestAuthorsBulk_SetMonitorNewItemsInvalid rejects a value the single-author
+// handler would also reject, rather than storing it and normalising later.
+func TestAuthorsBulk_SetMonitorNewItemsInvalid(t *testing.T) {
+	h, _, _, author, _ := bulkFixture(t)
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"set_monitor_mode","monitorMode":"none","monitorNewItems":"sometimes"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestAuthorsBulk_SetMonitorModeLatest_AppliesToExistingBooks(t *testing.T) {
 	h, authors, books, author, ctx := bulkFixture(t)
 

--- a/web/src/api/bulk.ts
+++ b/web/src/api/bulk.ts
@@ -1,6 +1,6 @@
 import { request } from './core'
 import type { Book } from './books'
-import type { AuthorMonitorMode, MediaType } from './authors'
+import type { AuthorMonitorMode, MediaType, MonitorNewItems } from './authors'
 
 export type AuthorBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search' | 'refresh' | 'set_media_type'
 export type AuthorBulkMonitorMode = Exclude<AuthorMonitorMode, 'series'>
@@ -14,6 +14,9 @@ export interface BulkResult {
 export interface BulkSetAuthorMonitorModeOptions {
   monitorLatestCount?: number
   applyMonitorModeToExisting?: boolean
+  // Omit to leave each author's existing value alone. Monitor mode and
+  // monitor-new-items are independent settings on the server (#2065).
+  monitorNewItems?: MonitorNewItems
 }
 
 export const bulkApi = {
@@ -35,6 +38,7 @@ export const bulkApi = {
         monitorMode,
         ...(opts.monitorLatestCount !== undefined ? { monitorLatestCount: opts.monitorLatestCount } : {}),
         ...(opts.applyMonitorModeToExisting !== undefined ? { applyMonitorModeToExisting: opts.applyMonitorModeToExisting } : {}),
+        ...(opts.monitorNewItems !== undefined ? { monitorNewItems: opts.monitorNewItems } : {}),
       }),
     }),
   searchAuthorWanted: (id: number) =>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -192,6 +192,8 @@
     "bulkSetMonitorModeCount": "Selected authors: {{count}}",
     "bulkApplyMonitorModeToExisting": "Apply monitor mode to existing books",
     "bulkApplyMonitorModeToExistingHint": "Otherwise this only affects books discovered in future refreshes.",
+    "bulkMonitorNewItemsUnchanged": "Leave unchanged",
+    "bulkMonitorNewItemsHint": "Separate from monitor mode: this decides whether a refresh may add books it discovers at all. Monitor mode “None” on its own still lets the back-catalogue in, unmonitored.",
     "bulkSetMonitorModeApply": "Apply monitor mode",
     "bulkSetMonitorModeFailed": "Bulk monitor mode update failed",
     "bulkSetMonitorModePartial": "Monitor mode was not updated for author {{id}}: {{error}}",

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
-import { api, Author, AuthorBulkMonitorMode, MediaType, AuthorRefreshStatus } from '../api/client'
+import { api, Author, AuthorBulkMonitorMode, MediaType, MonitorNewItems, AuthorRefreshStatus } from '../api/client'
 import AddAuthorModal from '../components/AddAuthorModal'
 import AddBookModal from '../components/AddBookModal'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
@@ -42,6 +42,9 @@ export default function AuthorsPage() {
   const [bulkMonitorMode, setBulkMonitorMode] = useState<AuthorBulkMonitorMode>('none')
   const [bulkMonitorLatestCount, setBulkMonitorLatestCount] = useState(1)
   const [bulkApplyMonitorModeToExisting, setBulkApplyMonitorModeToExisting] = useState(true)
+  // '' = leave each author's existing value alone, which is what this dialog
+  // did before it could write the field at all (#2065).
+  const [bulkMonitorNewItems, setBulkMonitorNewItems] = useState<MonitorNewItems | ''>('')
   const [bulkMonitorModeError, setBulkMonitorModeError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
@@ -238,6 +241,7 @@ export default function AuthorsPage() {
     setBulkMonitorMode('none')
     setBulkMonitorLatestCount(1)
     setBulkApplyMonitorModeToExisting(true)
+    setBulkMonitorNewItems('')
     setBulkMonitorModeError(null)
     setShowMonitorModeBulk(true)
   }
@@ -256,6 +260,7 @@ export default function AuthorsPage() {
       const result = await api.bulkSetAuthorMonitorMode([...selectedIds], bulkMonitorMode, {
         monitorLatestCount: bulkMonitorMode === 'latest' ? bulkMonitorLatestCount : undefined,
         applyMonitorModeToExisting: bulkApplyMonitorModeToExisting,
+        monitorNewItems: bulkMonitorNewItems === '' ? undefined : bulkMonitorNewItems,
       })
       const failed = Object.entries(result.results).find(([, item]) => !item.ok)
       if (failed) {
@@ -601,6 +606,25 @@ export default function AuthorsPage() {
                   <option value="latest">{t('monitorMode.latest', 'Latest only')}</option>
                   <option value="none">{t('monitorMode.none', 'None')}</option>
                 </select>
+              </div>
+              <div>
+                <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1" htmlFor="bulk-monitor-new-items">
+                  {t('editAuthorModal.monitorNewItems', 'Monitor newly discovered books')}
+                </label>
+                <select
+                  id="bulk-monitor-new-items"
+                  value={bulkMonitorNewItems}
+                  onChange={e => setBulkMonitorNewItems(e.target.value as MonitorNewItems | '')}
+                  disabled={bulkBusy}
+                  className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500 disabled:opacity-50"
+                >
+                  <option value="">{t('authors.bulkMonitorNewItemsUnchanged', 'Leave unchanged')}</option>
+                  <option value="all">{t('monitorNewItems.all', 'Follow monitor mode')}</option>
+                  <option value="none">{t('monitorNewItems.none', 'Don’t add them')}</option>
+                </select>
+                <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">
+                  {t('authors.bulkMonitorNewItemsHint', 'Separate from monitor mode: this decides whether a refresh may add books it discovers at all. Monitor mode “None” on its own still lets the back-catalogue in, unmonitored.')}
+                </p>
               </div>
               {bulkMonitorMode === 'latest' && (
                 <div>


### PR DESCRIPTION
Closes #2065. clebcleb traced this one to the line, and the trace is correct.

## The gap

`AuthorsBulk` / `setAuthorMonitorMode` in `internal/api/bulk.go` write `MonitorMode` and `MonitorLatestCount`. The file contains no reference to `MonitorNewItems` at all. `applyMonitorModeToExistingBooks` only touches book-level `monitored`.

Discovery is gated on `MonitorNewItems`, not on the mode — `authorAcceptsDiscoveredBooks` in `internal/api/authors.go`. So selecting every author, setting monitor mode to None, and refreshing still pulled in the back-catalogue. From the report: 17 of 74 authors were still on `monitor_new_items='all'` after the bulk action, and exactly those 17 contributed all 385 books added that run.

The field was already fully wired for single-author edits (`authors.go` accepts and writes `monitorNewItems` as an optional pointer). It was just never added to the bulk request or handler, and there was no bulk control for it anywhere in the UI.

## What this does not do

It does not derive `monitor_new_items` from the mode. `authorAcceptsDiscoveredBooks` documents why:

> MonitorMode "none" is deliberately NOT in this list: with new items allowed it is the "list the whole catalogue, monitor none of it" setup (#1290's Hardcover-list authors are exactly that), and those rows are created unmonitored anyway.

Coupling the two would silently break that setup for anyone who bulk-sets a mode. They stay independent, exactly as the single-author form presents them.

## Changes

- `internal/api/bulk.go` — optional `monitorNewItems` on the request, validated with `models.IsAuthorMonitorNewItemsValid`, threaded into `setAuthorMonitorMode` as a pointer. Omitted means unchanged, so existing callers behave identically.
- `web/src/api/bulk.ts` — optional field on `BulkSetAuthorMonitorModeOptions`, only serialised when set.
- `web/src/pages/AuthorsPage.tsx` — a **Monitor newly discovered books** select in the bulk dialog: *Leave unchanged* (default), *Follow monitor mode*, *Don't add them*. Same labels as the per-author form.
- `docs/User-Guide-Wiki.md` — states that mode *None* is not a substitute for *Don't add them*, which is the misreading behind the report.

## Tests

- `TestAuthorsBulk_SetMonitorNewItems` — the reported case; asserts `authorAcceptsDiscoveredBooks` is false afterwards, not just that the column changed
- `TestAuthorsBulk_SetMonitorModeLeavesNewItemsAlone` — omitted field is not rewritten
- `TestAuthorsBulk_SetMonitorNewItemsInvalid` — 400 rather than storing a value that normalises later

Go suite, `golangci-lint`, `tsc --noEmit`, eslint and the AuthorsPage vitest file all pass.