### PR TITLE
perf(abs): fan out Hardcover series catalog fetches, and reuse the cover client (#2144)

### DIFF
--- a/changelog.d/2144-abs-series-fanout-cover-client.md
+++ b/changelog.d/2144-abs-series-fanout-cover-client.md
@@ -1,0 +1,3 @@
+### Changed
+- **Audiobookshelf imports fetch Hardcover series catalogs concurrently** (#2144). A search returns up to five candidate series and each one's catalog was fetched only after the previous had returned, so a book whose series were not yet cached cost five sequential round trips. Most noticeable on the first import of a library, which is when the fewest series are cached.
+- **Calibre cover downloads reuse one HTTP client** (#2144). Each cover fetch built its own client, so two covers from the same host could not share a connection. Affects the first import of a library, before the on disk cover cache is warm.

--- a/internal/abs/import_hardcover_series.go
+++ b/internal/abs/import_hardcover_series.go
@@ -6,11 +6,34 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 
+	"github.com/vavallee/bindery/internal/concurrency"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/seriesmatch"
 	"github.com/vavallee/bindery/internal/textutil"
+)
+
+const (
+	// hardcoverSeriesCatalogConcurrency bounds the catalog fan-out per book.
+	// A search returns at most five results and a book rarely has more than
+	// two usable series queries, so four in flight covers the realistic worst
+	// case without turning one import into a burst against Hardcover.
+	hardcoverSeriesCatalogConcurrency = 4
+
+	// Bounded but deliberately NOT paced. RunBoundedPaced gates every launch
+	// on a wall-clock interval, and the aggregator caches series catalogs
+	// (internal/metadata/aggregator_series.go), so a paced fan-out would
+	// pay that interval even when the call is about to be served from cache. A
+	// real library reuses the same series across many books, so cache hits are
+	// the common case here, and pacing would tax the whole import for a
+	// burst risk that the bound above already covers.
+	//
+	// A cap is still meaningful: matchHardcoverSeries is called once per item,
+	// serially, from Importer.importItem (importer.go:670), so this bound is
+	// the ceiling on concurrent Hardcover calls for the whole import, not a
+	// per-book burst on top of other work.
 )
 
 type hardcoverSeriesQuery struct {
@@ -41,7 +64,25 @@ func (i *Importer) matchHardcoverSeries(ctx context.Context, cfg ImportConfig, r
 	if author != nil && strings.TrimSpace(author.Name) != "" {
 		authorName = strings.TrimSpace(author.Name)
 	}
-	candidates := make(map[string]hardcoverSeriesCandidate)
+	// Search first, collecting every (query, result) pair, then fetch the
+	// catalogs those results point at concurrently, then score. Splitting the
+	// three phases buys two things over the nested loop this replaces.
+	//
+	// The catalog fetches stop being serial. Each one is an outbound Hardcover
+	// call, and there are up to five per query, so a cold cache used to mean
+	// five round trips end to end for every book an import touches.
+	//
+	// Collecting unique ForeignIDs before fetching also stops the same series
+	// being requested once per query that returned it, which happens routinely
+	// when a book carries both an ABS series name and an alternate spelling.
+	// That is tidiness rather than a saving: the aggregator already caches by
+	// ForeignID, so the repeat never reached the network. It does mean the
+	// fan-out width reflects real work instead of duplicates.
+	type pendingCandidate struct {
+		query  hardcoverSeriesQuery
+		result metadata.SeriesSearchResult
+	}
+	var pending []pendingCandidate
 	for _, query := range queries {
 		results, err := i.meta.SearchSeries(ctx, query.Title, 5)
 		if err != nil {
@@ -49,22 +90,53 @@ func (i *Importer) matchHardcoverSeries(ctx context.Context, cfg ImportConfig, r
 			continue
 		}
 		for _, result := range results {
-			catalog, err := i.meta.GetSeriesCatalog(ctx, result.ForeignID)
+			pending = append(pending, pendingCandidate{query: query, result: result})
+		}
+	}
+
+	wanted := make([]string, 0, len(pending))
+	seenSeries := make(map[string]struct{}, len(pending))
+	for _, p := range pending {
+		if _, ok := seenSeries[p.result.ForeignID]; ok {
+			continue
+		}
+		seenSeries[p.result.ForeignID] = struct{}{}
+		wanted = append(wanted, p.result.ForeignID)
+	}
+
+	var catalogMu sync.Mutex
+	catalogs := make(map[string]*metadata.SeriesCatalog, len(wanted))
+	concurrency.RunBounded(ctx, wanted, hardcoverSeriesCatalogConcurrency,
+		func(ctx context.Context, foreignID string) {
+			catalog, err := i.meta.GetSeriesCatalog(ctx, foreignID)
 			if err != nil {
-				slog.Warn("abs import: hardcover series catalog failed", "itemID", item.ItemID, "series", result.ForeignID, "error", err)
-				continue
+				slog.Warn("abs import: hardcover series catalog failed", "itemID", item.ItemID, "series", foreignID, "error", err)
+				return
 			}
 			if catalog == nil {
-				continue
+				return
 			}
-			candidate, ok := evaluateHardcoverSeriesCandidate(query, authorName, item, result, catalog)
-			if !ok {
-				continue
-			}
-			key := catalog.ForeignID
-			if existing, exists := candidates[key]; !exists || candidate.Score > existing.Score {
-				candidates[key] = candidate
-			}
+			catalogMu.Lock()
+			catalogs[foreignID] = catalog
+			catalogMu.Unlock()
+		})
+
+	// Score in the original query-then-result order so the highest-score-wins
+	// tie-break below resolves exactly as it did serially. The fan-out above
+	// only changes when the catalogs are fetched, never which one is picked.
+	candidates := make(map[string]hardcoverSeriesCandidate)
+	for _, p := range pending {
+		catalog := catalogs[p.result.ForeignID]
+		if catalog == nil {
+			continue
+		}
+		candidate, ok := evaluateHardcoverSeriesCandidate(p.query, authorName, item, p.result, catalog)
+		if !ok {
+			continue
+		}
+		key := catalog.ForeignID
+		if existing, exists := candidates[key]; !exists || candidate.Score > existing.Score {
+			candidates[key] = candidate
 		}
 	}
 	selected, ambiguous := selectHardcoverSeriesCandidate(candidates)

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -855,6 +856,16 @@ type stubABSMetadataProvider struct {
 	catalogs             map[string]*metadata.SeriesCatalog
 	searchSeriesCalls    int
 	searchAuthorsCalls   int
+
+	// catalogMu guards catalogCalls: GetSeriesCatalog is fanned out
+	// concurrently by matchHardcoverSeries, so the counter is written from
+	// several goroutines at once.
+	catalogMu    sync.Mutex
+	catalogCalls map[string]int
+
+	// onCatalog, when set, runs inside GetSeriesCatalog. Used to observe how
+	// many catalog fetches are in flight at once.
+	onCatalog func()
 }
 
 func (p *stubABSMetadataProvider) Name() string { return "stub" }
@@ -907,10 +918,28 @@ func (p *stubABSMetadataProvider) SearchSeries(_ context.Context, query string, 
 	return results, nil
 }
 func (p *stubABSMetadataProvider) GetSeriesCatalog(_ context.Context, foreignID string) (*metadata.SeriesCatalog, error) {
+	p.catalogMu.Lock()
+	if p.catalogCalls == nil {
+		p.catalogCalls = map[string]int{}
+	}
+	p.catalogCalls[foreignID]++
+	hook := p.onCatalog
+	p.catalogMu.Unlock()
+	if hook != nil {
+		hook()
+	}
 	if p.catalogs == nil {
 		return nil, nil
 	}
 	return p.catalogs[foreignID], nil
+}
+
+// catalogCallCount reports how many times GetSeriesCatalog was asked for one
+// series, safely against the concurrent fan-out.
+func (p *stubABSMetadataProvider) catalogCallCount(foreignID string) int {
+	p.catalogMu.Lock()
+	defer p.catalogMu.Unlock()
+	return p.catalogCalls[foreignID]
 }
 
 func TestImporter_NormalizedAuthorMatchLinksExistingAuthor(t *testing.T) {
@@ -3230,6 +3259,110 @@ func TestImporter_HardcoverSeriesLinksExistingCatalogBookWithRollback(t *testing
 	}
 	if link != nil {
 		t.Fatalf("series membership provenance after rollback = %+v, want nil", link)
+	}
+}
+
+// TestImporter_HardcoverSeriesCatalogFetchesOverlap asserts the catalog
+// lookups actually run concurrently. Before this, matchHardcoverSeries fetched
+// each search result's catalog one after another, so a cold cache meant up to
+// five sequential Hardcover round trips for every book an import touched.
+//
+// The test observes overlap directly rather than timing the run: each stubbed
+// fetch parks until a second one has started, so it can only complete if the
+// fan-out is real. Against the serial implementation the first fetch waits
+// alone, hits its timeout, and maxInFlight stays at 1.
+func TestImporter_HardcoverSeriesCatalogFetchesOverlap(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, _, _, _, _, _, _, _ := newABSImporterFixture(t)
+	enableHardcoverSeriesMatching(t, importer)
+	item := sampleABSItem()
+	item.ItemID = "li-all-systems-red"
+	item.Title = "All Systems Red"
+	item.Authors = []NormalizedAuthor{{ID: "author-martha-wells", Name: "Martha Wells"}}
+	item.Series = []NormalizedSeries{{Name: "The Murderbot Diaries", Sequence: "1"}}
+
+	// Three distinct series, so three distinct catalog fetches. Distinct IDs
+	// matter: the aggregator caches by ForeignID, so repeats would never reach
+	// the stub at all.
+	var results []metadata.SeriesSearchResult
+	catalogs := map[string]*metadata.SeriesCatalog{}
+	for _, id := range []string{"hc-series:200", "hc-series:201", "hc-series:202"} {
+		results = append(results, metadata.SeriesSearchResult{
+			ForeignID: id, ProviderID: id, Title: "The Murderbot Diaries", AuthorName: "Martha Wells",
+		})
+		catalogs[id] = &metadata.SeriesCatalog{
+			ForeignID: id, ProviderID: id, Title: "The Murderbot Diaries", AuthorName: "Martha Wells",
+			Books: []metadata.SeriesCatalogBook{{
+				ForeignID: "hc:all-systems-red-" + id,
+				Title:     "All Systems Red",
+				Position:  "1",
+				Book: models.Book{
+					ForeignID:        "hc:all-systems-red-" + id,
+					Title:            "All Systems Red",
+					MetadataProvider: providerHardcover,
+					Author:           &models.Author{Name: "Martha Wells"},
+				},
+			}},
+		}
+	}
+
+	var mu sync.Mutex
+	var inFlight, maxInFlight int
+	overlapped := make(chan struct{})
+	var once sync.Once
+
+	provider := &stubABSMetadataProvider{
+		series:   map[string][]metadata.SeriesSearchResult{"The Murderbot Diaries": results},
+		catalogs: catalogs,
+	}
+	provider.onCatalog = func() {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		reached := inFlight >= 2
+		mu.Unlock()
+
+		if reached {
+			once.Do(func() { close(overlapped) })
+		}
+		// Park until another fetch joins. The timeout keeps a serial
+		// implementation from hanging the suite; it just fails instead.
+		select {
+		case <-overlapped:
+		case <-time.After(2 * time.Second):
+		}
+
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+	}
+
+	importer.WithMetadata(metadata.NewAggregator(provider))
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+	if _, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: item.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	peak := maxInFlight
+	mu.Unlock()
+	if peak < 2 {
+		t.Errorf("peak concurrent catalog fetches = %d, want at least 2: the fan-out is running serially", peak)
 	}
 }
 

--- a/internal/calibre/metadata.go
+++ b/internal/calibre/metadata.go
@@ -264,6 +264,29 @@ func FormatPublishedDate(t *time.Time) string {
 	return t.UTC().Format("2006-01-02")
 }
 
+// coverFetchClient is shared across cover downloads. It used to be built
+// inline on every call, which meant a fresh Transport and therefore a fresh
+// connection pool per cover: no keep-alive reuse between two covers from the
+// same host, which is the normal case when importing a Calibre library. Every
+// other outbound client in the codebase is built once in a constructor and
+// reused; this was the one exception.
+//
+// The disk cache in findExistingCover suppresses repeat fetches of the same
+// URL, so this only shows up on the first import of a library, which is
+// exactly when there are the most covers to fetch.
+var coverFetchClient = &http.Client{
+	Timeout: 15 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if err := httpsec.ValidateOutboundURL(req.URL.String(), httpsec.PolicyStrict); err != nil {
+			return fmt.Errorf("redirect blocked: %w", err)
+		}
+		if len(via) >= 5 {
+			return fmt.Errorf("too many redirects")
+		}
+		return nil
+	},
+}
+
 // MaterializeCover fetches an external cover into cacheDir and returns a local
 // path Calibre can consume. It validates outbound URLs to avoid SSRF and keeps
 // failures non-fatal for callers.
@@ -281,23 +304,11 @@ func MaterializeCover(ctx context.Context, cacheDir, rawURL string) (string, err
 		return existing, nil
 	}
 
-	client := &http.Client{
-		Timeout: 15 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if err := httpsec.ValidateOutboundURL(req.URL.String(), httpsec.PolicyStrict); err != nil {
-				return fmt.Errorf("redirect blocked: %w", err)
-			}
-			if len(via) >= 5 {
-				return fmt.Errorf("too many redirects")
-			}
-			return nil
-		},
-	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return "", err
 	}
-	resp, err := client.Do(req)
+	resp, err := coverFetchClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/calibre/metadata_test.go
+++ b/internal/calibre/metadata_test.go
@@ -1,7 +1,9 @@
 package calibre
 
 import (
+	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -141,3 +143,64 @@ func TestIdentifierArgs_CleansAndSortsIdentifiers(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// TestCoverFetchClientCheckRedirect covers the redirect policy on the shared
+// cover client. MaterializeCover validates the URL it is given, but a cover
+// host can answer with a 302 to somewhere else entirely, so the redirect hook
+// is the control that stops a public cover URL being used to reach a private
+// address. It had no test.
+func TestCoverFetchClientCheckRedirect(t *testing.T) {
+	if coverFetchClient.CheckRedirect == nil {
+		t.Fatal("cover client has no CheckRedirect hook")
+	}
+
+	newReq := func(rawURL string) *http.Request {
+		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		if err != nil {
+			t.Fatalf("build request for %q: %v", rawURL, err)
+		}
+		return req
+	}
+
+	// Every URL below uses an IP literal. ValidateOutboundURL resolves
+	// hostnames, so a name here would make the test depend on DNS and fail
+	// wherever lookups are unavailable.
+	const publicHost = "https://93.184.216.34/a.jpg"
+
+	t.Run("allows a public redirect", func(t *testing.T) {
+		if err := coverFetchClient.CheckRedirect(newReq(publicHost), nil); err != nil {
+			t.Errorf("public redirect rejected: %v", err)
+		}
+	})
+
+	t.Run("blocks a redirect to a private address", func(t *testing.T) {
+		for _, target := range []string{
+			"http://127.0.0.1/a.jpg",
+			"http://169.254.169.254/latest/meta-data/",
+			"http://10.0.0.5/a.jpg",
+		} {
+			err := coverFetchClient.CheckRedirect(newReq(target), nil)
+			if err == nil {
+				t.Errorf("redirect to %s was allowed", target)
+				continue
+			}
+			if !strings.Contains(err.Error(), "redirect blocked") {
+				t.Errorf("redirect to %s: error = %v, want it to name the block", target, err)
+			}
+		}
+	})
+
+	t.Run("caps the redirect chain", func(t *testing.T) {
+		via := make([]*http.Request, 5)
+		for i := range via {
+			via[i] = newReq(publicHost)
+		}
+		err := coverFetchClient.CheckRedirect(newReq(publicHost), via)
+		if err == nil {
+			t.Fatal("a 5 hop chain was allowed to continue")
+		}
+		if !strings.Contains(err.Error(), "too many redirects") {
+			t.Errorf("error = %v, want it to name the hop limit", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #2144.

## The sequential fan-out

`matchHardcoverSeries` walked its candidates strictly one at a time. A search returns up to five results and each result's catalog was fetched only after the previous had returned, so a single book could cost five sequential Hardcover round trips. It runs once per item from `importItem` (`internal/abs/importer.go:670`), and an import walks the whole library.

Now split into three phases: search and collect every (query, result) pair, fan the catalog fetches out over the unique series IDs, then score in the original query-then-result order.

**Scoring order is preserved deliberately**, so the highest-score-wins tie-break resolves exactly as it did serially. The fan-out changes when catalogs are fetched, never which candidate is chosen.

## Bounded, not paced

`RunBoundedPaced` gates every launch on a wall-clock interval, and the aggregator caches series catalogs, so a paced fan-out would pay that interval even when the call was about to be served from cache. Cache hits are the common case in a real library, so pacing would tax the whole import to guard against a burst the concurrency bound already covers.

The bound of 4 is a genuine ceiling rather than a per-book burst, because the caller is serial.

## How big is this actually

Worth being straight rather than overselling it. The aggregator caches both `SearchSeries` and `GetSeriesCatalog` (`aggregator_series.go:18`, `:45`), so after warmup most fetches cost nothing and the serial shape does not show. **It hurts on the cold path**: the first import of a library, or any import whose series are mostly new. That is also the import with the most work to do, which is why it is worth fixing.

Collecting unique ForeignIDs before fetching also stops the same series being requested once per query that returned it. That is tidiness rather than a saving, since the cache already absorbed the repeat.

## The test

It asserts overlap directly rather than timing the run: each stubbed fetch parks until a second one has started, so it can only complete if the fan-out is real. **Verified it fails against the previous implementation** with `peak concurrent catalog fetches = 1`.

An earlier version of this test asserted the dedup instead, by counting calls per series. It passed against the old code too, because the aggregator cache meant the duplicate lookup never reached the stub. I replaced it rather than keeping it, since a test that passes either way documents nothing.

## Calibre cover client

`internal/calibre/metadata.go` built an `&http.Client{}` inline on every cover fetch, meaning a fresh Transport and therefore a fresh connection pool per cover: no keep-alive reuse between two covers from the same host, which is the normal case for a Calibre library. It was the only outbound client in the codebase not built once and reused.

Now a package-level var. The on-disk cover cache suppresses repeat fetches of the same URL, so this only shows up on a library's first import, which is when there are the most covers to fetch.

## Scope

No migration. `go test -race` green on `./internal/abs/` and `./internal/calibre/`. Neither `import_hardcover_series.go` nor `calibre/metadata.go` is touched by any other open PR (#2134 edits `internal/abs/import_upserts.go`, a different file).