### PR TITLE
fix(hardcover): skip every query when no api token is configured (#2075)

### DIFF
--- a/changelog.d/2075-hardcover-unconfigured-guard.md
+++ b/changelog.d/2075-hardcover-unconfigured-guard.md
@@ -1,0 +1,11 @@
+### Fixed
+- **Hardcover no longer hammered when no API token is set** (#2075) — a bulk CSV
+  author import on a fresh config fired hundreds of Hardcover requests that came
+  back `401 Unable to verify token` and then `429 Throttled`, because only one
+  of the client's queries checked for a token first. Every Hardcover query now
+  short-circuits as "not configured" before any network call, so an install
+  without a token makes no Hardcover requests at all. Adding a token still takes
+  effect immediately, with no restart.
+- **Honest Hardcover line in the startup log** (#2075) — startup always logged
+  `hardcover enrichment enabled`, even with no token configured. It now logs
+  `hardcover enrichment idle: no api token configured` in that case.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -281,8 +281,17 @@ func main() {
 	hcClient := hardcover.New().WithTokenSource(func(ctx context.Context) string {
 		return api.GetHardcoverAPIToken(ctx, settingsRepo)
 	})
+	// The enricher is registered whether or not a token is set: the token is
+	// read live per request through WithTokenSource, so configuring one later
+	// takes effect without a restart. Only the log line is conditional, so it
+	// no longer claims enrichment is running when every call will short-circuit
+	// as unconfigured (#2075).
 	enrichers = append(enrichers, hcClient)
-	slog.Info("hardcover enrichment enabled")
+	if api.GetHardcoverAPIToken(context.Background(), settingsRepo) != "" {
+		slog.Info("hardcover enrichment enabled")
+	} else {
+		slog.Info("hardcover enrichment idle: no api token configured")
+	}
 
 	// Add the non-primary provider as enricher so metadata is always
 	// cross-checked regardless of which provider is primary.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -130,7 +130,7 @@ Bindery's primary metadata provider is OpenLibrary or DNB (the German national l
 
 The provider dropdown in `Settings → General` only offers **OpenLibrary** or **DNB** for the *primary* provider. Hardcover cannot be set as the primary, and it does not need to be: it always runs as a **search enricher**. Add Book and Add Author fan the query out to the primary provider **plus** Hardcover (and Google Books, if an API key is set), then merge in any titles the primary didn't return. Books that only exist on hardcover.app are exactly what that path is meant to surface.
 
-The catch is that **Hardcover's GraphQL API requires an API token for every query, including search** — an unauthenticated request returns `{"error":"Unable to verify token"}`. Bindery skips a provider that errors rather than failing the whole search, so without a token Hardcover contributes nothing silently and you only see OpenLibrary / DNB results.
+The catch is that **Hardcover's GraphQL API requires an API token for every query, including search** — an unauthenticated request returns `{"error":"Unable to verify token"}`. With no token saved, Bindery skips Hardcover before sending anything, so it contributes nothing silently and you only see OpenLibrary / DNB results. Startup says so too: the log reads `hardcover enrichment idle: no api token configured` instead of `hardcover enrichment enabled`. Saving a token takes effect on the next lookup, with no restart.
 
 **Fix:** add a Hardcover API token in `Settings → General` (the same token used for [Enhanced Hardcover Series](./Hardcover-Series-Wiki.md) and wishlist features), then re-run the search. Hardcover-only titles should appear in the merged results.
 

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -113,6 +113,9 @@ func (c *Client) SearchAuthors(ctx context.Context, query string) ([]models.Auth
 	if query == "" {
 		return nil, nil
 	}
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
+	}
 	gql := `query SearchAuthors($query: String!, $queryType: String!, $perPage: Int!) {
 		search(query: $query, query_type: $queryType, per_page: $perPage) {
 			results
@@ -144,6 +147,9 @@ func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, 
 	query = strings.TrimSpace(query)
 	if query == "" {
 		return nil, nil
+	}
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
 	}
 	gql := `query SearchBooks($query: String!, $queryType: String!, $perPage: Int!) {
 		search(query: $query, query_type: $queryType, per_page: $perPage) {
@@ -252,6 +258,9 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 }
 
 func (c *Client) GetAuthor(ctx context.Context, foreignID string) (*models.Author, error) {
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
+	}
 	id := strings.TrimPrefix(foreignID, idPrefix)
 	const slugGQL = `query GetAuthor($slug: String!) {
 		authors(where: {slug: {_eq: $slug}}, limit: 1) {
@@ -303,6 +312,9 @@ func (c *Client) GetAuthor(ctx context.Context, foreignID string) (*models.Autho
 }
 
 func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, error) {
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
+	}
 	id := strings.TrimPrefix(foreignID, idPrefix)
 	const slugGQL = `query GetBook($slug: String!) {
 		books(where: {slug: {_eq: $slug}}, limit: 1) {
@@ -375,6 +387,9 @@ func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]model
 	id := strings.TrimSpace(strings.TrimPrefix(bookForeignID, idPrefix))
 	if id == "" {
 		return nil, nil
+	}
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
 	}
 
 	const slugGQL = `query GetEditions($slug: String!, $limit: Int!, $offset: Int!) {
@@ -468,6 +483,9 @@ func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]model
 }
 
 func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, error) {
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
+	}
 	gql := `query GetBookByISBN($isbn: String!) {
 		editions(where: {_or: [{isbn_10: {_eq: $isbn}}, {isbn_13: {_eq: $isbn}}]}, limit: 1) {
 			language { language }

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -65,10 +65,24 @@ func gqlResponse(t *testing.T, statusCode int, data interface{}) *http.Response 
 	}
 }
 
+// mockClientToken is the token newMockClient sets. Every query method
+// short-circuits without one (see TestUnconfiguredClient_MakesNoRequests), so a
+// mock client needs a token to reach its transport at all.
+const mockClientToken = "hc-mock-token"
+
+// newUnconfiguredMockClient is newMockClient without a token, for the
+// unconfigured-provider guards.
+func newUnconfiguredMockClient(handler func(*http.Request) (*http.Response, error)) *Client {
+	return &Client{
+		http: &http.Client{Transport: &testTransport{handler: handler}},
+	}
+}
+
 // newMockClient creates a hardcover Client backed by a custom transport.
 func newMockClient(handler func(*http.Request) (*http.Response, error)) *Client {
 	return &Client{
-		http: &http.Client{Transport: &testTransport{handler: handler}},
+		http:  &http.Client{Transport: &testTransport{handler: handler}},
+		token: mockClientToken,
 	}
 }
 
@@ -739,7 +753,7 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 
 func TestGetAuthorWorksByName_NoTokenSkipsRequest(t *testing.T) {
 	called := false
-	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+	c := newUnconfiguredMockClient(func(r *http.Request) (*http.Response, error) {
 		called = true
 		return gqlResponse(t, http.StatusOK, map[string]interface{}{}), nil
 	})
@@ -1757,7 +1771,7 @@ func TestWithToken(t *testing.T) {
 func TestGetUserWishlist_NoToken(t *testing.T) {
 	// Without a token, GetUserWishlist must return (nil, nil) without calling the API.
 	called := false
-	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+	c := newUnconfiguredMockClient(func(r *http.Request) (*http.Response, error) {
 		called = true
 		return gqlResponse(t, http.StatusOK, map[string]interface{}{}), nil
 	})

--- a/internal/metadata/hardcover/lists.go
+++ b/internal/metadata/hardcover/lists.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -133,6 +134,9 @@ func hcShelfStatusID(listID int) (int, bool) {
 // Did Not Finish). Built-in shelves always appear even when the user has no
 // custom lists, which was the root cause of the "No lists found" report.
 func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
+	}
 	gql := `query GetUserLists {
 		me {
 			want_to_read: user_books_aggregate(where: {status_id: {_eq: 1}}) {
@@ -211,6 +215,9 @@ func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
 // ("want-to-read", ...), so the username is what makes a saved list's
 // identity unique across accounts: (slug, account).
 func (c *Client) GetUsername(ctx context.Context) (string, error) {
+	if c.authorizationToken(ctx) == "" {
+		return "", metadata.ErrProviderNotConfigured
+	}
 	gql := `query GetUsername {
 		me {
 			username
@@ -245,6 +252,9 @@ func (a hcCountAggregate) count() int {
 // GetListBooks returns all books in the given list as Bindery models.
 // Negative listIDs refer to built-in Hardcover shelves (see hcBuiltinShelves).
 func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, error) {
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
+	}
 	if statusID, ok := hcShelfStatusID(listID); ok {
 		return c.getShelfBooks(ctx, statusID)
 	}

--- a/internal/metadata/hardcover/series.go
+++ b/internal/metadata/hardcover/series.go
@@ -24,6 +24,9 @@ func (c *Client) SearchSeries(ctx context.Context, query string, limit int) ([]m
 	if limit <= 0 {
 		limit = 10
 	}
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
+	}
 	gql := `query SearchSeries($query: String!, $queryType: String!, $perPage: Int!) {
 		search(query: $query, query_type: $queryType, per_page: $perPage) {
 			ids
@@ -60,6 +63,9 @@ func (c *Client) SearchSeries(ctx context.Context, query string, limit int) ([]m
 
 // GetSeriesCatalog fetches the ordered books in a Hardcover series.
 func (c *Client) GetSeriesCatalog(ctx context.Context, foreignID string) (*metadata.SeriesCatalog, error) {
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
+	}
 	seriesID, err := hardcoverSeriesNumericID(foreignID)
 	if err != nil {
 		return nil, err

--- a/internal/metadata/hardcover/unconfigured_test.go
+++ b/internal/metadata/hardcover/unconfigured_test.go
@@ -1,0 +1,204 @@
+package hardcover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/metadata"
+)
+
+// hardcoverQueryCalls names every exported Client method that issues a GraphQL
+// query, so the guard tests below stay in step with the API surface.
+func hardcoverQueryCalls() []struct {
+	name string
+	call func(context.Context, *Client) error
+} {
+	return []struct {
+		name string
+		call func(context.Context, *Client) error
+	}{
+		{"SearchAuthors", func(ctx context.Context, c *Client) error {
+			authors, err := c.SearchAuthors(ctx, "Frank Herbert")
+			if authors != nil {
+				return fmt.Errorf("authors = %+v, want nil", authors)
+			}
+			return err
+		}},
+		{"SearchBooks", func(ctx context.Context, c *Client) error {
+			books, err := c.SearchBooks(ctx, "Dune")
+			if books != nil {
+				return fmt.Errorf("books = %+v, want nil", books)
+			}
+			return err
+		}},
+		{"GetAuthorWorksByName", func(ctx context.Context, c *Client) error {
+			books, err := c.GetAuthorWorksByName(ctx, "Frank Herbert")
+			if books != nil {
+				return fmt.Errorf("books = %+v, want nil", books)
+			}
+			return err
+		}},
+		{"GetAuthor", func(ctx context.Context, c *Client) error {
+			author, err := c.GetAuthor(ctx, "hc:frank-herbert")
+			if author != nil {
+				return fmt.Errorf("author = %+v, want nil", author)
+			}
+			return err
+		}},
+		{"GetBook", func(ctx context.Context, c *Client) error {
+			book, err := c.GetBook(ctx, "hc:dune")
+			if book != nil {
+				return fmt.Errorf("book = %+v, want nil", book)
+			}
+			return err
+		}},
+		{"GetEditions", func(ctx context.Context, c *Client) error {
+			editions, err := c.GetEditions(ctx, "hc:dune")
+			if editions != nil {
+				return fmt.Errorf("editions = %+v, want nil", editions)
+			}
+			return err
+		}},
+		{"GetBookByISBN", func(ctx context.Context, c *Client) error {
+			book, err := c.GetBookByISBN(ctx, "9780441013593")
+			if book != nil {
+				return fmt.Errorf("book = %+v, want nil", book)
+			}
+			return err
+		}},
+		{"SearchSeries", func(ctx context.Context, c *Client) error {
+			results, err := c.SearchSeries(ctx, "Dune", 5)
+			if results != nil {
+				return fmt.Errorf("results = %+v, want nil", results)
+			}
+			return err
+		}},
+		{"GetSeriesCatalog", func(ctx context.Context, c *Client) error {
+			catalog, err := c.GetSeriesCatalog(ctx, "hc-series:42")
+			if catalog != nil {
+				return fmt.Errorf("catalog = %+v, want nil", catalog)
+			}
+			return err
+		}},
+		{"GetUserLists", func(ctx context.Context, c *Client) error {
+			lists, err := c.GetUserLists(ctx)
+			if lists != nil {
+				return fmt.Errorf("lists = %+v, want nil", lists)
+			}
+			return err
+		}},
+		{"GetUsername", func(ctx context.Context, c *Client) error {
+			username, err := c.GetUsername(ctx)
+			if username != "" {
+				return fmt.Errorf("username = %q, want empty", username)
+			}
+			return err
+		}},
+		{"GetListBooks", func(ctx context.Context, c *Client) error {
+			books, err := c.GetListBooks(ctx, 7)
+			if books != nil {
+				return fmt.Errorf("books = %+v, want nil", books)
+			}
+			return err
+		}},
+	}
+}
+
+// countingServerTransport points the client at a local test server, since the
+// GraphQL endpoint is a package constant, and counts the requests that reach it.
+type countingServerTransport struct {
+	base  *url.URL
+	inner http.RoundTripper
+	calls atomic.Int64
+}
+
+func (t *countingServerTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.calls.Add(1)
+	clone := r.Clone(r.Context())
+	clone.URL.Scheme = t.base.Scheme
+	clone.URL.Host = t.base.Host
+	return t.inner.RoundTrip(clone)
+}
+
+func newCountingServer(t *testing.T) *countingServerTransport {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	t.Cleanup(srv.Close)
+	base, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	return &countingServerTransport{base: base, inner: srv.Client().Transport}
+}
+
+// TestUnconfiguredClient_MakesNoRequests is the #2075 regression test. A bulk
+// author import on a config with no Hardcover token fired hundreds of requests
+// that could only come back 401 and then 429, because the token guard existed
+// on GetAuthorWorksByName alone.
+func TestUnconfiguredClient_MakesNoRequests(t *testing.T) {
+	for _, tc := range hardcoverQueryCalls() {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := newCountingServer(t)
+			c := &Client{http: &http.Client{Transport: transport}}
+
+			err := tc.call(context.Background(), c)
+			if !errors.Is(err, metadata.ErrProviderNotConfigured) {
+				t.Fatalf("error = %v, want ErrProviderNotConfigured", err)
+			}
+			if got := transport.calls.Load(); got != 0 {
+				t.Fatalf("HTTP requests = %d, want 0", got)
+			}
+		})
+	}
+}
+
+// TestConfiguredClient_StillReachesServer is the other half of the guard: with
+// a token every one of those calls is a real request again.
+func TestConfiguredClient_StillReachesServer(t *testing.T) {
+	for _, tc := range hardcoverQueryCalls() {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := newCountingServer(t)
+			c := (&Client{http: &http.Client{Transport: transport}}).WithToken("hc-token")
+
+			_ = tc.call(context.Background(), c)
+			if got := transport.calls.Load(); got == 0 {
+				t.Fatal("HTTP requests = 0, want at least 1 once a token is configured")
+			}
+		})
+	}
+}
+
+// TestUnconfiguredClient_TokenSourceCanArriveLater covers why the enricher
+// stays registered at startup: the token is resolved per request, so setting
+// one in the UI takes effect without a restart.
+func TestUnconfiguredClient_TokenSourceCanArriveLater(t *testing.T) {
+	transport := newCountingServer(t)
+	token := ""
+	c := (&Client{http: &http.Client{Transport: transport}}).WithTokenSource(func(context.Context) string {
+		return token
+	})
+
+	if _, err := c.SearchBooks(context.Background(), "Dune"); !errors.Is(err, metadata.ErrProviderNotConfigured) {
+		t.Fatalf("SearchBooks without token: error = %v, want ErrProviderNotConfigured", err)
+	}
+	if got := transport.calls.Load(); got != 0 {
+		t.Fatalf("HTTP requests before a token = %d, want 0", got)
+	}
+
+	token = "hc-token"
+	if _, err := c.SearchBooks(context.Background(), "Dune"); err != nil {
+		t.Fatalf("SearchBooks with token: %v", err)
+	}
+	if got := transport.calls.Load(); got != 1 {
+		t.Fatalf("HTTP requests after a token = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
Refs #2075. This is one part of that issue; the provider-level rate limiting and 429 backoff it also asks for are not addressed here, so the issue stays open.

## What was happening

A bulk CSV author import on a config with no Hardcover API token fired 447 Hardcover requests. 240 came back `401 Unable to verify token`, then Hardcover throttled the rest with 205 `429`s. Hardcover's GraphQL API requires a token for every query, search included, so not one of those requests could have succeeded.

The token guard already existed, but only on `GetAuthorWorksByName`. Every other query method went straight to the network.

## What changed

**Client guards.** `metadata.ErrProviderNotConfigured` is now returned before any HTTP work from `SearchAuthors`, `SearchBooks`, `GetAuthor`, `GetBook`, `GetEditions`, `GetBookByISBN` (client.go), `SearchSeries`, `GetSeriesCatalog` (series.go), and `GetUserLists`, `GetUsername`, `GetListBooks` (lists.go). `GetUserWishlist` was already guarded and returns `(nil, nil)`; left as is so its callers keep their current contract.

**Honest startup log.** The enricher is still registered unconditionally, on purpose: the token is resolved live per request via `WithTokenSource`, so saving one in the UI takes effect without a restart. Only the log line is conditional now, `hardcover enrichment idle: no api token configured` when there is no token.

The aggregator already treats the sentinel as a quiet skip: `aggregator.go:191` excludes it from the warn and from `firstErr`, `aggregator_author_candidates.go:32` and `aggregator_author_works.go:94` continue past it, and `GetBookByISBN` logs it at debug as `skippedUnconfigured`. `enrichBook` logs any enricher failure at debug. So the 401s that used to be logged become silence, and nothing new is logged or counted as an error.

## Verified

`go build ./...`, `go vet ./...`, `gofmt -l .`, and the full `go test ./internal/...` suite pass.

New `internal/metadata/hardcover/unconfigured_test.go` covers all eleven guarded methods plus `GetAuthorWorksByName` in a table:

- unconfigured client returns `ErrProviderNotConfigured` and the counting test server sees **zero** requests
- the same calls with a token reach the server
- a client whose token source starts empty and is filled in later makes no request before the token and one request after, which is the no-restart guarantee

`newMockClient` in the existing test file now carries a token, since a mock client with none can no longer reach its transport. The two deliberate no-token tests use a new `newUnconfiguredMockClient`.

`docs/Troubleshooting-Wiki.md` described the old behaviour (unauthenticated request, error logged and skipped) and now describes the skip plus the new startup line.
