### PR TITLE
fix(hardcover): select book_series in GetBook and GetBookByISBN (#2116)

### DIFF
--- a/changelog.d/2116-hardcover-getbook-series.md
+++ b/changelog.d/2116-hardcover-getbook-series.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Adding a second volume of a series did nothing** (#2116) — with Hardcover as the metadata provider, adding a book whose main title matched a volume already in the library was silently collapsed onto that volume. The Add button flickered and no book appeared, with no error. Bindery has a guard for exactly this case, comparing the two volumes' series positions, but the query that fetches a single book never asked Hardcover for its series, so the guard had nothing to compare and always let the merge through. The same field was missing from the ISBN lookup.

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -328,6 +328,10 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 			rating
 			default_audio_edition_id
 			default_ebook_edition_id
+			book_series(order_by: { position: asc }) {
+				position
+				series { id name }
+			}
 			contributions {
 				contribution
 				author { id name slug }
@@ -346,6 +350,10 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 			rating
 			default_audio_edition_id
 			default_ebook_edition_id
+			book_series(order_by: { position: asc }) {
+				position
+				series { id name }
+			}
 			contributions {
 				contribution
 				author { id name slug }
@@ -500,6 +508,10 @@ func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, 
 				rating
 				default_audio_edition_id
 				default_ebook_edition_id
+				book_series(order_by: { position: asc }) {
+					position
+					series { id name }
+				}
 				contributions {
 					contribution
 					author { id name slug }

--- a/internal/metadata/hardcover/getbook_series_test.go
+++ b/internal/metadata/hardcover/getbook_series_test.go
@@ -1,0 +1,134 @@
+package hardcover
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// recordingTransport redirects the client's hard-coded GraphQL endpoint at a
+// test server and keeps the request bodies, so a test can assert what was
+// actually asked for rather than only what came back.
+type recordingTransport struct {
+	base    *url.URL
+	inner   http.RoundTripper
+	queries []string
+}
+
+func (t *recordingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err == nil {
+			var payload struct {
+				Query string `json:"query"`
+			}
+			_ = json.Unmarshal(body, &payload)
+			t.queries = append(t.queries, payload.Query)
+		}
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		r.ContentLength = int64(len(body))
+	}
+	clone := r.Clone(r.Context())
+	clone.URL.Scheme = t.base.Scheme
+	clone.URL.Host = t.base.Host
+	return t.inner.RoundTrip(clone)
+}
+
+// newSeriesResponseClient returns a client whose every GraphQL call answers
+// with one book carrying a book_series relation, plus the transport recording
+// what was asked.
+func newSeriesResponseClient(t *testing.T, response string) (*Client, *recordingTransport) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(srv.Close)
+	base, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	tr := &recordingTransport{base: base, inner: srv.Client().Transport}
+	return (&Client{http: &http.Client{Transport: tr}}).WithToken("hc-token"), tr
+}
+
+const bookWithSeriesGQL = `{"data":{"books":[{
+	"id": 42,
+	"title": "Legendary Rule: Book Two",
+	"slug": "legendary-rule",
+	"book_series": [{"position": 2, "series": {"id": 7, "name": "Legendary Rule"}}]
+}]}}`
+
+// TestGetBook_RequestsAndReturnsSeries is #2116. GetBook's two queries never
+// selected book_series, so every work it fetched arrived with SeriesRefs nil.
+// AddBook's directInsertSeriesConflict guard takes those refs as its input, so
+// it could never fire: adding volume 2 of a series whose volume 1 shares the
+// main title was deduped onto volume 1 and silently dropped, with no book
+// created and no error shown.
+//
+// Both halves are asserted. toBook's fallback to bookSeriesRefs already worked,
+// so a test that only checked the returned book would have needed the field to
+// be requested anyway; asserting the query text as well names the actual defect
+// if someone removes the selection later.
+func TestGetBook_RequestsAndReturnsSeries(t *testing.T) {
+	t.Parallel()
+	c, tr := newSeriesResponseClient(t, bookWithSeriesGQL)
+
+	book, err := c.GetBook(context.Background(), "hc:legendary-rule")
+	if err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if book == nil {
+		t.Fatal("GetBook returned nil book")
+	}
+
+	if len(tr.queries) == 0 {
+		t.Fatal("no GraphQL query recorded")
+	}
+	if !strings.Contains(tr.queries[0], "book_series") {
+		t.Errorf("GetBook query does not select book_series:\n%s", tr.queries[0])
+	}
+
+	if len(book.SeriesRefs) != 1 {
+		t.Fatalf("SeriesRefs = %d, want 1 — the series conflict guard has nothing to compare without it", len(book.SeriesRefs))
+	}
+	ref := book.SeriesRefs[0]
+	if ref.Title != "Legendary Rule" {
+		t.Errorf("series Title = %q, want %q", ref.Title, "Legendary Rule")
+	}
+	if ref.Position != "2" {
+		t.Errorf("series Position = %q, want %q: the guard needs a sequence on both sides to tell two volumes apart", ref.Position, "2")
+	}
+}
+
+// TestGetBookByISBN_RequestsSeries covers the same omission on the ISBN lookup,
+// which the report named alongside GetBook.
+func TestGetBookByISBN_RequestsSeries(t *testing.T) {
+	t.Parallel()
+	const resp = `{"data":{"editions":[{"language":{"language":"English"},"book":{
+		"id": 42,
+		"title": "Legendary Rule: Book Two",
+		"slug": "legendary-rule",
+		"book_series": [{"position": 2, "series": {"id": 7, "name": "Legendary Rule"}}]
+	}}]}}`
+	c, tr := newSeriesResponseClient(t, resp)
+
+	book, err := c.GetBookByISBN(context.Background(), "9781234567890")
+	if err != nil {
+		t.Fatalf("GetBookByISBN: %v", err)
+	}
+	if book == nil {
+		t.Fatal("GetBookByISBN returned nil book")
+	}
+	if len(tr.queries) == 0 || !strings.Contains(tr.queries[0], "book_series") {
+		t.Errorf("GetBookByISBN query does not select book_series:\n%v", tr.queries)
+	}
+	if len(book.SeriesRefs) != 1 {
+		t.Fatalf("SeriesRefs = %d, want 1", len(book.SeriesRefs))
+	}
+}


### PR DESCRIPTION
## Summary

`GetBook`'s two GraphQL queries never selected `book_series`, so every work they returned arrived with `SeriesRefs` nil and the direct-insert series guard could never fire. Adding volume 2 of a series whose volume 1 shares the main title was silently deduped onto volume 1: no row created, no error shown. Closes #2116.

## Implementation notes

`directInsertSeriesConflict` exists for exactly this case. It compares the dedup match's primary series against the requested work's `SeriesRefs` and creates a distinct row when both carry a sequence and the sequences differ. Its input was always empty on this path.

The plumbing was already in place. `toBook` falls back to `bookSeriesRefs(b.BookSeries)`, and the relation is selected elsewhere:

| Query | Selects `book_series` |
|---|---|
| `lists.go:289`, `lists.go:357` | yes |
| `series.go:79` | yes |
| `GetBook` slugGQL / idGQL | **no**, fixed here |
| `GetBookByISBN` | **no**, fixed here |

So the change is three added selections and nothing else. The reporter diagnosed all of this from source before filing.

## Why minimal / scope decisions

`GetAuthorWorksByName` omits the same relation. Left alone deliberately: giving the author catalogue sync series refs it has never carried changes what series linking does for every Hardcover author on every sync, which is not a patch-release change. It is noted on the issue.

It does not affect the reported bug either. With `GetBook` fixed, the direct insert creates the row and the single-work fallback never runs.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no env vars, config, settings or Helm values changed
- [x] Wiki pages updated if user-facing behaviour changed — n/a
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `go test ./internal/metadata/hardcover/` — pass
- [x] `gofmt -l .` clean, `go vet ./internal/metadata/...` clean, `golangci-lint run ./internal/metadata/hardcover/...` — 0 issues

The tests assert the request as well as the response. `toBook`'s fallback already worked, so checking only the returned book would pass for the wrong reason if someone later dropped the selection; recording the outgoing query text names the actual defect. Mutation checked: removing the two `GetBook` selections fails the test with "GetBook query does not select book_series" and prints the query.
