### PR TITLE
perf(importer): match bulk-import units concurrently (#1638)

### DIFF
--- a/changelog.d/1638-parallel-bulk-import-scan.md
+++ b/changelog.d/1638-parallel-bulk-import-scan.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Bulk folder import scan timed out and returned nothing** (#1638) — the scan matched each file against the catalogue one at a time, and each one costs three separate filesystem reads. On a library over network or spinning storage that ran to roughly 213 ms per file, so a 1000 file scan took over three minutes, outlived the server's write timeout, and the response died mid encode. The page sat there and then retried straight back into the same wall. Matching now runs up to eight files at once, which brings that same scan under half a minute.

--- a/internal/importer/lookup.go
+++ b/internal/importer/lookup.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/vavallee/bindery/internal/concurrency"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/textutil"
 )
@@ -95,6 +96,10 @@ func (s *Scanner) LookupBatch(ctx context.Context, paths []string) ([]LookupResu
 //
 // root is the folder the scan was pointed at; it anchors the layout author
 // derivation. Results are aligned with the input paths.
+//
+// Units are matched concurrently (lookupBatchConcurrency). A canceled ctx
+// aborts the whole batch with an error rather than returning a slice whose
+// tail was never matched.
 func (s *Scanner) LookupBatchLayout(ctx context.Context, root string, paths []string) ([]LookupResult, error) {
 	books, err := s.books.List(ctx)
 	if err != nil {
@@ -109,11 +114,43 @@ func (s *Scanner) LookupBatchLayout(ctx context.Context, root string, paths []st
 		authorNames[a.ID] = a.Name
 	}
 	results := make([]LookupResult, len(paths))
-	for i, p := range paths {
-		results[i] = lookupUnit(root, p, books, authorNames)
+	// lookupUnit is filesystem-bound, not CPU-bound: per unit it stats the
+	// path, opens and parses the EPUB container, then stats again to detect
+	// the format. Run sequentially that was ~213 ms per unit on a library
+	// over a network mount, so a 1000-unit scan took 213 s and the response
+	// died against the 120 s server WriteTimeout mid-encode, so the scan
+	// never returned anything to the UI at all (#1638).
+	//
+	// Safe to parallelise because lookupUnit only reads: books and
+	// authorNames are loaded once above and never written, results are
+	// written by distinct index, and nothing on the path (ParseFilename,
+	// authorTitleFromLayout, firstEpubIn, ReadEpubMetadata, detectUnitFormat)
+	// keeps package-level state.
+	idx := make([]int, len(paths))
+	for i := range paths {
+		idx[i] = i
+	}
+	concurrency.RunBounded(ctx, idx, lookupBatchConcurrency, func(_ context.Context, i int) {
+		results[i] = lookupUnit(root, paths[i], books, authorNames)
+	})
+	// RunBounded stops launching on cancellation, which would leave the tail
+	// of results as zero-value LookupResults, a Match of "" that is neither
+	// confident, ambiguous nor none and would render as a silently empty row
+	// in the wizard. Fail the whole batch instead.
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("lookup batch: %w", err)
 	}
 	return results, nil
 }
+
+// lookupBatchConcurrency bounds LookupBatchLayout's per-unit fan-out.
+//
+// The work is I/O, so this is not sized from CPU count. 8 recovers most of
+// the serial cost on the network and spinning storage where the problem
+// actually shows up, without the queue-depth thrash a much larger number
+// causes on an SMB or NFS mount, where going wider can be slower than going
+// narrow.
+const lookupBatchConcurrency = 8
 
 // lookupUnit matches one bulk-import unit against the pre-loaded catalogue using
 // the embedded-metadata → folder-layout → filename precedence described on

--- a/internal/importer/lookup_layout_parallel_test.go
+++ b/internal/importer/lookup_layout_parallel_test.go
@@ -1,0 +1,85 @@
+package importer
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// TestLookupBatchLayout_PreservesOrderAcrossFanOut is the regression guard for
+// #1638's fix: LookupBatchLayout now matches units through a bounded worker
+// pool instead of a sequential loop, and its documented contract is that
+// "results are aligned with the input paths". A pool that wrote results in
+// completion order rather than by index would still return the right SET of
+// matches, so every existing single-path test would keep passing while the
+// wizard silently attached each match to the wrong file.
+//
+// Uses three times lookupBatchConcurrency paths so the pool genuinely recycles
+// slots rather than launching everything at once.
+func TestLookupBatchLayout_PreservesOrderAcrossFanOut(t *testing.T) {
+	t.Parallel()
+	s, books, authors, ctx := scannerFixture(t, t.TempDir())
+
+	const n = lookupBatchConcurrency * 3
+	root := t.TempDir()
+	paths := make([]string, n)
+	wantTitles := make([]string, n)
+	for i := range paths {
+		// Distinct author per book so each unit has exactly one corroborated
+		// catalogue match and lands on "confident".
+		author := fmt.Sprintf("Author %02d", i)
+		title := fmt.Sprintf("Title %02d", i)
+		seedLayoutBook(t, books, authors, ctx, author, title)
+		paths[i] = filepath.Join(root, author, title+".epub")
+		wantTitles[i] = title
+		writeFileAt(t, paths[i])
+	}
+
+	res, err := s.LookupBatchLayout(ctx, root, paths)
+	if err != nil {
+		t.Fatalf("LookupBatchLayout: %v", err)
+	}
+	if len(res) != n {
+		t.Fatalf("len(results) = %d, want %d", len(res), n)
+	}
+	for i := range res {
+		if res[i].Match == "" {
+			t.Fatalf("results[%d].Match is empty: a slot was never written", i)
+		}
+		if res[i].Book == nil {
+			t.Fatalf("results[%d].Book = nil, want a match for %q", i, wantTitles[i])
+		}
+		if res[i].Book.Title != wantTitles[i] {
+			t.Errorf("results[%d].Book.Title = %q, want %q (results are misaligned with paths)",
+				i, res[i].Book.Title, wantTitles[i])
+		}
+	}
+}
+
+// TestLookupBatchLayout_CanceledContextReturnsError pins the contract that a
+// canceled batch fails outright rather than returning a partially populated
+// slice. The fan-out stops launching on cancellation, so without an explicit
+// error the tail of the results slice would be zero-value LookupResults whose
+// Match is "" — neither confident, ambiguous nor none — and the wizard would
+// render them as silently empty rows.
+func TestLookupBatchLayout_CanceledContextReturnsError(t *testing.T) {
+	t.Parallel()
+	s, books, authors, ctx := scannerFixture(t, t.TempDir())
+	seedLayoutBook(t, books, authors, ctx, "Andy Weir", "Project Hail Mary")
+
+	root := t.TempDir()
+	p := filepath.Join(root, "Andy Weir", "Project Hail Mary.epub")
+	writeFileAt(t, p)
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+
+	res, err := s.LookupBatchLayout(canceled, root, []string{p})
+	if err == nil {
+		t.Fatalf("LookupBatchLayout returned nil error for a canceled context, results = %+v", res)
+	}
+	if res != nil {
+		t.Errorf("results = %+v, want nil so no partially matched batch reaches the caller", res)
+	}
+}


### PR DESCRIPTION
## Summary

Bulk folder import scanned a large library for over three minutes, outlived the server's 120 s `WriteTimeout`, and the response died mid encode, so the UI received nothing and retried straight back into the same wall. Matching now runs through a bounded worker pool instead of a sequential loop. Refs #1638.

## Implementation notes

`LookupBatchLayout` already loaded the books and authors catalogue exactly once per batch (#1473), so the remaining cost was pure per file I/O. `lookupUnit` does three separate filesystem passes per unit: a stat in `firstEpubIn`, a zip open and OPF parse in `ReadEpubMetadata`, then another stat in `detectUnitFormat`. On the reporter's library over a network mount that measured around 213 ms per unit, so the 1000 unit cap took 213 s.

Safe to parallelise, checked rather than assumed:

| Shared state | Status |
|---|---|
| `books []models.Book` | loaded before the fan out, never written |
| `authorNames map[int64]string` | same, read only |
| `results []LookupResult` | preallocated, written by distinct index |
| `ParseFilename`, `authorTitleFromLayout`, `firstEpubIn`, `ReadEpubMetadata`, `detectUnitFormat` | no package level state |

`concurrency.RunBounded` at 8. The number is sized for I/O, not CPU count: the libraries where this hurts are on SMB, NFS or spinning disks, where a much larger pool costs more in queue depth than it recovers in parallelism.

One behaviour change beyond the speed. `RunBounded` stops launching on cancellation, which would leave the tail of `results` as zero-value `LookupResult`s whose `Match` is `""`, neither confident, ambiguous nor none, and the wizard would draw those as silently empty rows. The batch now returns an error instead, and that is documented on the exported method.

## Why minimal / scope decisions

Two things from the #1638 triage are deliberately **not** here:

- **The 1000 unit cap** (`maxScanEntries`, `internal/api/manual_import.go`). The reporter's log shows `truncated: true`, so his library is larger and he will still only see the first 1000 entries after this. Raising the cap is only safe once the scan is no longer synchronous, so it belongs with the next piece rather than bolted onto this one.
- **The synchronous request shape.** Even at 25 s there is no progress feedback. A background job with a poll or progress stream is the right end state. This PR is what makes the feature usable in the meantime.

Both are called out on #1638, which stays open.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no env vars, config, settings or Helm values changed; the exported method's godoc gained the new cancellation behaviour
- [x] Wiki pages updated if user-facing behaviour changed — n/a, no UI or settings change
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `go test ./internal/importer/... ./internal/api/... ./internal/concurrency/...` — all pass
- [x] `go test -race ./internal/importer/ -run TestLookupBatchLayout -count=3` — clean
- [x] `gofmt -l .` clean, `go vet ./internal/... ./cmd/...` clean
- [x] `golangci-lint run ./internal/importer/... ./internal/concurrency/...` — 0 issues
- [ ] `cd web && npm run build` — not run, backend only change touching no frontend file

`TestLookupBatchLayout_PreservesOrderAcrossFanOut` was mutation checked: rewriting the pool to store at `results[(i+1)%len(paths)]` makes it fail on 23 of 24 entries. That matters because a pool writing in completion order would return the correct set of matches and every pre-existing single path test would still pass, while the wizard attached each match to the wrong file.
