### PR TITLE
fix(sync): stamp the import list's root folder on authors it creates (#1864)

### DIFF
--- a/changelog.d/1864-importlist-root-folder.md
+++ b/changelog.d/1864-importlist-root-folder.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Import lists ignored their root folder** (#1864) — the per-list root folder picker saved its value and the Hardcover list syncer never read it, so authors created by a list landed with no root folder at all. Same defect as the quality profile in #1781, one field over. A list with no root folder configured still leaves the author's unset rather than guessing at a default, because root folders belong to a user and picking one for somebody else's authors is worse than leaving it empty.

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -460,6 +460,19 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 	// user has since changed on the author.
 	qualityProfileID := il.QualityProfileID
 
+	// Root folder to stamp on every author this sync creates. Same shape as the
+	// quality profile above and the same defect: models.ImportList.RootFolderID
+	// is persisted and settable from the per-list picker, and the syncer never
+	// read it, so a list configured with a root folder produced authors with
+	// none (#1864). Create-only for the same reason, so a re-synced list never
+	// overwrites a root folder the user has since changed on the author.
+	//
+	// No fallback when the list configures none, for the reason #1781
+	// established for quality profiles: root folders are owner-scoped, so
+	// stamping a "default" row from a background job can hand one user's
+	// storage to another user's authors on a tenanted install.
+	rootFolderID := il.RootFolderID
+
 	// Index existing authors by normalized name so a Hardcover author already in
 	// the library under a different provider's foreign id (e.g. an OpenLibrary
 	// author imported via ABS) is reused instead of duplicated (#1223).
@@ -517,7 +530,7 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 		}
 
 		// Look up or create the author
