### PR TITLE
fix(abs): name the missing scheme instead of blaming the port (#2056)

### DIFF
--- a/changelog.d/2056-abs-base-url-scheme.md
+++ b/changelog.d/2056-abs-base-url-scheme.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Audiobookshelf base URL rejected a port with an error about the scheme** (#2056) — typing `audiobookshelf:13378`, the natural form when everything runs under Compose on one host, produced "must use http or https". Go reads a scheme-less `host:port` as a scheme, so the complaint pointed at the wrong half of the input, and the obvious next move was to drop the port and land on port 80. Ports were always supported. The error now says the scheme is missing and prints the exact value to use, and the field's placeholder shows Audiobookshelf's default port.

--- a/docs/ABS-Import-Wiki.md
+++ b/docs/ABS-Import-Wiki.md
@@ -59,6 +59,7 @@ A good pre-import cleanup pass in ABS is worth it. If your library already has s
 
 1. Open `Settings -> ABS`.
 2. Save the ABS base URL, API key, label, target book libraries, and any optional path remaps. Saving stores normalized settings without contacting ABS.
+   - The base URL needs a scheme, and it may carry a port. On a single host running everything under Compose that is usually `http://audiobookshelf:13378`. Typing `audiobookshelf:13378` without the scheme is rejected, because Go reads the port as the scheme.
 3. Test the connection and list available book libraries.
 4. Pick one or more book libraries from the list, or keep known saved library IDs until listing succeeds.
 5. Start a dry run if you want a safe first pass.

--- a/internal/abs/base_url_scheme_test.go
+++ b/internal/abs/base_url_scheme_test.go
@@ -1,0 +1,75 @@
+package abs
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNormalizeBaseURL_SchemelessHostNamesTheRealProblem covers #2056: a user
+// typing the natural docker-compose form got an error about the scheme for
+// input whose only visible novelty was the port, concluded the port had been
+// refused, retried without it, and reached port 80.
+//
+// The assertion is on what the message tells them, not just that it failed:
+// the old message failed too, it just pointed at the wrong thing.
+func TestNormalizeBaseURL_SchemelessHostNamesTheRealProblem(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"host and port", "audiobookshelf:13378"},
+		{"bare host", "audiobookshelf"},
+		{"host with path", "audiobookshelf/abs"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NormalizeBaseURL(tc.raw)
+			if err == nil {
+				t.Fatalf("NormalizeBaseURL(%q) = nil error, want a scheme complaint", tc.raw)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "missing a scheme") {
+				t.Errorf("error = %q, want it to say the scheme is missing", msg)
+			}
+			if !strings.Contains(msg, "http://"+tc.raw) {
+				t.Errorf("error = %q, want it to name the corrected value %q", msg, "http://"+tc.raw)
+			}
+		})
+	}
+}
+
+// TestNormalizeBaseURL_UnsupportedSchemeStillRejectedAsScheme guards the other
+// side of the split: a real scheme that Bindery does not speak must keep the
+// original message. Telling someone who typed ftp:// that they "left off the
+// scheme" would be a worse error than the one #2056 replaced.
+func TestNormalizeBaseURL_UnsupportedSchemeStillRejectedAsScheme(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{"ftp://audiobookshelf", "ws://audiobookshelf:13378"} {
+		_, err := NormalizeBaseURL(raw)
+		if err == nil {
+			t.Fatalf("NormalizeBaseURL(%q) = nil error, want rejection", raw)
+		}
+		if !strings.Contains(err.Error(), "must use http or https") {
+			t.Errorf("NormalizeBaseURL(%q) error = %q, want the unsupported-scheme message", raw, err.Error())
+		}
+		if strings.Contains(err.Error(), "missing a scheme") {
+			t.Errorf("NormalizeBaseURL(%q) error = %q, but a scheme was present", raw, err.Error())
+		}
+	}
+}
+
+// TestNormalizeBaseURL_PortIsPreserved is the fact the reporter never got to
+// find out: ports were always supported, the input boundary just never let
+// them prove it.
+func TestNormalizeBaseURL_PortIsPreserved(t *testing.T) {
+	t.Parallel()
+	got, err := NormalizeBaseURL("http://audiobookshelf:13378")
+	if err != nil {
+		t.Fatalf("NormalizeBaseURL: %v", err)
+	}
+	if got != "http://audiobookshelf:13378" {
+		t.Errorf("got %q, want the port preserved", got)
+	}
+}

