### PR TITLE
fix(api): say when an explicit add bypasses strict media type (#1759)

### DIFF
--- a/changelog.d/1759-strict-media-type-explicit-add.md
+++ b/changelog.d/1759-strict-media-type-explicit-add.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Strict media type never said it was letting explicit adds through** (#1759) — the setting skips catalogue books in the wrong format and narrows dual-format ones, but a book you add yourself has always been created in the format you picked, on both add paths. That is deliberate, since silently refusing something you explicitly asked for is worse than the row it prevents, but nothing said so anywhere. The setting's help text now states the boundary, and an add that goes past the policy is logged instead of passing unremarked.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -3112,6 +3112,21 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// 3b. Say so when this add went past the strict media-type policy (#1759).
+	//
+	// The policy is a catalogue-population rule, not a veto on what the user
+	// may own: the direct insert above never consults it, and the single-work
+	// fallback is exempt by #1612's rule that "an explicit add of one specific
+	// work must not be vetoed by catalogue-sync heuristics". Both of those are
+	// deliberate, because silently refusing an explicit user action is the
+	// worse of the two failures.
+	//
+	// What was missing is that it happened invisibly, so a user who turned the
+	// setting on to stop un-grabbable rows appearing had no way to learn that
+	// their own add was the exception. The setting's help text now says the
+	// same thing, which is the half most people will actually see.
+	h.logStrictMediaTypeBypass(ctx, book)
+
 	// 4. Optionally trigger an indexer search. Use the process-lifecycle
 	// context so the search goroutine is cancelled on shutdown rather than
 	// running against context.Background(). See #846.
@@ -3120,6 +3135,36 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusCreated, book)
+}
+
+// logStrictMediaTypeBypass records an explicit add that the strict media-type
+// policy would have excluded from a catalogue sync.
+//
+// Fires only when the policy is on AND pinned to one format, which is the
+// condition under which fetchAuthorBooks narrows a dual-format work or skips a
+// single-format one. A default of "both" clamps nothing, so there is nothing to
+// bypass and nothing to say.
+func (h *AuthorHandler) logStrictMediaTypeBypass(ctx context.Context, book *models.Book) {
+	if !h.strictMediaTypeBypassed(ctx, book) {
+		return
+	}
+	slog.Info("added a book the strict media-type default would have excluded from a catalogue sync; an explicit add is not vetoed by it",
+		"title", book.Title, "bookMediaType", book.MediaType, "default", h.resolveDefaultMediaType(ctx))
+}
+
+// strictMediaTypeBypassed is logStrictMediaTypeBypass's condition, split out so
+// the decision can be asserted directly rather than by capturing log output.
+func (h *AuthorHandler) strictMediaTypeBypassed(ctx context.Context, book *models.Book) bool {
+	if book == nil || !h.resolveDefaultMediaTypeStrict(ctx) {
+		return false
+	}
+	def := h.resolveDefaultMediaType(ctx)
+	// Only a single-format default clamps anything, so only that can be
+	// bypassed. "both" narrows nothing and skips nothing.
+	if def != models.MediaTypeEbook && def != models.MediaTypeAudiobook {
+		return false
+	}
+	return book.MediaType != def
 }
 
 // cleanupOrphanIfNoBooks deletes the given author iff (a) the book add

