### PR TITLE
chore(lint): exclude SA5011 from test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,6 +71,25 @@ linters:
           - gosec
           - noctx
           - unused
+      # SA5011 fires on the standard table-test guard:
+      #
+      #   if got == nil {
+      #       t.Fatal("...")
+      #   }
+      #   if got.Field != want { ... }
+      #
+      # t.Fatal ends the test goroutine, so the dereference below it is
+      # unreachable, but staticcheck does not always model that and reports a
+      # possible nil dereference. It is environment-dependent: the same pinned
+      # golangci-lint v2.11.4 on the same Go 1.26.6 finds nothing locally with
+      # a cleared cache and six findings on CI. The pattern appears in roughly
+      # 77 test files, so suppressing the check in tests is the proportionate
+      # fix; rewriting every guard to carry a redundant return would churn the
+      # whole suite for an analyser quirk. Non-test code keeps SA5011.
+      - path: _test\.go
+        linters:
+          - staticcheck
+        text: "SA5011"
       # CORS middleware writes OPTIONS response headers and can't meaningfully
       # propagate a Write error.
       - path: cmd/bindery/main\.go


### PR DESCRIPTION
`lint` is red on `main` (and therefore on every open PR) with staticcheck SA5011 findings against the standard table-test guard:

```go
if got == nil {
    t.Fatal("...")
}
if got.Field != want { ... }
```

`t.Fatal` ends the test goroutine, so the dereference below it is unreachable. staticcheck does not always model that and reports a possible nil dereference.

The findings are environment-dependent. The same pinned golangci-lint v2.11.4 on the same Go 1.26.6 reports nothing locally with the cache cleared, and six findings on CI. It survived a job re-run, so it is not a poisoned cache.

I first tried adding an explicit `return` after each `t.Fatal`. That cleared the original six and immediately surfaced three more in the same file, because staticcheck caps findings per file. A repo-wide sweep found the pattern in about 77 test files. Churning the whole suite for an analyser quirk is not worth it, so the check is suppressed in tests only. Non-test code keeps SA5011.

Unblocks #1969 and #2041, both of which inherit this failure.