### PR TITLE
fix(downloader): keep SABnzbd's reason for refusing an upload

### DIFF
--- a/changelog.d/2105-sabnzbd-rejection-reason.md
+++ b/changelog.d/2105-sabnzbd-rejection-reason.md
@@ -1,0 +1,2 @@
+### Fixed
+- **"SABnzbd rejected download" never said why** — SAB replies to a refused upload with its own explanation, and Bindery decoded only the success flag and threw the reason away. Since SAB deletes the uploaded file before its own backup step, that reply was the last place the explanation existed. The reason now reaches the queue and the history entry, and a SAB that refuses without one says so rather than leaving a message that reads as truncated.

--- a/internal/downloader/sabnzbd/addfile_rejection_test.go
+++ b/internal/downloader/sabnzbd/addfile_rejection_test.go
@@ -1,0 +1,106 @@
+package sabnzbd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestAddURL_RejectionCarriesSABsReason covers the reporting half of #2105.
+// AddURLResponse decoded only status and nzo_ids, so SAB's own explanation of
+// a refused upload was thrown away and the grab failed as a bare "SABnzbd
+// rejected download": the one component in the chain that behaved correctly,
+// named without saying what it objected to.
+//
+// SAB purges the uploaded file before its own backup step, so the bytes that
+// would explain it are gone by the time anyone looks. Its reply is the only
+// place the reason survives.
+func TestAddURL_RejectionCarriesSABsReason(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-nzb")
+		fmt.Fprint(w, testNZBContent)
+	}))
+	defer indexerSrv.Close()
+
+	const reason = "Error: Invalid NZB file Legendary.Rule.nzb, skipping"
+	sabSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(AddURLResponse{Status: false, Error: reason})
+	}))
+	defer sabSrv.Close()
+
+	c := New("127.0.0.1", 0, "testkey", "", false)
+	c.baseURL = sabSrv.URL
+	allowNZBFetch(c)
+
+	_, err := c.AddURL(context.Background(), indexerSrv.URL+"/file.nzb", "Legendary Rule", "books", 0)
+	if err == nil {
+		t.Fatal("AddURL returned nil error for a refused upload")
+	}
+	if !strings.Contains(err.Error(), reason) {
+		t.Errorf("error = %q, want it to carry SAB's reason %q", err.Error(), reason)
+	}
+}
+
+// TestAddURL_RejectionWithoutAReasonSaysSo pins the other branch. An older or
+// differently configured SAB can answer status:false with no error string, and
+// the message must not imply Bindery simply failed to read one. Saying SAB gave
+// no reason points the next person at SAB's log rather than at Bindery's.
+func TestAddURL_RejectionWithoutAReasonSaysSo(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-nzb")
+		fmt.Fprint(w, testNZBContent)
+	}))
+	defer indexerSrv.Close()
+
+	sabSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(AddURLResponse{Status: false})
+	}))
+	defer sabSrv.Close()
+
+	c := New("127.0.0.1", 0, "testkey", "", false)
+	c.baseURL = sabSrv.URL
+	allowNZBFetch(c)
+
+	_, err := c.AddURL(context.Background(), indexerSrv.URL+"/file.nzb", "Legendary Rule", "books", 0)
+	if err == nil {
+		t.Fatal("AddURL returned nil error for a refused upload")
+	}
+	if !strings.Contains(err.Error(), "gave no reason") {
+		t.Errorf("error = %q, want it to say SABnzbd gave no reason", err.Error())
+	}
+}
+
+// TestAddURL_WhitespaceOnlyReasonIsTreatedAsNone guards the trim: a reason of
+// spaces would otherwise produce "rejected download: " with nothing after it,
+// which reads as a truncated message rather than an absent one.
+func TestAddURL_WhitespaceOnlyReasonIsTreatedAsNone(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-nzb")
+		fmt.Fprint(w, testNZBContent)
+	}))
+	defer indexerSrv.Close()
+
+	sabSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(AddURLResponse{Status: false, Error: "   "})
+	}))
+	defer sabSrv.Close()
+
+	c := New("127.0.0.1", 0, "testkey", "", false)
+	c.baseURL = sabSrv.URL
+	allowNZBFetch(c)
+
+	_, err := c.AddURL(context.Background(), indexerSrv.URL+"/file.nzb", "Legendary Rule", "books", 0)
+	if err == nil {
+		t.Fatal("AddURL returned nil error for a refused upload")
+	}
+	if strings.HasSuffix(err.Error(), ": ") || strings.HasSuffix(err.Error(), ":") {
+		t.Errorf("error = %q, want no dangling colon for a blank reason", err.Error())
+	}
+	if !strings.Contains(err.Error(), "gave no reason") {
+		t.Errorf("error = %q, want it to say SABnzbd gave no reason", err.Error())
+	}
+}

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -155,7 +155,10 @@ func (c *Client) AddURL(ctx context.Context, nzbURL, title, category string, pri
 		return nil, fmt.Errorf("add nzb: %w", err)
 	}
 	if !resp.Status {
-		return nil, fmt.Errorf("SABnzbd rejected download")
+		if detail := strings.TrimSpace(resp.Error); detail != "" {
+			return nil, fmt.Errorf("SABnzbd rejected download: %s", detail)
+		}
+		return nil, fmt.Errorf("SABnzbd rejected download (SABnzbd gave no reason)")
 	}
 	return &resp, nil
 }

