### PR TITLE
fix(hardcover): select book_series in GetAuthorWorksByName

### DIFF
--- a/changelog.d/hardcover-author-works-series.md
+++ b/changelog.d/hardcover-author-works-series.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Hardcover-supplemented author catalogues had no series information** — works Bindery pulls from Hardcover to fill out an author's bibliography arrived with no series membership, so those books were never linked into a series and an author set to monitor a specific series never picked them up. They now carry the series and volume number Hardcover holds. Existing books gain their series links on the next author refresh.

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -226,6 +226,10 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 			audio_seconds
 			default_audio_edition_id
 			default_ebook_edition_id
+			book_series(order_by: { position: asc }) {
+				position
+				series { id name }
+			}
 			contributions {
 				contribution
 				author { id name slug }

--- a/internal/metadata/hardcover/getbook_series_test.go
+++ b/internal/metadata/hardcover/getbook_series_test.go
@@ -132,3 +132,36 @@ func TestGetBookByISBN_RequestsSeries(t *testing.T) {
 		t.Fatalf("SeriesRefs = %d, want 1", len(book.SeriesRefs))
 	}
 }
+
+// TestGetAuthorWorksByName_RequestsSeries covers the same omission on the
+// author-catalogue supplement. Works fetched by author name arrived with
+// SeriesRefs nil, so a Hardcover-supplemented catalogue produced books with no
+// series membership at all, and an author on "series" monitor mode never saw
+// its pinned-series short circuit fire for them.
+//
+// The query-text assertion carries weight here beyond regression cover: the
+// comment above this query records that requesting a field the `books` type
+// lacks makes Hardcover reject the WHOLE query, taking the entire supplement
+// down with it. book_series is valid on `books`, which lists.go selects through
+// list_books { book { ... } }, and this pins that it is actually asked for.
+func TestGetAuthorWorksByName_RequestsSeries(t *testing.T) {
+	t.Parallel()
+	c, tr := newSeriesResponseClient(t, bookWithSeriesGQL)
+
+	books, err := c.GetAuthorWorksByName(context.Background(), "Bruce Sentar")
+	if err != nil {
+		t.Fatalf("GetAuthorWorksByName: %v", err)
+	}
+	if len(tr.queries) == 0 || !strings.Contains(tr.queries[0], "book_series") {
+		t.Fatalf("author-works query does not select book_series:\n%v", tr.queries)
+	}
+	if len(books) == 0 {
+		t.Fatal("no books returned")
+	}
+	if len(books[0].SeriesRefs) != 1 {
+		t.Fatalf("SeriesRefs = %d, want 1", len(books[0].SeriesRefs))
+	}
+	if books[0].SeriesRefs[0].Title != "Legendary Rule" {
+		t.Errorf("series Title = %q, want %q", books[0].SeriesRefs[0].Title, "Legendary Rule")
+	}
+}


### PR DESCRIPTION
## Summary

The same omission #2116 found in `GetBook`, one query over. `GetAuthorWorksByName` never selected `book_series`, so works pulled from Hardcover to supplement an author's catalogue arrived with `SeriesRefs` nil and were never linked into a series.

**Stacked on #2118** — that PR adds the shared test helper this one extends. Merge #2118 first.

## Read this before merging

Two consequences, and the second is a behaviour change rather than missing data being filled in.

**1. Series linking starts happening for these books.** `handleNewWantedBook` creates and links `series` / `series_books` rows from `SeriesRefs`. With the refs always empty it had nothing to do. Straightforward improvement.

**2. The pinned-series monitor short circuit becomes reachable.** `internal/api/authors.go:2188`: an author on `MonitorMode=series` with pinned series monitors a newly discovered book when one of its `SeriesRefs` matches. That branch was dead for Hardcover-supplemented works, so such an author has been silently under-monitoring exactly the books they pinned a series to catch. Fixing the data makes it live, which means more books monitored, which means more grabbed.

That is the behaviour the user asked for by pinning the series, and it is still a change in what gets downloaded. It arrives on the next author refresh, not on upgrade. **If you would rather this not ride in a patch release, this is the PR to hold.**

## Why it is type-safe

The comment above this query records a real failure mode: requesting a field the `books` type lacks makes Hardcover reject the whole query and take the entire author-works supplement down with it. `book_series` is valid on `books` — `lists.go` selects it through `list_books { book { ... } }` and has done in production — and the test asserts the outgoing query actually carries it rather than trusting that.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no env vars, config, settings or Helm values changed
- [x] Wiki pages updated if user-facing behaviour changed — n/a, no UI or settings change
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `go test ./internal/metadata/hardcover/` — pass
- [x] `gofmt -l .` clean, `golangci-lint run ./internal/metadata/hardcover/...` — 0 issues

Mutation checked: removing the selection fails the test with "author-works query does not select book_series" and prints the query.
