### PR TITLE
feat(api): allow 'both' in bulk media-type edits, and expose them on the author page (#2066)

### DIFF
--- a/changelog.d/2066-bulk-set-both-media-type.md
+++ b/changelog.d/2066-bulk-set-both-media-type.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Bulk media-type editing gained a "Set Both" action, and works from the
+  author page** (#2066) — the Books view's bulk bar could set Ebook or
+  Audiobook but never the pair, because `POST /book/bulk` rejected
+  `mediaType: "both"` even though the author-level bulk action accepted it and
+  the underlying write is media-type agnostic. A batch of books owned in both
+  formats had to be corrected one at a time from each book's edit page. `both`
+  is now accepted, **📖🎧 Set Both** sits alongside the existing two buttons,
+  and all three are also available on an author page's book list — where a
+  media-type correction after a bad sync usually starts, and where the previous
+  workaround (filter the global Books view by author) cost the author-scoped
+  context the cleanup needs.

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -395,9 +395,17 @@ func (h *BulkHandler) BooksBulk(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown action: " + req.Action})
 		return
 	}
-	if req.Action == "set_media_type" && req.MediaType != models.MediaTypeEbook && req.MediaType != models.MediaTypeAudiobook {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "mediaType must be 'ebook' or 'audiobook'"})
-		return
+	// 'both' is accepted here for the same reason AuthorsBulk accepts it: a book
+	// owned in both formats is a first-class media type, and rejecting it left
+	// the Books bulk bar able to set either format but never the pair, so a
+	// batch correction had to be done one book at a time (#2066).
+	if req.Action == "set_media_type" {
+		switch req.MediaType {
+		case models.MediaTypeEbook, models.MediaTypeAudiobook, models.MediaTypeBoth:
+		default:
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "mediaType must be 'ebook', 'audiobook', or 'both'"})
+			return
+		}
 	}
 
 	resp := bulkResponse{Results: make(map[string]bulkItemResult, len(req.IDs))}

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -368,7 +368,8 @@ func (h *BulkHandler) fanOutSearches(books []models.Book) {
 // BooksBulk handles POST /api/v1/book/bulk.
 //
 // Supported actions: "monitor", "unmonitor", "delete", "search", "set_media_type", "exclude".
-// For "set_media_type" the body must also include "mediaType": "ebook"|"audiobook".
+// For "set_media_type" the body must also include "mediaType":
+// "ebook"|"audiobook"|"both".
 // "exclude" sets the book's excluded flag to true so it disappears from author
 // lists and is blocked from re-import on the next OL sync — mirrors the
 // single-book PUT /book/:id/exclude path but skips the toggle semantics

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -767,6 +767,42 @@ func TestBooksBulk_SetMediaType_Ebook(t *testing.T) {
 	}
 }
 