--- a/internal/api/authors_strict_media_type_add_test.go
+++ b/internal/api/authors_strict_media_type_add_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// strictMediaTypeFixture builds an AuthorHandler with a settings repo, which is
+// all strictMediaTypeBypassed reads.
+func strictMediaTypeFixture(t *testing.T) (*AuthorHandler, *db.SettingsRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	settings := db.NewSettingsRepo(database)
+	h := NewAuthorHandler(db.NewAuthorRepo(database), nil, db.NewBookRepo(database), nil, nil, settings, db.NewMetadataProfileRepo(database), nil)
+	return h, settings, context.Background()
+}
+
+// TestLogStrictMediaTypeBypass_FiresOnlyWhenThePolicyWouldHaveExcluded pins
+// #1759's decision: an explicit add is honoured whatever the strict media-type
+// policy says, and the bypass is announced rather than silent.
+//
+// The behaviour was already correct on both add paths (the direct insert never
+// consults the policy, and the single-work catalogue fallback is exempt under
+// #1612). What was missing was any sign it had happened, so what this test
+// guards is the condition, not the create: firing on every add would be noise,
+// and firing on none would be the original complaint.
+func TestLogStrictMediaTypeBypass_FiresOnlyWhenThePolicyWouldHaveExcluded(t *testing.T) {
+	cases := []struct {
+		name      string
+		strict    string
+		def       string
+		bookMedia string
+		want      bool
+	}{
+		{"strict on, ebook default, audiobook added", "true", models.MediaTypeEbook, models.MediaTypeAudiobook, true},
+		{"strict on, ebook default, both added", "true", models.MediaTypeEbook, models.MediaTypeBoth, true},
+		{"strict on, audiobook default, ebook added", "true", models.MediaTypeAudiobook, models.MediaTypeEbook, true},
+		// The added format is the one the policy wants, so nothing was bypassed.
+		{"strict on, ebook default, ebook added", "true", models.MediaTypeEbook, models.MediaTypeEbook, false},
+		// A "both" default clamps nothing, so there is nothing to bypass.
+		{"strict on, both default", "true", models.MediaTypeBoth, models.MediaTypeAudiobook, false},
+		// Policy off: the catalogue sync would have created this row too.
+		{"strict off", "false", models.MediaTypeEbook, models.MediaTypeAudiobook, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, settings, ctx := strictMediaTypeFixture(t)
+			if err := settings.Set(ctx, SettingDefaultMediaTypeStrict, tc.strict); err != nil {
+				t.Fatalf("set strict: %v", err)
+			}
+			if err := settings.Set(ctx, SettingDefaultMediaType, tc.def); err != nil {
+				t.Fatalf("set default: %v", err)
+			}
+			got := h.strictMediaTypeBypassed(ctx, &models.Book{Title: "T", MediaType: tc.bookMedia})
+			if got != tc.want {
+				t.Errorf("bypassed = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogStrictMediaTypeBypass_NilBook guards the defensive branch: AddBook
+// only calls this once the book is non-nil, but the helper must not panic if
+// that ever changes.
+func TestLogStrictMediaTypeBypass_NilBook(t *testing.T) {
+	h, settings, ctx := strictMediaTypeFixture(t)
+	if err := settings.Set(ctx, SettingDefaultMediaTypeStrict, "true"); err != nil {
+		t.Fatalf("set strict: %v", err)
+	}
+	if h.strictMediaTypeBypassed(ctx, nil) {
+		t.Error("nil book reported as a bypass")
+	}
+	h.logStrictMediaTypeBypass(context.Background(), nil)
+}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -32,6 +32,14 @@ const SettingDefaultMediaType = "default.media_type"
 // default.media_type at add/refresh time so single-format users stop
 // accumulating un-grabbable rows; any other value (or unset) leaves the
 // historical mixed-catalogue behaviour untouched.
+//
+// It governs catalogue POPULATION only. A book the user adds explicitly is
+// created in the format they picked whichever way this is set: AddBook's
+// direct insert never consults it, and the single-work catalogue fallback is
+// exempt under #1612's rule that an explicit add of one specific work must not
+// be vetoed by catalogue-sync heuristics. Silently refusing an explicit user
+// action is the worse of the two failures, so the add is honoured and logged
+// rather than blocked (#1759).
 const SettingDefaultMediaTypeStrict = "default.media_type_strict"
 
 // SettingAuthorDefaultMonitorMode controls which newly discovered books are

--- a/web/src/pages/settings/MetadataTab.tsx
+++ b/web/src/pages/settings/MetadataTab.tsx
@@ -122,7 +122,7 @@ export default function MetadataTab() {
                 <span>
                   {t('settings.general.strictMediaTypeLabel', 'Restrict new books to this media type')}
                   <span className="block text-xs text-slate-600 dark:text-zinc-500">
-                    {t('settings.general.strictMediaTypeHint', 'Skip catalogue books available only in the other format, and narrow dual-format books to this one. Prevents monitoring books you can never grab.')}
+                    {t('settings.general.strictMediaTypeHint', 'Skip catalogue books available only in the other format, and narrow dual-format books to this one. Prevents monitoring books you can never grab. Governs catalogue population only: a book you add yourself is always created in the format you picked.')}
                   </span>
                 </span>
               </label>


### PR DESCRIPTION
## Summary

#1759 asked for a decision: is the strict media-type policy a catalogue-sync heuristic an explicit add may override, or a user policy that holds everywhere? It is a heuristic, and it already behaves that way. What was missing was any sign of it. Closes #1759.

## The decision

Honour the explicit add, and surface it.

Silently refusing a book the user specifically asked for is the worse of the two failures, and it is the same shape as the "polled forever for a row nothing would create" bug #1612 exists to prevent.

## Implementation notes

**No behaviour change.** Both add paths already honour the explicit pick:

| Path | Consults the policy? |
|---|---|
| `AddBook` direct insert | no, never did |
| single-work catalogue fallback | exempt, `!singleWork` guard under #1612 |

So the whole of this PR is the surfacing the issue asked for, on two surfaces, neither of which blocks anything:

1. The setting's help text states the boundary, which is the half most people actually read. This is what the issue proposed as the fallback if the behaviour stayed as-is.
2. An add that goes past the policy logs at Info rather than passing unremarked.

The godoc on `SettingDefaultMediaTypeStrict` carries the same reasoning, so the next person to touch either path finds it next to the key instead of in an issue.

## Why the condition is narrow

`strictMediaTypeBypassed` fires only when the policy is on **and** the default is a single format, which is exactly the condition under which `fetchAuthorBooks` narrows a dual-format work or skips a single-format one. A default of `both` clamps nothing, so there is nothing to bypass and nothing to say. Firing on every add would be noise; firing on none would be the original complaint.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — godoc on the setting key updated; no env vars, config or Helm values changed
- [x] Wiki pages updated if user-facing behaviour changed — n/a, no behaviour changed
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `go test ./internal/api/` — pass
- [x] `gofmt -l .` clean, `golangci-lint run ./internal/api/...` — 0 issues
- [x] `npx tsc --noEmit` — clean

The condition is split out of the logging call so it can be asserted directly rather than by capturing log output. Six cases cover both directions, including the two that must stay quiet: the added format matching the default, and a `both` default.