-		authorID, err := s.ensureAuthor(ctx, &book, nameIndex, ownerID, qualityProfileID)
+		authorID, err := s.ensureAuthor(ctx, &book, nameIndex, ownerID, qualityProfileID, rootFolderID)
 		if err != nil {
 			slog.Warn("failed to ensure author for book", "title", book.Title, "error", err)
 			countStat(func(st *SyncStats) { st.Failed++ })
@@ -678,7 +691,7 @@ func uniqueAuthorByName(index map[string][]models.Author, name string) *models.A
 // none configured) are stamped only on a freshly created author; a reused
 // existing author keeps whatever owner and profile it already had, so a list
 // never silently reassigns another user's — or a shared/global — author.
-func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book, nameIndex map[string][]models.Author, ownerID int64, qualityProfileID *int64) (int64, error) {
+func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book, nameIndex map[string][]models.Author, ownerID int64, qualityProfileID, rootFolderID *int64) (int64, error) {
 	if book.Author == nil {
 		return 0, fmt.Errorf("book %q has no author metadata", book.Title)
 	}
@@ -743,6 +756,13 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book, nameIn
 	if qualityProfileID != nil {
 		id := *qualityProfileID
 		author.QualityProfileID = &id
+	}
+
+	// Same copy-by-value rule as the quality profile: one pointer is shared
+	// across every author in the sync, and each row must own its field.
+	if rootFolderID != nil {
+		id := *rootFolderID
+		author.RootFolderID = &id
 	}
 
 	if err := s.authors.CreateForUser(ctx, author, ownerID); err != nil {

--- a/internal/hardcoverlistsyncer/syncer_root_folder_test.go
+++ b/internal/hardcoverlistsyncer/syncer_root_folder_test.go
@@ -1,0 +1,119 @@
+package hardcoverlistsyncer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// newTestSyncerWithRootFolders is newTestSyncerWithQualityProfiles with a root
+// folder repo instead, so the test can seed a real folder row to point the list
+// at rather than a made-up id.
+func newTestSyncerWithRootFolders(t *testing.T) (*ListSyncer, *db.ImportListRepo, *db.RootFolderRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	importLists := db.NewImportListRepo(database)
+	return New(importLists, db.NewAuthorRepo(database), db.NewBookRepo(database)),
+		importLists,
+		db.NewRootFolderRepo(database)
+}
+
+// TestSyncOne_NewAuthorInheritsListRootFolder is #1864, the same defect #1781
+// fixed for quality profiles: models.ImportList.RootFolderID is persisted and
+// settable from the per-list picker, and the syncer never read it, so a list
+// configured with a root folder produced authors with none.
+func TestSyncOne_NewAuthorInheritsListRootFolder(t *testing.T) {
+	s, repo, folders := newTestSyncerWithRootFolders(t)
+	ctx := context.Background()
+
+	folder, err := folders.Create(ctx, "/books/hardcover")
+	if err != nil {
+		t.Fatalf("seed root folder: %v", err)
+	}
+
+	il := testImportList("HC rooted", "hardcover", true)
+	il.RootFolderID = &folder.ID
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 21, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{
+				{ForeignID: "hc:rf-book", Title: "Rooted Book", MetadataProvider: "hardcover",
+					Author: &models.Author{ForeignID: "hc:rf-author", Name: "Rooted Author", MetadataProvider: "hardcover"}},
+			},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	created, err := s.authors.GetByAnyForeignID(ctx, "hc:rf-author")
+	if err != nil {
+		t.Fatalf("GetByAnyForeignID: %v", err)
+	}
+	if created == nil {
+		t.Fatal("expected the new author to be created")
+	}
+	if created.RootFolderID == nil {
+		t.Fatal("new author RootFolderID is nil, want the list's root folder (#1864)")
+	}
+	if *created.RootFolderID != folder.ID {
+		t.Errorf("new author RootFolderID = %d, want %d (the list's root folder)", *created.RootFolderID, folder.ID)
+	}
+}
+
+// TestSyncOne_ListWithoutRootFolderLeavesAuthorUnset pins the deliberate
+// non-behaviour, for the reason #1781 established: root folders are
+// owner-scoped, so a background job stamping a "default" row can hand one
+// user's storage to another user's list-synced authors on a tenanted install.
+// A list with none configured must leave the author's root folder nil.
+func TestSyncOne_ListWithoutRootFolderLeavesAuthorUnset(t *testing.T) {
+	s, repo, folders := newTestSyncerWithRootFolders(t)
+	ctx := context.Background()
+
+	// A folder exists and is the only one, which is exactly the shape a blind
+	// fallback would latch onto.
+	if _, err := folders.Create(ctx, "/books/someone-elses"); err != nil {
+		t.Fatalf("seed root folder: %v", err)
+	}
+
+	il := testImportList("HC unrooted", "hardcover", true)
+	// RootFolderID deliberately left nil.
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 22, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{
+				{ForeignID: "hc:nrf-book", Title: "Unrooted Book", MetadataProvider: "hardcover",
+					Author: &models.Author{ForeignID: "hc:nrf-author", Name: "Unrooted Author", MetadataProvider: "hardcover"}},
+			},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	created, err := s.authors.GetByAnyForeignID(ctx, "hc:nrf-author")
+	if err != nil {
+		t.Fatalf("GetByAnyForeignID: %v", err)
+	}
+	if created == nil {
+		t.Fatal("expected the new author to be created")
+	}
+	if created.RootFolderID != nil {
+		t.Errorf("new author RootFolderID = %d, want nil: an unconfigured list must not inherit a root folder", *created.RootFolderID)
+	}
+}


### PR DESCRIPTION
## Summary

`models.ImportList.RootFolderID` is persisted and settable from the per-list picker, and the Hardcover syncer never read it, so a list configured with a root folder created authors with none. Same defect as #1781 one field over. Closes #1864.

## Implementation notes

`ensureAuthor` takes the root folder alongside the quality profile and stamps it on create only, so a re-synced list never overwrites a root folder the user has since changed on the author. Copied by value for the same reason the profile is: one pointer is shared across every author in the sync and each row must own its field.

No fallback when the list configures none, following the reasoning #1781 established. Root folders are owner-scoped, so a background job stamping a "default" row can hand one user's storage to another user's authors on a tenanted install. The negative test seeds exactly one folder, the shape a blind fallback would latch onto, and asserts the author's stays nil.

## Follow-ups (not in this PR)

The issue asked whether any other `ImportList` field is in this state. Audited the model: **two more are**.

| Field | Persisted | API settable | Read by the syncer |
|---|---|---|---|
| `RootFolderID` | yes | yes | no, fixed here |
| `MonitorNew` | yes | yes | **no** |
| `AutoAdd` | yes | yes | **no** |

Neither is a missing stamp. `MonitorNew` and `AutoAdd` both change what the sync does rather than what it writes on a row, so getting them wrong could stop a working list from adding books. They want their own issue and their own reasoning, not a ride along in a patch release.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no env vars, config, settings or Helm values changed
- [x] Wiki pages updated if user-facing behaviour changed — n/a, the setting already exists in the UI, it just did nothing
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `go test ./internal/hardcoverlistsyncer/` — pass
- [x] `gofmt -l .` clean, `golangci-lint run ./internal/hardcoverlistsyncer/...` — 0 issues

Mutation checked: dropping the stamp makes `TestSyncOne_NewAuthorInheritsListRootFolder` fail with "RootFolderID is nil, want the list's root folder".