+// TestBooksBulk_SetMediaType_Both covers #2066: 'both' was rejected here even
+// though AuthorsBulk accepted it and setBookMediaType is media-type agnostic,
+// so a batch of dual-format books could only be corrected one at a time.
+func TestBooksBulk_SetMediaType_Both(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	ebookOnly := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_MT_BOTH_1", AuthorID: author.ID, Title: "Owned In Both",
+		SortTitle: "owned in both", Status: models.BookStatusWanted,
+		MediaType: models.MediaTypeEbook,
+		Genres:    []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+	audioOnly := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_MT_BOTH_2", AuthorID: author.ID, Title: "Also Owned In Both",
+		SortTitle: "also owned in both", Status: models.BookStatusWanted,
+		MediaType: models.MediaTypeAudiobook,
+		Genres:    []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d,%d],"action":"set_media_type","mediaType":"both"}`, ebookOnly.ID, audioOnly.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	for _, id := range []int64{ebookOnly.ID, audioOnly.ID} {
+		got, err := books.GetByID(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.MediaType != models.MediaTypeBoth {
+			t.Errorf("book %d: media type = %q, want both", id, got.MediaType)
+		}
+	}
+}
+
 func TestBooksBulk_SetMediaType_Invalid(t *testing.T) {
 	h, _, books, author, ctx := bulkFixture(t)
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -306,6 +306,7 @@
     "downloadFile": "Download file",
     "setEbook": "📖 Set Ebook",
     "setAudiobook": "🎧 Set Audiobook",
+    "setBoth": "📖🎧 Set Both",
     "mediaEbook": "📖 Ebook",
     "mediaAudiobook": "🎧 Audiobook",
     "mediaBoth": "📖🎧 Both",

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -515,9 +515,35 @@ describe('AuthorDetailPage', () => {
     fireEvent.click(excludeBtn)
 
     await waitFor(() => {
-      expect(api.bulkActionBooks).toHaveBeenCalledWith([101, 102], 'exclude')
+      expect(api.bulkActionBooks).toHaveBeenCalledWith([101, 102], 'exclude', undefined)
     })
     confirmSpy.mockRestore()
+  })
+
+  // #2066: the author page's book list had no media-type bulk action at all,
+  // so correcting several mistagged titles under one author meant editing each
+  // book or leaving the page for the global Books view.
+  it('bulk-sets media type from the author page book list', async () => {
+    vi.mocked(api.bulkActionBooks).mockResolvedValue({
+      results: { '301': { ok: true }, '302': { ok: true } },
+    })
+    renderAuthorDetailPage(
+      [
+        makeBook({ id: 301, title: 'Mistagged One', status: 'wanted' }),
+        makeBook({ id: 302, title: 'Mistagged Two', status: 'wanted' }),
+      ],
+      'table',
+    )
+
+    await screen.findByText('Mistagged One')
+    fireEvent.click(within(rowForTitle('Mistagged One')).getByRole('checkbox'))
+    fireEvent.click(within(rowForTitle('Mistagged Two')).getByRole('checkbox'))
+
+    fireEvent.click(await screen.findByRole('button', { name: '📖🎧 Set Both' }))
+
+    await waitFor(() => {
+      expect(api.bulkActionBooks).toHaveBeenCalledWith([301, 302], 'set_media_type', 'both')
+    })
   })
 
   it('surfaces partial-failure summary when some bulk actions fail', async () => {
@@ -651,7 +677,7 @@ describe('AuthorDetailPage', () => {
     expect(await screen.findByText('1 selected')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Monitor' }))
-    await waitFor(() => expect(api.bulkActionBooks).toHaveBeenCalledWith([401], 'monitor'))
+    await waitFor(() => expect(api.bulkActionBooks).toHaveBeenCalledWith([401], 'monitor', undefined))
   })
 
   it('groups books by series with a Standalone group when the toggle is on', async () => {

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
-import { api, Author, AuthorAlias, Book, BookBulkAction, Series } from '../api/client'
+import { api, Author, AuthorAlias, Book, BookBulkAction, MediaType, Series } from '../api/client'
 import ViewToggle from '../components/ViewToggle'
 import { bookStatusBadge } from '../components/bookStatus'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
@@ -315,14 +315,14 @@ export default function AuthorDetailPage() {
   // endpoint. The handler returns 200 with per-id outcomes even when some
   // rows fail (stale IDs, missing books) — surface the first error inline
   // so the user knows partial success happened without burying it.
-  const runBulk = async (action: BookBulkAction, actionLabel: string, confirmMsg?: string) => {
+  const runBulk = async (action: BookBulkAction, actionLabel: string, confirmMsg?: string, mediaType?: MediaType) => {
     if (selected.size === 0) return
     if (confirmMsg && !confirm(confirmMsg)) return
     setBulkBusy(true)
     setError(null)
     try {
       const ids = Array.from(selected)
-      const res = await api.bulkActionBooks(ids, action)
+      const res = await api.bulkActionBooks(ids, action, mediaType)
       let okCount = 0
       let firstError = ''
       for (const id of ids) {
@@ -1005,6 +1005,21 @@ export default function AuthorDetailPage() {
         actions={[
           { label: t('authorDetail.bulk.monitor'), onClick: () => runBulk('monitor', t('authorDetail.bulk.monitor')) },
           { label: t('authorDetail.bulk.unmonitor'), onClick: () => runBulk('unmonitor', t('authorDetail.bulk.unmonitor')) },
+          // Media-type corrections are author-scoped work in practice — a sync
+          // mistags several titles under one author — so they belong here as
+          // well as on the global Books view (#2066).
+          {
+            label: t('books.setEbook'),
+            onClick: () => runBulk('set_media_type', t('books.setEbook'), undefined, 'ebook'),
+          },
+          {
+            label: t('books.setAudiobook'),
+            onClick: () => runBulk('set_media_type', t('books.setAudiobook'), undefined, 'audiobook'),
+          },
+          {
+            label: t('books.setBoth'),
+            onClick: () => runBulk('set_media_type', t('books.setBoth'), undefined, 'both'),
+          },
           {
             label: t('authorDetail.bulk.exclude'),
             variant: 'caution',

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -7,7 +7,7 @@ import BookStatusLegend from '../components/BookStatusLegend'
 import { useView } from '../components/useView'
 import GettingStartedGuidance from '../components/GettingStartedGuidance'
 import { useNeedsSetup } from '../components/useNeedsSetup'
-import { api, BINDERY_BASE, Book } from '../api/client'
+import { api, BINDERY_BASE, Book, MediaType } from '../api/client'
 import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
 import { useServerPagination } from '../components/usePagination'
@@ -115,7 +115,7 @@ export default function BooksPage() {
   const selectAllOnPage = () => setSelectedIds(new Set(books.map(b => b.id)))
   const clearSelection = () => setSelectedIds(new Set())
 
-  const runBulk = async (action: Parameters<typeof api.bulkActionBooks>[1], mediaType?: 'ebook' | 'audiobook') => {
+  const runBulk = async (action: Parameters<typeof api.bulkActionBooks>[1], mediaType?: MediaType) => {
     if (selectedIds.size === 0) return
     if (action === 'delete' && !confirm(t('books.deleteConfirm', { count: selectedIds.size }))) return
     setBulkBusy(true)
@@ -418,6 +418,7 @@ export default function BooksPage() {
           { label: t('common.search'), onClick: () => runBulk('search') },
           { label: t('books.setEbook'), onClick: () => runBulk('set_media_type', 'ebook') },
           { label: t('books.setAudiobook'), onClick: () => runBulk('set_media_type', 'audiobook') },
+          { label: t('books.setBoth'), onClick: () => runBulk('set_media_type', 'both') },
           { label: t('common.delete'), onClick: () => runBulk('delete'), variant: 'danger' },
         ]}
       />


### PR DESCRIPTION
Closes #2066.

Two gaps, one of which turned out to be a backend restriction rather than a missing button.

## 1. `both` was rejected by the books bulk endpoint

`BooksBulk` in `internal/api/bulk.go` validated:

```go
if req.Action == "set_media_type" && req.MediaType != models.MediaTypeEbook && req.MediaType != models.MediaTypeAudiobook {
```

`AuthorsBulk` right above it accepts `both`, and `setBookMediaType` is media-type agnostic — it assigns and calls `reevaluateBookStatus`, which already handles `both` through `NeedsEbook()/NeedsAudiobook()`. So the value was rejected at the door for no reason the rest of the path shares. Now validated with the same three-way switch as the author action.

## 2. The author page's book list had no media-type action

Its bulk bar had Monitor / Unmonitor / Exclude / Delete. The workaround was to filter the global Books view by author, which drops the author-scoped context the cleanup uses. All three media-type actions are now on both bars.

## Changes

- `internal/api/bulk.go` — `BooksBulk` accepts `both`
- `web/src/pages/BooksPage.tsx` — **📖🎧 Set Both** button; `runBulk`'s media-type parameter widened from the inline `'ebook' | 'audiobook'` to `MediaType`
- `web/src/pages/AuthorDetailPage.tsx` — `runBulk` takes an optional media type and forwards it; Set Ebook / Set Audiobook / Set Both added to the bar
- `web/src/i18n/locales/en.json` — `books.setBoth`

## Tests

- `TestBooksBulk_SetMediaType_Both` — two books, one ebook-only and one audiobook-only, both end on `both`
- `bulk-sets media type from the author page book list` in `AuthorDetailPage.test.tsx`

Two existing assertions in `AuthorDetailPage.test.tsx` were pinned to the old two-argument `bulkActionBooks` call and now expect the third parameter.

Go suite, `golangci-lint`, `tsc --noEmit` and eslint all clean.