--- a/internal/downloader/sabnzbd/types.go
+++ b/internal/downloader/sabnzbd/types.go
@@ -1,9 +1,17 @@
 package sabnzbd
 
 // AddURLResponse is returned when adding an NZB by URL.
+//
+// Error carries SAB's own explanation when Status is false. SAB answers a
+// refused mode=addfile with {"status": false, "error": "..."}, and dropping it
+// left the grab failing as a bare "SABnzbd rejected download": the one
+// component in the chain that behaved correctly, named without saying what it
+// objected to. SAB then purges the uploaded file before its own backup step,
+// so by the time anyone looks the bytes that would explain it are gone.
 type AddURLResponse struct {
 	Status bool     `json:"status"`
 	NzoIDs []string `json:"nzo_ids"`
+	Error  string   `json:"error"`
 }
 
 // QueueResponse is the SABnzbd queue status.


### PR DESCRIPTION
## Summary

`AddURLResponse` decoded only `status` and `nzo_ids`, so SAB's own explanation of a refused upload was discarded and every rejection surfaced as a bare "SABnzbd rejected download". Refs #2105.

## Why it matters

That reply is the last place the reason exists. SAB writes the uploaded file, fails to parse it, and purges it before `backup_nzb`, so the bytes are gone by the time anyone looks and its own log line has scrolled away. #2105 was only diagnosed because the reporter read SAB's log at the moment it happened, which is not available after the fact.

## Implementation notes

One field on the response struct, and the error branch uses it:

| SAB reply | Before | After |
|---|---|---|
| `{"status": false, "error": "Invalid NZB file ..."}` | `SABnzbd rejected download` | `SABnzbd rejected download: Invalid NZB file ...` |
| `{"status": false}` | `SABnzbd rejected download` | `SABnzbd rejected download (SABnzbd gave no reason)` |

The blank case is a distinct message rather than an empty suffix. An older or differently configured SAB can answer `status:false` with no error string, and `rejected download: ` reads as a message Bindery failed to finish rather than one SAB declined to give. The reason is trimmed, so whitespace counts as absent.

## Relationship to #2107

helios57's #2107 stops most of these arising at all, by rejecting a body that is not an NZB before the download client sees it. This covers the rejections that are genuinely SAB's to explain: a category that does not exist, a disk problem, a duplicate. The two are complementary and neither supersedes the other.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no env vars, config, settings or Helm values changed
- [x] Wiki pages updated if user-facing behaviour changed — n/a, error text only
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `go test ./internal/downloader/... ./internal/api/` — pass
- [x] `gofmt -l .` clean, `golangci-lint run ./internal/downloader/sabnzbd/...` — 0 issues

Three cases covered: a reason present, absent, and whitespace only. The last one asserts there is no dangling colon, which is the failure a naive `%s` interpolation would produce.
