### PR TITLE
fix(migrate): strip the UTF-8 BOM from imported CSVs (#2075)

### DIFF
--- a/changelog.d/2075-csv-bom.md
+++ b/changelog.d/2075-csv-bom.md
@@ -1,0 +1,10 @@
+### Fixed
+- **CSV imports of files saved by Excel, Google Sheets or Numbers** (#2075) —
+  those apps put a byte order mark at the start of a UTF-8 CSV, and it used to
+  stick to the first cell. The header row was no longer recognised as a header,
+  so it was imported as if it were an author name, matched some unrelated
+  person on OpenLibrary, and pulled in that stranger's whole catalogue — often
+  hundreds of provider requests, rate limiting and a bogus author in your
+  library. The mark is now stripped before parsing, for author CSVs (both the
+  two-column and the plain name-per-line form) and for Goodreads exports, where
+  it made the Title column unfindable and the import fail outright.

--- a/internal/migrate/csv.go
+++ b/internal/migrate/csv.go
@@ -4,6 +4,7 @@
 package migrate
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/csv"
@@ -148,6 +149,30 @@ type csvRow struct {
 	monitored bool
 }
 
+// utf8BOM is the UTF-8 encoding of U+FEFF. Excel, Google Sheets and Numbers all
+// write it at the head of a CSV they save as UTF-8, and it is not data: left in
+// place it becomes part of the first cell, so a header cell reads "\ufeffname"
+// and no longer matches the header names we skip on. The header row then gets
+// imported as if it were an author, and the resulting metadata search burns a
+// provider lookup on a name that does not exist (#2075).
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// stripBOM removes a single leading UTF-8 BOM. Only at the very start, and only
+// one: a BOM anywhere else is a legitimate (if odd) character in a cell.
+func stripBOM(b []byte) []byte {
+	return bytes.TrimPrefix(b, utf8BOM)
+}
+
+// skipBOM wraps a reader so a leading UTF-8 BOM is consumed before the caller
+// sees any bytes. For readers parsed as a stream rather than read whole.
+func skipBOM(reader io.Reader) io.Reader {
+	br := bufio.NewReader(reader)
+	if prefix, err := br.Peek(len(utf8BOM)); err == nil && bytes.Equal(prefix, utf8BOM) {
+		_, _ = br.Discard(len(utf8BOM))
+	}
+	return br
+}
+
 func parseCSVRows(reader io.Reader) ([]csvRow, error) {
 	// Read everything upfront. bufio.ReadLine returns a slice into its internal
 	// buffer; any subsequent read reuses that buffer and would corrupt the slice
@@ -157,6 +182,9 @@ func parseCSVRows(reader io.Reader) ([]csvRow, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read csv: %w", err)
 	}
+	// Strip before anything inspects the bytes, including the first-line comma
+	// check below, so both the CSV branch and the bare-name branch are covered.
+	all = stripBOM(all)
 	if len(all) == 0 {
 		return nil, nil
 	}

--- a/internal/migrate/csv_test.go
+++ b/internal/migrate/csv_test.go
@@ -159,6 +159,33 @@ func TestParseCSVRows(t *testing.T) {
 			},
 		},
 		{
+			// #2075: a spreadsheet app writes a UTF-8 BOM at the head of the
+			// file. Without stripping it the header cell reads "\ufeffname",
+			// misses the header check, and gets imported as an author.
+			name: "csv with BOM-prefixed header row skipped",
+			in:   "\ufeffname,monitored\nAndy Weir,true\nIsaac Asimov,false\n",
+			want: []csvRow{
+				{name: "Andy Weir", monitored: true},
+				{name: "Isaac Asimov", monitored: false},
+			},
+		},
+		{
+			// #2075: the bare-name branch has no header to skip, but the BOM
+			// still lands in the first name unless it is stripped before the
+			// first-line comma check picks a branch.
+			name: "bare-name list with BOM",
+			in:   "\ufeffAndy Weir\nN. K. Jemisin\n",
+			want: []csvRow{
+				{name: "Andy Weir", monitored: true},
+				{name: "N. K. Jemisin", monitored: true},
+			},
+		},
+		{
+			name: "BOM only",
+			in:   "\ufeff",
+			want: nil,
+		},
+		{
 			name: "empty input",
 			in:   "",
 			want: nil,

--- a/internal/migrate/goodreads_csv.go
+++ b/internal/migrate/goodreads_csv.go
@@ -65,7 +65,10 @@ func ParseGoodreadsCSV(reader io.Reader) ([]GoodreadsRow, error) {
 		return nil, errors.New("reader is nil")
 	}
 
-	cr := csv.NewReader(reader)
+	// Goodreads exports saved through a spreadsheet app carry a UTF-8 BOM, which
+	// would otherwise glue itself to the first header cell and make the Title
+	// column unresolvable (#2075).
+	cr := csv.NewReader(skipBOM(reader))
 	cr.FieldsPerRecord = -1 // tolerate ragged rows; we index by header
 	cr.LazyQuotes = true    // Goodreads descriptions occasionally contain stray quotes
 

--- a/internal/migrate/goodreads_csv_test.go
+++ b/internal/migrate/goodreads_csv_test.go
@@ -173,3 +173,28 @@ func TestGoodreadsAuthorFromLF(t *testing.T) {
 		}
 	}
 }
+
+// TestParseGoodreadsCSV_BOM covers #2075: a Goodreads export re-saved from a
+// spreadsheet app starts with a UTF-8 BOM, which would glue itself to the
+// first header cell and make the mandatory Title column unresolvable.
+func TestParseGoodreadsCSV_BOM(t *testing.T) {
+	const in = "\ufeffTitle,Author,Exclusive Shelf\n" +
+		"Project Hail Mary,Andy Weir,to-read\n"
+
+	rows, err := ParseGoodreadsCSV(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("ParseGoodreadsCSV: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1: %+v", len(rows), rows)
+	}
+	if rows[0].Title != "Project Hail Mary" {
+		t.Errorf("title = %q, want %q", rows[0].Title, "Project Hail Mary")
+	}
+	if rows[0].Author != "Andy Weir" {
+		t.Errorf("author = %q, want %q", rows[0].Author, "Andy Weir")
+	}
+	if rows[0].ExclusiveShelf != GoodreadsShelfToRead {
+		t.Errorf("shelf = %q, want %q", rows[0].ExclusiveShelf, GoodreadsShelfToRead)
+	}
+}


### PR DESCRIPTION
Refs #2075. This is one part of that issue; the provider-level rate limiting and 429 backoff it also asks for are not addressed here, so the issue stays open.

## What changed

`parseCSVRows` now strips a single leading UTF-8 BOM from the input before anything inspects the bytes, including the first-line comma check that chooses between the `encoding/csv` branch and the bare-name list branch. One strip at the top covers both branches.

`ParseGoodreadsCSV` does not share `parseCSVRows`, and it had the same defect, so its reader is now wrapped with `skipBOM` before `csv.NewReader`.

## Why

A CSV saved as UTF-8 by Excel, Google Sheets or Numbers starts with a byte order mark. The first header cell then read as a BOM-prefixed `name`, missed the `headerFields` lookup, and the header row was imported as an author name. OpenLibrary got searched for the percent-encoded BOM (`q=%EF%BB%BFname`), matched an unrelated author (OL5631454A in the report), and Bindery paginated that stranger's whole catalogue. That accounts for a large share of the 557 provider requests in the issue, the 429s and timeouts that followed, and it left a bogus author record behind.

The bare-name (no comma) form was affected too, more quietly: the first line became the author `﻿Andy Weir`, which resolves to whatever OpenLibrary makes of it. Stripping before the comma check fixes that case with the same call.

Goodreads exports failed differently. The mark stuck to the first header cell, the mandatory Title column never resolved, and the import aborted with "missing a Title column".

## How it was verified

New cases in `internal/migrate/csv_test.go`: a BOM-prefixed two-column header is skipped and only the real rows import, a BOM-prefixed bare-name list imports `Andy Weir` rather than the BOM-prefixed spelling, and a BOM-only input parses to nothing. Plus `TestParseGoodreadsCSV_BOM` in `internal/migrate/goodreads_csv_test.go`. All four fail with the strip removed and pass with it.

`go build ./...`, `go vet ./...`, `gofmt -l .`, and `go test ./internal/migrate/... ./internal/metadata/...` are green.

No env var, config or documented surface changes, so no docs update.

