### PR TITLE
fix(auth): bound the login limiter's map and compare stats tokens in constant time (#2137, #2138)

### DIFF
--- a/changelog.d/2137-limiter-bound-and-token-compare.md
+++ b/changelog.d/2137-limiter-bound-and-token-compare.md
@@ -1,0 +1,3 @@
+### Security
+- **Login rate limiter no longer grows without bound** (#2137). The per-address bucket map only expired entries for an address that came back, so a caller rotating source addresses could grow it indefinitely. Buckets are now swept once per window.
+- **Telemetry server compares its stats token in constant time** (#2138). The `/api/stats` and `/api/backup` bearer check used a plain string comparison, whose timing leaks how much of a guess was correct.

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"compress/gzip"
 	"context"
+	"crypto/subtle"
 	"database/sql"
 	"encoding/csv"
 	"encoding/json"
@@ -1676,12 +1677,28 @@ func (s *server) computeStats(ctx context.Context) (*statsData, error) {
 	return d, nil
 }
 
+// statsTokenValid reports whether the request carries the stats bearer token.
+// The comparison is constant time so the response latency does not reveal how
+// many leading bytes of a guess were right, which is what makes a token
+// recoverable one byte at a time. Matches how the main binary compares every
+// other secret (internal/auth/password.go, internal/auth/middleware.go,
+// internal/api/opds_auth.go). Callers must reject an empty s.statsToken before
+// calling this; both current callers do (#2138).
+func (s *server) statsTokenValid(r *http.Request) bool {
+	if s.statsToken == "" {
+		return false
+	}
+	got := r.Header.Get("Authorization")
+	want := "Bearer " + s.statsToken
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
 func (s *server) handleStats(w http.ResponseWriter, r *http.Request) {
 	if s.statsToken == "" {
 		http.Error(w, "stats endpoint not configured", http.StatusForbidden)
 		return
 	}
-	if r.Header.Get("Authorization") != "Bearer "+s.statsToken {
+	if !s.statsTokenValid(r) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -1934,7 +1951,7 @@ func (s *server) handleBackup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "backup endpoint not configured", http.StatusForbidden)
 		return
 	}
-	if r.Header.Get("Authorization") != "Bearer "+s.statsToken {
+	if !s.statsTokenValid(r) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -271,6 +271,52 @@ func TestHandleStatsJSON(t *testing.T) {
 	}
 }
 
+// TestStatsTokenValid covers the constant time bearer check added for #2138.
+// The behaviour must be identical to the plain != it replaced, so these cases
+// pin the accept/reject boundary rather than trying to time the comparison.
+func TestStatsTokenValid(t *testing.T) {
+	s := newTestServer(t, "v1.9.5")
+	s.statsToken = "s3cret"
+
+	cases := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"exact match", "Bearer s3cret", true},
+		{"wrong token", "Bearer nope", false},
+		{"correct prefix only", "Bearer s3c", false},
+		{"token without scheme", "s3cret", false},
+		{"wrong scheme case", "bearer s3cret", false},
+		{"trailing byte", "Bearer s3cretx", false},
+		{"missing header", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			if got := s.statsTokenValid(req); got != tc.want {
+				t.Errorf("statsTokenValid(%q) = %v, want %v", tc.header, got, tc.want)
+			}
+		})
+	}
+
+	// An unconfigured token must never be satisfiable, including by a request
+	// that sends the bare scheme and an empty secret.
+	t.Run("unconfigured token rejects everything", func(t *testing.T) {
+		s.statsToken = ""
+		for _, header := range []string{"", "Bearer ", "Bearer "} {
+			req := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+			req.Header.Set("Authorization", header)
+			if s.statsTokenValid(req) {
+				t.Errorf("empty statsToken accepted header %q", header)
+			}
+		}
+	})
+}
+
 func TestHandleBackup(t *testing.T) {
 	s := newTestServer(t, "v1.9.5")
 	s.statsToken = "secret"

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -238,11 +238,14 @@ func TestLoginLimiterExpiresOldEvents(t *testing.T) {
 // that failed once and never returned kept its entry for the life of the
 // process. A caller rotating source addresses grew the map without limit.
 //
-// Drive many distinct IPs, let the window elapse, then drive one more so a
-// sweep runs, and assert the stale buckets are gone rather than merely that
-// the limiter still rate-limits.
+// Deliberately free of sleeps and wall-clock races. The window is an hour, so
+// no sweep can fire while the addresses are being recorded, and the events are
+// then aged out by rewriting their timestamps rather than by waiting. An
+// earlier version used a 10ms window and a sleep, which failed under -race on
+// a slow runner because the record loop outlived the window and swept its own
+// setup away.
 func TestLoginLimiterBoundsMapAcrossDistinctIPs(t *testing.T) {
-	const window = 10 * time.Millisecond
+	const window = time.Hour
 	const distinct = 5000
 	lim := NewLoginLimiter(5, window)
 
@@ -252,30 +255,36 @@ func TestLoginLimiterBoundsMapAcrossDistinctIPs(t *testing.T) {
 	lim.mu.Lock()
 	grown := len(lim.events)
 	lim.mu.Unlock()
-	if grown < distinct/2 {
-		t.Fatalf("setup: expected the map to hold the recorded IPs, got %d of %d", grown, distinct)
+	if grown != distinct {
+		t.Fatalf("setup: map holds %d buckets, want %d; nothing should expire inside a one hour window", grown, distinct)
 	}
 
-	// Age every recorded event out, then touch the limiter once so a sweep runs.
-	time.Sleep(2 * window)
+	// Age every recorded event out, and make a sweep due, without sleeping.
+	lim.mu.Lock()
+	stale := time.Now().Add(-2 * window)
+	for ip := range lim.events {
+		lim.events[ip] = []time.Time{stale}
+	}
+	lim.lastSweep = stale
+	lim.mu.Unlock()
+
+	// Allow does not record anything, so nothing should survive the sweep it
+	// triggers, including the address used to trigger it.
 	lim.Allow("192.0.2.1")
 
 	lim.mu.Lock()
 	remaining := len(lim.events)
 	lim.mu.Unlock()
-
-	// Only the address used to trigger the sweep may survive, and Allow does
-	// not record anything, so the map should be empty.
-	if remaining > 1 {
-		t.Fatalf("expired buckets were not swept: %d entries remain after %d distinct IPs aged out", remaining, distinct)
+	if remaining != 0 {
+		t.Errorf("expired buckets were not swept: %d of %d entries remain", remaining, distinct)
 	}
 }
 
 // TestLoginLimiterSweepKeepsLiveBuckets guards the other direction: the sweep
 // added for #2137 must not drop an address that is still inside its window,
-// which would hand an attacker a free reset by simply waiting.
+// which would hand an attacker a free reset by simply waiting for one.
 func TestLoginLimiterSweepKeepsLiveBuckets(t *testing.T) {
-	const window = 40 * time.Millisecond
+	const window = time.Hour
 	lim := NewLoginLimiter(2, window)
 	const victim = "203.0.113.7"
 
@@ -285,17 +294,17 @@ func TestLoginLimiterSweepKeepsLiveBuckets(t *testing.T) {
 		t.Fatal("setup: victim should be blocked after filling the bucket")
 	}
 
-	// Force a sweep to become due without letting the victim's events expire.
+	// Make a sweep due while leaving the victim's events well inside the
+	// window, so the only thing under test is whether the sweep respects them.
 	lim.mu.Lock()
 	lim.lastSweep = time.Now().Add(-2 * window)
 	lim.mu.Unlock()
 
-	if lim.Allow("198.51.100.4") {
-		// Unrelated address is allowed; the call exists to trigger the sweep.
-		_ = 0
-	}
+	// An unrelated address, purely to trigger the sweep.
+	lim.Allow("198.51.100.4")
+
 	if lim.Allow(victim) {
-		t.Fatal("sweep cleared a bucket that was still inside its window")
+		t.Error("sweep cleared a bucket that was still inside its window")
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -233,6 +233,72 @@ func TestLoginLimiterExpiresOldEvents(t *testing.T) {
 	}
 }
 
+// TestLoginLimiterBoundsMapAcrossDistinctIPs is the regression test for #2137:
+// gc only ever expired the bucket for the IP being looked up, so an address
+// that failed once and never returned kept its entry for the life of the
+// process. A caller rotating source addresses grew the map without limit.
+//
+// Drive many distinct IPs, let the window elapse, then drive one more so a
+// sweep runs, and assert the stale buckets are gone rather than merely that
+// the limiter still rate-limits.
+func TestLoginLimiterBoundsMapAcrossDistinctIPs(t *testing.T) {
+	const window = 10 * time.Millisecond
+	const distinct = 5000
+	lim := NewLoginLimiter(5, window)
+
+	for i := 0; i < distinct; i++ {
+		lim.Record(fmt.Sprintf("10.0.%d.%d", i/256, i%256))
+	}
+	lim.mu.Lock()
+	grown := len(lim.events)
+	lim.mu.Unlock()
+	if grown < distinct/2 {
+		t.Fatalf("setup: expected the map to hold the recorded IPs, got %d of %d", grown, distinct)
+	}
+
+	// Age every recorded event out, then touch the limiter once so a sweep runs.
+	time.Sleep(2 * window)
+	lim.Allow("192.0.2.1")
+
+	lim.mu.Lock()
+	remaining := len(lim.events)
+	lim.mu.Unlock()
+
+	// Only the address used to trigger the sweep may survive, and Allow does
+	// not record anything, so the map should be empty.
+	if remaining > 1 {
+		t.Fatalf("expired buckets were not swept: %d entries remain after %d distinct IPs aged out", remaining, distinct)
+	}
+}
+
+// TestLoginLimiterSweepKeepsLiveBuckets guards the other direction: the sweep
+// added for #2137 must not drop an address that is still inside its window,
+// which would hand an attacker a free reset by simply waiting.
+func TestLoginLimiterSweepKeepsLiveBuckets(t *testing.T) {
+	const window = 40 * time.Millisecond
+	lim := NewLoginLimiter(2, window)
+	const victim = "203.0.113.7"
+
+	lim.Record(victim)
+	lim.Record(victim)
+	if lim.Allow(victim) {
+		t.Fatal("setup: victim should be blocked after filling the bucket")
+	}
+
+	// Force a sweep to become due without letting the victim's events expire.
+	lim.mu.Lock()
+	lim.lastSweep = time.Now().Add(-2 * window)
+	lim.mu.Unlock()
+
+	if lim.Allow("198.51.100.4") {
+		// Unrelated address is allowed; the call exists to trigger the sweep.
+		_ = 0
+	}
+	if lim.Allow(victim) {
+		t.Fatal("sweep cleared a bucket that was still inside its window")
+	}
+}
+
 // --- middleware integration --------------------------------------------------
 
 type fakeProvider struct {

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -8,18 +8,28 @@ import (
 // LoginLimiter is a tiny in-memory per-IP sliding-window limiter for /login.
 // A successful login resets the counter; consecutive failures push it up.
 // Exceeding `max` within `window` returns Allowed()=false until the oldest
-// failure ages out. Memory is bounded by expiring buckets in Allow.
+// failure ages out. Memory is bounded by sweep, which expires whole buckets
+// once per window so the map tracks only addresses seen within it (#2137).
 type LoginLimiter struct {
 	mu     sync.Mutex
 	events map[string][]time.Time
 	max    int
 	window time.Duration
+	// lastSweep is when sweep last walked the whole map. Without it, gc only
+	// ever expires the one IP being looked at, so an address that is never
+	// seen again keeps its slice for the life of the process (#2137).
+	lastSweep time.Time
 }
 
 // NewLoginLimiter returns a limiter allowing `max` failed attempts per `window`.
 // Sonarr-ish defaults: 5 per 15 min.
 func NewLoginLimiter(max int, window time.Duration) *LoginLimiter {
-	return &LoginLimiter{events: make(map[string][]time.Time), max: max, window: window}
+	return &LoginLimiter{
+		events:    make(map[string][]time.Time),
+		max:       max,
+		window:    window,
+		lastSweep: time.Now(),
+	}
 }
 
 // Allow returns true if the caller may attempt another login. Record a failure
@@ -27,7 +37,9 @@ func NewLoginLimiter(max int, window time.Duration) *LoginLimiter {
 func (l *LoginLimiter) Allow(ip string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.gc(ip, time.Now())
+	now := time.Now()
+	l.sweep(now)
+	l.gc(ip, now)
 	return len(l.events[ip]) < l.max
 }
 
@@ -36,6 +48,7 @@ func (l *LoginLimiter) Record(ip string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	now := time.Now()
+	l.sweep(now)
 	l.gc(ip, now)
 	l.events[ip] = append(l.events[ip], now)
 }
@@ -62,4 +75,23 @@ func (l *LoginLimiter) gc(ip string, now time.Time) {
 		return
 	}
 	l.events[ip] = events[i:]
+}
+
+// sweep expires every bucket whose events have all aged out, bounding the map
+// to the number of distinct IPs seen within one window. gc alone cannot do
+// this: it only touches the IP currently being looked up, so a caller that
+// rotates source addresses (trivial inside a single IPv6 /64) would otherwise
+// grow l.events without limit. Runs at most once per window, so the O(n) walk
+// is amortised to near nothing on the login path. Caller holds l.mu.
+func (l *LoginLimiter) sweep(now time.Time) {
+	if now.Sub(l.lastSweep) < l.window {
+		return
+	}
+	l.lastSweep = now
+	cutoff := now.Add(-l.window)
+	for ip, events := range l.events {
+		if len(events) == 0 || !events[len(events)-1].After(cutoff) {
+			delete(l.events, ip)
+		}
+	}
 }


### PR DESCRIPTION
Closes #2137. Closes #2138.

Two small security defects found while sweeping the repo. Both weaken a control that is otherwise carefully built, and neither is a data leak on its own.

## LoginLimiter grew without bound (#2137)

`gc` prunes expired events for a single address, the one being looked up, and both `Allow` and `Record` call it as `gc(ip, time.Now())`. A bucket was therefore only ever cleaned when that same address came back. An IP that failed once and never returned kept its map entry for the life of the process, so `l.events` tracked every address that had ever attempted a login rather than the ones currently rate limited. Rotating source addresses inside a single IPv6 /64 grows it indefinitely.

The struct comment already claimed the property that was missing: *"Memory is bounded by expiring buckets in Allow."*

Fixed with a whole map sweep that runs at most once per window, so the map is bounded by the number of distinct addresses seen within one window. The O(n) walk is amortised to nothing on the login path because it runs once per window, not once per attempt.

A size cap with eviction was the alternative and was rejected: it raises the question of which address to evict, and an attacker who picks their own source address could then evict a genuinely rate limited one.

Worth noting that forged `X-Forwarded-For` is **not** the vector. `trustedProxyMiddleware` (`cmd/bindery/proxy.go:73-78`) strips forwarded headers from untrusted peers, so the key really is the peer address.

## Constant time stats token compare (#2138)

`cmd/telemetry-server/main.go` compared the bearer token with `!=` on both `/api/stats` and `/api/backup`. Go's string comparison returns at the first differing byte, so response latency leaks how many leading bytes of a guess were right.

`/api/backup` returns a `VACUUM INTO` snapshot of the whole installs database, so that token is the only control in front of the full telemetry dataset.

Now goes through `subtle.ConstantTimeCompare`, matching how the main binary already compares every other secret (`internal/auth/password.go:71`, `internal/auth/middleware.go:421`, `internal/api/opds_auth.go:50`). Both call sites already rejected an empty configured token; the new helper repeats that check so it cannot be satisfied by an unconfigured server.

## Tests

They assert behaviour, not mechanism.

* The limiter test drives 5000 distinct addresses, ages them out, then touches the limiter once so a sweep runs. **Verified it fails without the fix**, reporting all 5000 entries retained.
* A second test forces a sweep to become due while one bucket is still inside its window, so the sweep cannot hand an attacker a free reset by waiting.
* `TestStatsTokenValid` pins the accept and reject boundary, including a correct prefix, a missing scheme, and an unconfigured token.

## Scope

No migration, so this does not interact with the 076 to 079 sequence in flight. Touches `internal/auth/ratelimit.go` and `cmd/telemetry-server/`, neither of which any other open PR modifies.

`go build ./...`, `go vet`, and `go test -race` on both packages are green.