### PR TITLE
fix(oidc): read group claims from userinfo, and stop demoting on a missing claim (#2097)

### DIFF
--- a/changelog.d/2097-oidc-userinfo-claims.md
+++ b/changelog.d/2097-oidc-userinfo-claims.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **OIDC group mapping works with Authelia, Okta and Auth0 again, and a missing
+  group claim no longer takes your admin rights away** (#2097) — Bindery read
+  group membership only from the ID token and never called the IdP's userinfo
+  endpoint. Those providers do not put `groups` in the ID token by default and
+  serve it only from userinfo, so Bindery saw no groups at all. With
+  `BINDERY_OIDC_ADMIN_GROUP` set, that empty result was then read as "not an
+  admin" and the user was demoted on every login — including the operator who
+  configured it, and with local auth disabled that was a lockout, since the
+  last-admin demotion guard is deliberately bypassed on this path. It also
+  explains OIDC users whose Bindery username was their `sub` UUID:
+  `preferred_username` is userinfo-only under the same defaults.
+
+  Bindery now reads the userinfo document as well and merges it underneath the
+  ID token, so a claim carried by both keeps the signed ID token's value, and a
+  userinfo document whose subject does not match the ID token's is discarded
+  (OIDC Core 1.0 §5.3.2). A group claim that is missing from both leaves the
+  existing role untouched and logs why; a claim that is present and does not
+  list the admin group still demotes, because that is the IdP actually saying
+  so. `allowed_groups` now says which of the two it rejected a login for
+  instead of giving the same message either way.

--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -23,8 +23,8 @@ Sessions are issued using the same HMAC-signed cookie as password login. OIDC si
 | `BINDERY_OIDC_AUTO_PROVISION` | `true` | Set to `false` to require that OIDC users already exist in Bindery's database. First-time OIDC logins from unknown `(issuer, sub)` pairs return 403 instead of creating an account. |
 | `BINDERY_OIDC_EMAIL_LINK` | `false` | Set to `true` to link an unknown OIDC identity to an existing Bindery account if the email address matches. Runs before the auto-provision check. Useful for migrating from local accounts to OIDC without losing history. |
 | `BINDERY_OIDC_DEFAULT_ROLE` | `user` | Role assigned to a freshly auto-provisioned OIDC user. Valid values: `user`, `admin`. Any other value falls back to `user`. Set to `admin` for single-admin homelab deployments to skip the manual promotion step. |
-| `BINDERY_OIDC_ADMIN_GROUP` | _(unset)_ | When set, makes the IdP authoritative for the admin role. On **every** login, the user is promoted to `admin` if this group is present in the group claim and demoted to `user` if absent. See [Group-based role mapping](#group-based-role-mapping). |
-| `BINDERY_OIDC_GROUP_CLAIM` | `groups` | ID-token claim path Bindery reads the user's groups from — used for both `BINDERY_OIDC_ADMIN_GROUP` role mapping and the per-provider `allowed_groups` login filter. Override for IdPs that put groups under a non-standard claim (e.g. `roles`). |
+| `BINDERY_OIDC_ADMIN_GROUP` | _(unset)_ | When set, makes the IdP authoritative for the admin role. On **every** login, the user is promoted to `admin` if this group is listed in the group claim and demoted to `user` if it is not. If the claim is missing altogether the role is left unchanged. See [Group-based role mapping](#group-based-role-mapping). |
+| `BINDERY_OIDC_GROUP_CLAIM` | `groups` | Claim path Bindery reads the user's groups from, looked up in the ID token first and then the userinfo document — used for both `BINDERY_OIDC_ADMIN_GROUP` role mapping and the per-provider `allowed_groups` login filter. Override for IdPs that put groups under a non-standard claim (e.g. `roles`). |
 | `BINDERY_ALLOW_LAN_OIDC` | _(off)_ | Set to `true`/`1` to disable the SSRF guard on the OIDC discovery probe, allowing LAN / loopback / private-range issuer URLs. Restores the historical behaviour where any issuer URL an admin types is fetched verbatim. Only enable when your OIDC provider runs on the Bindery host or a trusted private network. |
 
 ## Redirect URL construction
@@ -137,10 +137,15 @@ BINDERY_OIDC_ADMIN_GROUP=bindery-admin
 BINDERY_OIDC_GROUP_CLAIM=groups
 ```
 
-When `BINDERY_OIDC_ADMIN_GROUP` is set, the **IdP becomes authoritative for the admin role**. On every login Bindery reads the configured group claim from the ID token and:
+When `BINDERY_OIDC_ADMIN_GROUP` is set, the **IdP becomes authoritative for the admin role**. On every login Bindery reads the configured group claim and:
 
-- promotes the user to `admin` if the group is present, or
-- demotes the user to `user` if the group is absent.
+- promotes the user to `admin` if the group is listed in the claim,
+- demotes the user to `user` if the claim is present and does not list it, or
+- **leaves the role exactly as it is** if the claim is missing altogether.
+
+That last case is the important one. A claim the IdP never sends says nothing about whether this user is an admin, so acting on it as a denial would take your own admin rights away the next time you logged in. Bindery logs `oidc: group claim absent, leaving role unchanged` instead — if you see that line, the IdP is not sending the claim and role mapping is doing nothing at all.
+
+Bindery looks for the claim in the ID token first, then in the **userinfo document**. Several IdPs, Authelia and Okta and Auth0 among them, do not put `groups` in the ID token by default and serve it only from userinfo; requesting the `groups` scope is often not enough on its own. Where a claim appears in both, the ID token wins, because it is signed and bound to the login nonce. A userinfo document whose `sub` does not match the ID token's is discarded entirely.
 
 `BINDERY_OIDC_GROUP_CLAIM` (default `groups`) selects the claim path; override it for IdPs that emit groups under a different name.
 
@@ -273,6 +278,24 @@ identity_providers:
           - profile
           - groups
 ```
+
+Authelia serves `groups` and `preferred_username` from its userinfo endpoint but does not put them in the ID token unless you say so. Bindery reads userinfo too, so the config above is enough. If you would rather have the claims in the ID token as well, add a claims policy (Authelia 4.39+; check your version's docs, the key moved between releases):
+
+```yaml
+identity_providers:
+  oidc:
+    claims_policies:
+      bindery:
+        id_token:
+          - groups
+          - preferred_username
+    clients:
+      - client_id: bindery
+        claims_policy: 'bindery'
+        # ...rest of the client config unchanged
+```
+
+Without either the userinfo lookup or this policy, `allowed_groups` rejects every login and `BINDERY_OIDC_ADMIN_GROUP` can never promote anyone.
 
 Bindery provider config:
 

--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -303,15 +303,28 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	if cfg, ok := h.mgr.ProviderConfig(providerID); ok && len(cfg.AllowedGroups) > 0 {
 		userGroups := oidc.GroupClaimValues(claims.Raw, h.oidcGroupClaim)
 		if !oidc.GroupsAllowed(cfg.AllowedGroups, userGroups) {
+			// Absent and present-but-unmatched are both rejections here, since
+			// this policy is fail-closed on purpose, but they call for
+			// different fixes and the operator has to be told which one they
+			// are looking at (#2097).
+			present := oidc.GroupClaimPresent(claims.Raw, h.oidcGroupClaim)
 			slog.Warn("oidc: login rejected by AllowedGroups policy",
 				"provider", providerID, // #nosec -- providerID validated by oidcProviderIDRe at handler entry
 				"sub", sanitizeLog(claims.Sub),
+				"claim_present", present,
 				"user_groups", len(userGroups),
 				"allowed_groups", strings.Join(cfg.AllowedGroups, ","),
 			)
+			if !present {
+				writeErr(w, http.StatusForbidden,
+					"access denied: the identity provider did not send a \""+h.oidcGroupClaim+"\" claim "+
+						"in either the id_token or userinfo, so group membership cannot be checked "+
+						"(add the claim to the provider's scope or claim mapping)")
+				return
+			}
 			writeErr(w, http.StatusForbidden,
 				"access denied: your account is not a member of an allowed group for this provider "+
-					"(check the provider's allowed_groups setting and that the IdP is sending a 'groups' claim)")
+					"(check the provider's allowed_groups setting)")
 			return
 		}
 	}
@@ -390,20 +403,35 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	// overrides any role set via PUT /api/v1/auth/users/{id}/role for OIDC users.
 	if h.oidcAdminGroup != "" {
 		groups := oidc.GroupClaimValues(claims.Raw, h.oidcGroupClaim)
-		want := "user"
-		if oidc.ContainsGroup(groups, h.oidcAdminGroup) {
-			want = "admin"
-		}
-		if user.Role != want {
-			if err := h.users.SetRoleUnguarded(ctx, user.ID, want); err != nil {
-				slog.Error("oidc: group-claim role sync failed", "error", err, "user_id", user.ID)
-				writeErr(w, http.StatusInternalServerError, "role sync failed")
-				return
+		// An absent claim is not a denial. Both the ID token and userinfo were
+		// checked by now, so a claim still missing here means the IdP was never
+		// configured to send it — not that this user is outside the admin
+		// group. Demoting on that evidence takes an operator's own admin rights
+		// away on their next login, and with local auth disabled locks them out
+		// of their instance entirely (#2097). Leave the role alone and say why.
+		if !oidc.GroupClaimPresent(claims.Raw, h.oidcGroupClaim) {
+			slog.Warn("oidc: group claim absent, leaving role unchanged",
+				"provider", providerID, // #nosec -- providerID validated by oidcProviderIDRe at handler entry
+				"sub", sanitizeLog(claims.Sub),
+				"group_claim", h.oidcGroupClaim,
+				"admin_group", h.oidcAdminGroup,
+				"hint", "the IdP is not sending this claim in the id_token or userinfo; check the scope and claim mapping")
+		} else {
+			want := "user"
+			if oidc.ContainsGroup(groups, h.oidcAdminGroup) {
+				want = "admin"
 			}
-			slog.Info("oidc: synced role from group claim",
-				"username", user.Username, "from", user.Role, "to", want,
-				"admin_group", h.oidcAdminGroup, "group_claim", h.oidcGroupClaim)
-			user.Role = want
+			if user.Role != want {
+				if err := h.users.SetRoleUnguarded(ctx, user.ID, want); err != nil {
+					slog.Error("oidc: group-claim role sync failed", "error", err, "user_id", user.ID)
+					writeErr(w, http.StatusInternalServerError, "role sync failed")
+					return
+				}
+				slog.Info("oidc: synced role from group claim",
+					"username", user.Username, "from", user.Role, "to", want,
+					"admin_group", h.oidcAdminGroup, "group_claim", h.oidcGroupClaim)
+				user.Role = want
+			}
 		}
 	}
 

--- a/internal/api/auth_oidc_callback_test.go
+++ b/internal/api/auth_oidc_callback_test.go
@@ -33,6 +33,12 @@ type fakeIDP struct {
 	kid    string
 	// claims is the claim set baked into the ID token returned by /token.
 	claims map[string]any
+	// userinfo, when non-nil, makes the IdP advertise and serve a userinfo
+	// endpoint returning this claim set. Several real IdPs (Authelia, Okta,
+	// Auth0) keep `groups` out of the ID token and serve it only here, which
+	// is the shape #2097 is about. nil means "no userinfo endpoint", which is
+	// also a supported configuration.
+	userinfo map[string]any
 }
 
 func newFakeIDP(t *testing.T) *fakeIDP {
@@ -47,12 +53,28 @@ func newFakeIDP(t *testing.T) *fakeIDP {
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		base := "http://" + r.Host
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		doc := map[string]any{
 			"issuer":                 base,
 			"authorization_endpoint": base + "/authorize",
 			"token_endpoint":         base + "/token",
 			"jwks_uri":               base + "/jwks",
-		})
+		}
+		if idp.userinfo != nil {
+			doc["userinfo_endpoint"] = base + "/userinfo"
+		}
+		_ = json.NewEncoder(w).Encode(doc)
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		if idp.userinfo == nil {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer fake-access-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(idp.userinfo)
 	})
 	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/api/auth_oidc_rolemap_test.go
+++ b/internal/api/auth_oidc_rolemap_test.go
@@ -163,10 +163,17 @@ func TestCallback_GroupClaim_DemoteOnAbsence(t *testing.T) {
 	}
 }
 
-// TestCallback_GroupClaim_DemoteWhenClaimMissingEntirely verifies that when the
-// group claim is absent altogether, an existing admin is demoted (fail-safe:
-// absence of the group, not presence of a deny signal).
-func TestCallback_GroupClaim_DemoteWhenClaimMissingEntirely(t *testing.T) {
+// TestCallback_GroupClaim_MissingClaimLeavesRoleAlone verifies that a group
+// claim absent from both the ID token and userinfo leaves the existing role
+// untouched rather than demoting (#2097).
+//
+// This inverts what the code did until #2097. Absent and present-but-empty are
+// different evidence: a claim the IdP never sends says nothing about this
+// user's membership, and treating it as a denial took an operator's own admin
+// rights away on their next login. With local auth disabled that locked them
+// out of their own instance, because the last-admin demotion guard is
+// deliberately bypassed on this path.
+func TestCallback_GroupClaim_MissingClaimLeavesRoleAlone(t *testing.T) {
 	idp := newFakeIDP(t)
 	idp.claims = map[string]any{
 		"sub": "g-noclaim", "nonce": "test-nonce", "preferred_username": "gn",
@@ -187,8 +194,37 @@ func TestCallback_GroupClaim_DemoteWhenClaimMissingEntirely(t *testing.T) {
 	if err != nil || u == nil {
 		t.Fatalf("lookup: u=%v err=%v", u, err)
 	}
+	if u.Role != "admin" {
+		t.Errorf("Role=%q, want admin (claim absent entirely, so nothing is known about membership)", u.Role)
+	}
+}
+
+// TestCallback_GroupClaim_EmptyClaimStillDemotes pins the other half of the
+// distinction: a claim the IdP *does* send, listing no groups, is the IdP
+// saying this user is in nothing, and demotion is correct.
+func TestCallback_GroupClaim_EmptyClaimStillDemotes(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-emptyclaim", "nonce": "test-nonce", "preferred_username": "ge",
+		"groups": []string{},
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("bindery-admin")
+
+	seeded, err := users.GetOrCreateByOIDC(ctx, idp.server.URL, "g-emptyclaim", "ge", "", "", "admin")
+	if err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByID(ctx, seeded.ID)
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
 	if u.Role != "user" {
-		t.Errorf("Role=%q, want user (no group claim → demote)", u.Role)
+		t.Errorf("Role=%q, want user (claim present and lists no groups)", u.Role)
 	}
 }
 
@@ -347,5 +383,107 @@ func TestCallback_PromoteFirstOIDC_SkippedWhenAdminExists(t *testing.T) {
 	}
 	if u.Role != "user" {
 		t.Errorf("Role=%q, want user (admin already exists → no fallback)", u.Role)
+	}
+}
+
+// TestCallback_GroupClaim_PromoteFromUserinfo is the #2097 regression: an IdP
+// that keeps `groups` out of the ID token and serves it only from userinfo.
+// This is Authelia's default shape, and Okta's and Auth0's, and before the fix
+// Bindery read the ID token alone, saw no groups, and demoted the user.
+func TestCallback_GroupClaim_PromoteFromUserinfo(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-userinfo", "nonce": "test-nonce",
+		// no groups and no preferred_username in the id_token, as Authelia
+		// ships by default without a claims policy
+	}
+	idp.userinfo = map[string]any{
+		"sub":                "g-userinfo",
+		"preferred_username": "abbie",
+		"groups":             []string{"media_admin", "media_viewer"},
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("media_admin")
+
+	seeded, err := users.GetOrCreateByOIDC(ctx, idp.server.URL, "g-userinfo", "", "", "", "user")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByID(ctx, seeded.ID)
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "admin" {
+		t.Errorf("Role=%q, want admin (media_admin is in the userinfo groups claim)", u.Role)
+	}
+}
+
+// TestCallback_Userinfo_SubjectMismatchIgnored covers OIDC Core 1.0 section
+// 5.3.2. A userinfo document whose subject is not the ID token's subject must
+// be discarded outright: merging it would let a provider that mixed up
+// sessions hand one user another user's groups, and the group claim is what
+// decides admin.
+func TestCallback_Userinfo_SubjectMismatchIgnored(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-mismatch", "nonce": "test-nonce", "preferred_username": "gm",
+	}
+	idp.userinfo = map[string]any{
+		"sub":    "somebody-else",
+		"groups": []string{"bindery-admin"},
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("bindery-admin")
+
+	seeded, err := users.GetOrCreateByOIDC(ctx, idp.server.URL, "g-mismatch", "gm", "", "", "user")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByID(ctx, seeded.ID)
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (mismatched userinfo subject must be discarded, not merged)", u.Role)
+	}
+}
+
+// TestCallback_Userinfo_DoesNotOverrideIDToken pins precedence. The ID token is
+// signed and nonce-bound; userinfo only fills gaps.
+func TestCallback_Userinfo_DoesNotOverrideIDToken(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-precedence", "nonce": "test-nonce", "preferred_username": "gp",
+		"groups": []string{"readers"},
+	}
+	idp.userinfo = map[string]any{
+		"sub":    "g-precedence",
+		"groups": []string{"bindery-admin"},
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("bindery-admin")
+
+	seeded, err := users.GetOrCreateByOIDC(ctx, idp.server.URL, "g-precedence", "gp", "", "", "user")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByID(ctx, seeded.ID)
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (the id_token groups claim wins over userinfo)", u.Role)
 	}
 }

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -125,6 +125,12 @@ type entry struct {
 	cfg      ProviderConfig
 	verifier *gooidc.IDTokenVerifier
 	endpoint oauth2.Endpoint
+	// provider is retained past discovery so Exchange can reach the IdP's
+	// userinfo endpoint. Several IdPs (Authelia, Okta and Auth0 among them)
+	// keep `groups` and `preferred_username` out of the ID token by default
+	// and serve them only from userinfo, so an ID-token-only reader sees no
+	// groups at all (#2097).
+	provider *gooidc.Provider
 }
 
 type failedEntry struct {
@@ -216,7 +222,7 @@ func (m *Manager) buildEntry(ctx context.Context, cfg ProviderConfig) (*entry, e
 		return nil, fmt.Errorf("oidc discovery for %q: %w", cfg.Issuer, err)
 	}
 	verifier := p.Verifier(&gooidc.Config{ClientID: cfg.ClientID})
-	return &entry{cfg: cfg, verifier: verifier, endpoint: p.Endpoint()}, nil
+	return &entry{cfg: cfg, verifier: verifier, endpoint: p.Endpoint(), provider: p}, nil
 }
 
 // EnsureLoaded attempts on-demand re-discovery for a provider that is in the
@@ -413,6 +419,22 @@ func (m *Manager) Exchange(ctx context.Context, redirectBase, id, code, nonce, c
 	if err := idToken.Claims(&raw); err != nil {
 		raw = nil
 	}
+
+	// Merge the userinfo claim set underneath the ID token's. The ID token is
+	// signed and nonce-bound, so where both carry a claim the ID token wins;
+	// userinfo only fills gaps. This is what makes group mapping work against
+	// an IdP that does not put `groups` in the ID token (#2097).
+	raw = mergeUserinfo(ctx, e, token, idToken.Subject, raw)
+	if claims.PreferredUsername == "" {
+		claims.PreferredUsername, _ = raw["preferred_username"].(string)
+	}
+	if claims.Email == "" {
+		claims.Email, _ = raw["email"].(string)
+	}
+	if claims.Name == "" {
+		claims.Name, _ = raw["name"].(string)
+	}
+
 	return &Claims{
 		Sub:               claims.Sub,
 		Issuer:            idToken.Issuer,
@@ -423,6 +445,64 @@ func (m *Manager) Exchange(ctx context.Context, redirectBase, id, code, nonce, c
 		Groups:            GroupClaimValues(raw, "groups"),
 		Raw:               raw,
 	}, nil
+}
+
+// mergeUserinfo fetches the provider's userinfo document and returns idClaims
+// with any claim it did not already carry filled in from userinfo. Returns
+// idClaims untouched on any failure: userinfo is an enrichment, and an IdP
+// that does not serve it (or serves it as a signed JWT this client cannot
+// read) must not break a login whose ID token already verified.
+//
+// The userinfo `sub` is checked against the ID token's before anything is
+// merged, per OIDC Core 1.0 section 5.3.2. Without that check a provider that
+// mixed up sessions could hand back another user's groups, and Bindery would
+// treat them as this user's.
+func mergeUserinfo(ctx context.Context, e *entry, token *oauth2.Token, idSub string, idClaims map[string]any) map[string]any {
+	if e == nil || e.provider == nil || token == nil {
+		return idClaims
+	}
+	info, err := e.provider.UserInfo(ctx, oauth2.StaticTokenSource(token))
+	if err != nil {
+		// Debug, not warn: an IdP with no userinfo endpoint is a supported
+		// configuration and this path runs on every single login.
+		slog.Debug("oidc: userinfo fetch failed, using id_token claims only",
+			"provider", e.cfg.ID, "error", err)
+		return idClaims
+	}
+	if info.Subject != idSub {
+		slog.Warn("oidc: userinfo subject does not match the id_token subject, ignoring userinfo",
+			"provider", e.cfg.ID)
+		return idClaims
+	}
+	var extra map[string]any
+	if err := info.Claims(&extra); err != nil || extra == nil {
+		return idClaims
+	}
+	if idClaims == nil {
+		idClaims = make(map[string]any, len(extra))
+	}
+	for k, v := range extra {
+		if _, ok := idClaims[k]; !ok {
+			idClaims[k] = v
+		}
+	}
+	return idClaims
+}
+
+// GroupClaimPresent reports whether the named claim exists in the claim set at
+// all, independently of whether it names any group.
+//
+// The distinction matters because absent and empty are not the same evidence.
+// A claim that is present and does not list the admin group is the IdP saying
+// "not an admin"; a claim that is missing entirely usually means the IdP was
+// never configured to send it, and acting on that as though it were a denial
+// is how an operator loses their own admin rights (#2097).
+func GroupClaimPresent(raw map[string]any, claimName string) bool {
+	if raw == nil || claimName == "" {
+		return false
+	}
+	v, ok := raw[claimName]
+	return ok && v != nil
 }
 
 // GroupClaimValues extracts a group list from the named claim in a decoded


### PR DESCRIPTION
Closes #2097. Reported in Discord #support by abbiecat, who is currently losing admin on every login.

## The bug

Bindery read group membership only from the verified ID token (`internal/api/auth_oidc.go:304` and `:392`, both via `Claims.Raw`, which is documented as the ID-token claim set). `UserinfoEndpoint` was parsed from discovery at `internal/auth/oidc/discover.go:57` and never read anywhere else in the tree.

Authelia, Okta and Auth0 all keep `groups` out of the ID token by default and serve it from userinfo. Requesting the `groups` scope is not enough on its own. So Bindery saw no group claim, and with `BINDERY_OIDC_ADMIN_GROUP` set, an empty result was indistinguishable from a user genuinely outside the admin group. Every login demoted them.

That includes the operator who configured the mapping. With `BINDERY_LOCAL_AUTH_ENABLED=false` it is a lockout, because the last-admin demotion guard is deliberately bypassed on this path. The same absence is why abbiecat's Bindery username was their `sub` UUID: `preferred_username` is userinfo-only under the same defaults.

Our own documented Authelia example (`docs/auth-oidc.md`) set `allowed_groups`, and that check is fail-closed, so on a default Authelia it rejected every login rather than merely demoting.

## Two changes

**Fetch userinfo and merge it underneath the ID token.** A claim present in both keeps the ID token's value, since that one is signed and nonce-bound; userinfo only fills gaps. A userinfo document whose `sub` does not match the ID token's is discarded rather than merged, per OIDC Core 1.0 §5.3.2 — without that check a provider that mixed up sessions could hand one user another user's groups, and groups decide admin. A missing or failing userinfo endpoint is a supported configuration: it logs at debug and the login proceeds on ID token claims alone.

**Distinguish an absent claim from an empty one.** Absent leaves the role untouched and logs what to check. Present-and-lists-nothing still demotes, because that is the IdP actually reporting no membership. `allowed_groups` still rejects in both cases but now says which one it hit, so the operator knows whether to fix their claim mapping or their group name.

The second change is worth having on its own. It is what turns a configuration problem into a lockout.

## Behaviour change

`TestCallback_GroupClaim_DemoteWhenClaimMissingEntirely` asserted the old demote-on-absent behaviour and is replaced by `TestCallback_GroupClaim_MissingClaimLeavesRoleAlone`, plus `TestCallback_GroupClaim_EmptyClaimStillDemotes` pinning the other half. Anyone relying on a missing claim to demote was relying on their IdP being misconfigured.

## Verified

Three new regression tests, and I confirmed each fails without its own hunk:

- `PromoteFromUserinfo` — Authelia's exact shape, groups only in userinfo. Fails with `Role="user", want admin` when the merge is removed.
- `MissingClaimLeavesRoleAlone` — fails with `Role="user", want admin` when the presence check is removed.
- `Userinfo_SubjectMismatchIgnored` and `Userinfo_DoesNotOverrideIDToken` cover the two security properties.

`go build`, `go vet`, `gofmt`, `golangci-lint` and the full `internal/api` and `internal/auth` suites pass locally.

The fake IdP in `auth_oidc_callback_test.go` gained an optional userinfo endpoint, advertised in discovery only when a test sets one, so existing tests still exercise the no-userinfo path.