--- a/internal/abs/client.go
+++ b/internal/abs/client.go
@@ -44,6 +44,9 @@ func NormalizeBaseURL(raw string) (string, error) {
 		return "", fmt.Errorf("base_url %q: %w", raw, err)
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
+		if isSchemeless(u) {
+			return "", fmt.Errorf("base_url %q is missing a scheme: write it as %q, or https:// if Audiobookshelf is behind TLS", raw, "http://"+raw)
+		}
 		return "", fmt.Errorf("base_url %q must use http or https", raw)
 	}
 	if u.Host == "" {
@@ -57,6 +60,46 @@ func NormalizeBaseURL(raw string) (string, error) {
 		u.Path = ""
 	}
 	return u.String(), nil
+}
+
+// isSchemeless reports whether raw was a bare host rather than a URL carrying an
+// unsupported scheme, so the caller can say "you left off http://" instead of
+// "that scheme is not allowed".
+//
+// The distinction matters because of how url.Parse reads a host:port pair with
+// no scheme. "audiobookshelf:13378" parses as Scheme "audiobookshelf" with
+// Opaque "13378", so the scheme check rejects it with a complaint about the
+// scheme for input whose only visible novelty is the port. A user reading that
+// reasonably concludes the port was refused and retries without it, landing on
+// port 80 and a connection to the wrong service entirely (#2056).
+//
+// Deliberately does not repair the value. Choosing http over https on the
+// user's behalf is a security relevant guess, so this names the corrected
+// string and lets them confirm it.
+func isSchemeless(u *url.URL) bool {
+	// "audiobookshelf" or "audiobookshelf/abs": no scheme at all.
+	if u.Scheme == "" {
+		return true
+	}
+	// "audiobookshelf:13378": the port became the opaque part and no host was
+	// found. Digits only, so a real unsupported scheme ("ftp://host") is not
+	// caught here.
+	if u.Host == "" && u.Opaque != "" && isAllDigits(u.Opaque) {
+		return true
+	}
+	return false
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateBaseURLSecure layers an SSRF policy check on top of NormalizeBaseURL.

--- a/web/src/pages/settings/ABSTab.tsx
+++ b/web/src/pages/settings/ABSTab.tsx
@@ -612,7 +612,7 @@ function AudiobookshelfSection() {
             <input
               value={draft.baseUrl}
               onChange={e => setDraft(prev => ({ ...prev, baseUrl: e.target.value }))}
-              placeholder="https://abs.example.com"
+              placeholder="http://audiobookshelf:13378"
               className={inputCls}
             />
           </div>


### PR DESCRIPTION
## Summary

Typing `audiobookshelf:13378` in the ABS base URL field failed with an error about the scheme, so the reporter concluded ports were unsupported, dropped the port, and reached port 80. Ports always worked. Closes #2056.

## Implementation notes

`url.Parse("audiobookshelf:13378")` returns Scheme `audiobookshelf` and Opaque `13378` with no host, so the only check that could fire was the scheme check, and its message pointed at the half of the input the user had not changed.

`isSchemeless` splits the two cases:

| Input | Parse result | Message |
|---|---|---|
| `audiobookshelf:13378` | Scheme=`audiobookshelf`, Opaque=`13378`, Host empty | missing a scheme, names `http://audiobookshelf:13378` |
| `audiobookshelf` | Scheme empty | missing a scheme, names `http://audiobookshelf` |
| `ftp://audiobookshelf` | Scheme=`ftp`, Host set | unchanged, must use http or https |

The opaque branch requires digits only, so a real unsupported scheme cannot fall into it.

It deliberately does not repair the value. Choosing http over https for the user is a security relevant guess, so the error names the corrected string and lets them confirm it.

The placeholder was `https://abs.example.com`, carrying no port, which is what made a port look unsupported to begin with. It now shows ABS's default, and the wiki's import flow says the same.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — `docs/ABS-Import-Wiki.md` import flow gained the base URL note; no env vars, config or Helm values changed
- [x] Wiki pages updated
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `go test ./internal/abs/` — pass
- [x] `gofmt -l .` clean, `golangci-lint run ./internal/abs/...` — 0 issues
- [x] `npx tsc --noEmit` — clean

The unsupported-scheme test asserts both directions: `ftp://` keeps the original message **and** must not gain the new one. Without that second assertion a helper that returned true unconditionally would still pass.
