### PR TITLE
docs: correct the SQLite concurrency claim and document the extension points

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,13 +173,85 @@ doc- and config-only PRs have no measured lines and pass automatically.
 Schema changes are additive SQL files in `internal/db/migrations/`, applied
 idempotently at startup, named `NNN_short_description.sql`.
 
-- **Use the next free number** — look at the highest existing file and add one.
+- **Use the next free number.** Look at the highest existing file and add one,
+  then **check the open pull requests too**. "Next free" computed against `main`
+  alone is wrong whenever another branch has already claimed a number and has not
+  merged yet, and announcing a number reserves nothing. Only a pushed file is
+  visible to anyone else.
 - **The gap at `010` is intentional**; numbering follows the filename prefix, not
   slice position. Don't fill the gap.
 - Two files sharing a number are rejected at boot (the duplicate-version guard),
   so if your branch and `main` both added `0NN`, **renumber yours** to the next
   free slot when you rebase.
 - Migrations are forward-only and must not destructively rewrite existing rows.
+
+## Adding a new integration
+
+The three most common contributions are a new metadata source, a new download
+client, and a new indexer. They are wired up very differently, so it is worth
+knowing which shape you are dealing with before you start.
+
+### A metadata provider (interface based)
+
+Implement `metadata.Provider` (`internal/metadata/provider.go`). That is the
+required surface: `Name`, `SearchAuthors`, `SearchBooks`, `GetAuthor`,
+`GetBook`, `GetEditions`, `GetBookByISBN`.
+
+Extra capabilities are **optional interfaces**, discovered by type assertion
+rather than declared up front. Implement only what your source supports:
+
+| Interface | Gives you |
+|-----------|-----------|
+| `metadata.SeriesCatalogProvider` | Series search and ordered series catalogues |
+| `metadata.CoverProvider` | Cover art lookup |
+
+Register the provider in `cmd/bindery/main.go`, at the
+`metadata.NewAggregator(primaryProvider, enrichers...)` call. A source is either
+the *primary* (the one that defines canonical identity) or an *enricher* (one
+that fills gaps). Most new sources are enrichers.
+
+Return `metadata.ErrProviderNotConfigured` when credentials are missing, rather
+than an error. The aggregator treats it as "skip me" instead of a failure, which
+is what lets an unconfigured provider stay registered without generating noise.
+
+### A download client (switch based)
+
+There is no interface here. `models.DownloadClient.Type` is a string and
+`internal/downloader/` switches on it, so adding a client means adding cases by
+hand. Missing one is the usual way a new client ends up half working.
+
+**Required**, in `internal/downloader/adapter.go`: `TestClient`, the dispatch
+switch, `RemoveDownload` and `GetStalledIDs`, plus the `IsTorrentClient` /
+`IsNZBGetClient` / `ProtocolForClient` helpers that decide protocol and
+semantics. Every client type must appear here. Plus the client package itself,
+under `internal/downloader/<name>/`.
+
+**Optional, and currently partial.** Do not assume these cover every client,
+because they do not:
+
+- `internal/downloader/pathcheck.go` carries path visibility. Only qBittorrent,
+  NZBGet and rTorrent implement it; the rest fall through.
+- `internal/downloader/health.go` carries health probing. qBittorrent only, and
+  every other type stores a fabricated OK. That is
+  [#2029](https://github.com/vavallee/bindery/issues/2029), so check whether it
+  has been generalised before adding a case.
+
+Grep for `qbittorrent` to see the fullest set of sites, since it is the one
+client wired into all of them.
+
+### An indexer
+
+Indexers live under `internal/indexer/`. Most are Newznab or Torznab compatible
+and go through `internal/indexer/newznab/`, so a genuinely new protocol is rare.
+Check whether your target speaks one of those first.
+
+### In all three cases
+
+Outbound HTTP must go through the SSRF guard. Use
+`httpsec.ValidateOutboundURL` with the policy that matches your source:
+`PolicyLANLoopback` for admin configured infrastructure, `PolicyStrict` for
+anything derived from data you did not type in yourself. See
+`internal/httpsec/ssrf.go` for what each policy allows and why.
 
 ## Changelog — add a fragment, don't edit CHANGELOG.md
 

--- a/changelog.d/2148-docs-sweep-followups.md
+++ b/changelog.d/2148-docs-sweep-followups.md
@@ -1,0 +1,2 @@
+### Changed
+- **Docs corrected and extended after the security and performance sweep**. `ARCHITECTURE.md` claimed SQLite reads run concurrently, which the single connection pool has never allowed. `DEPLOYMENT.md` gains a database durability section explaining what `synchronous=NORMAL` does and does not risk. `CONTRIBUTING.md` gains a guide to adding a metadata provider, download client or indexer, and now warns that the next free migration number must be checked against open pull requests, not just `main`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ OpenLibrary    Google Books, Hardcover.app,   Audnex, Audible
 |-------|-------|-------|
 | **HTTP router** | [chi](https://github.com/go-chi/chi) v5 | Sub-routers per resource, middleware-driven auth/CSRF/rate-limit. |
 | **Backend language** | Go 1.26 (built with `golang:1.26.4`) | Standard library HTTP server, structured logging via `slog`. |
-| **Database** | SQLite, WAL mode | [`modernc.org/sqlite`](https://pkg.go.dev/modernc.org/sqlite) — pure Go, no CGO. Single `bindery.db` file. |
+| **Database** | SQLite, WAL mode | [`modernc.org/sqlite`](https://pkg.go.dev/modernc.org/sqlite) — pure Go, no CGO. Single `bindery.db` file. Connection pragmas (`foreign_keys`, `busy_timeout`, `synchronous`, `temp_store`, `cache_size`) are carried in the DSN so the driver reapplies them to every connection it opens; see [Database durability](DEPLOYMENT.md#database-durability). |
 | **Schema migrations** | Embedded SQL files in `internal/db/migrations/` | Linearly-numbered, additive-only, applied at startup. |
 | **Frontend** | React 19 + TypeScript + Tailwind CSS 4 | Built with [Vite](https://vite.dev), output baked into the binary via `go:embed`. |
 | **Container** | Multi-stage build on [distroless/static-debian12:nonroot](https://github.com/GoogleContainerTools/distroless) | No shell, no package manager, runs as UID `65532`. |
@@ -87,7 +87,7 @@ If audiobooks live on a different volume, set `BINDERY_AUDIOBOOK_DIR` (and optio
 
 - One HTTP server goroutine pool; chi's per-request handlers run on caller goroutines.
 - Background workers (auto-grab sweep, recommendations refresh, indexer probes, ABS import) are scheduled by the `scheduler` package as long-lived goroutines guarded by context cancellation on shutdown.
-- SQLite uses WAL mode with a single writer; reads are concurrent, writes serialize at the connection-pool layer. This is sufficient for the workload — measured contention is negligible on libraries with tens of thousands of books.
+- SQLite runs in WAL mode, but the connection pool is pinned to a single connection (`SetMaxOpenConns(1)`), so **reads serialize alongside writes** rather than running concurrently. WAL's concurrent-reader property is not currently being used. This is sufficient for the workload in practice, and [#2147](https://github.com/vavallee/bindery/issues/2147) tracks lifting it, including the reason it is not a one-line change: migrations run a connection-scoped `PRAGMA foreign_keys=OFF`, which a pool would break.
 - All outbound HTTP calls go through a shared client with timeouts, SSRF guards, and User-Agent stamping (`bindery/<version>`).
 
 ## Why these choices

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -451,6 +451,21 @@ If your platform doesn't let you change the container command (some NAS app UIs)
 
 Where the orphans come from: before [#1727](https://github.com/vavallee/bindery/issues/1727), foreign key enforcement could silently switch off on a replacement pooled connection, so declared cascades stopped firing. Long-running instances accumulated orphan rows. They are harmless to normal operation — Bindery starts and runs fine with them — and this tooling exists to clean them up on your schedule. See [Troubleshooting](Troubleshooting-Wiki.md#bindery-will-not-start-after-upgrading-foreign_key_check-found-n-violations).
 
+## Database durability
+
+Bindery runs SQLite in WAL mode with `synchronous=NORMAL`. That is the setting SQLite documents as the correct companion to WAL, and it is what the database has used since [#2142](https://github.com/vavallee/bindery/issues/2142).
+
+What it means in practice:
+
+- **An application crash loses nothing.** If Bindery is killed, panics, or the container is stopped, WAL recovery replays the log on next start and every committed transaction is intact.
+- **A sudden power loss or OS crash can lose the last few committed transactions**, specifically those not yet checkpointed. It cannot corrupt the database.
+
+Under the previous default (`synchronous=FULL`) every single commit was flushed to disk. Bindery commits constantly on paths nobody triggers by hand: the importer updates status per file, the scheduler polls download clients and writes results back, library scans reconcile rows, and history rows are appended. Paying a disk flush for each of those cost far more than the few seconds of status updates at risk from a power cut.
+
+If your instance runs somewhere with unreliable power and you would rather have the old behaviour, run it on a UPS, or open an issue and it can be made configurable. There is no environment variable for it today because no one has needed one.
+
+This has no bearing on backups. Take a copy of `bindery.db` on your own schedule as before, with the instance stopped or via `sqlite3 bindery.db ".backup"`.
+
 ## Upgrading
 
 ### Legacy migration-marker repair


### PR DESCRIPTION
Follow-up to the security and performance sweep. Three things, one of which was simply wrong.

## ARCHITECTURE.md was inaccurate

It said:

> SQLite uses WAL mode with a single writer; reads are concurrent, writes serialize at the connection-pool layer.

Reads have never been concurrent. The pool is pinned with `SetMaxOpenConns(1)`, so everything serializes on one connection and WAL's concurrent-reader property is unused.

Corrected, with a pointer to #2147, which tracks lifting it and records why it is not a one line change: migrations run a connection scoped `PRAGMA foreign_keys=OFF` that a pool would break.

## DEPLOYMENT.md: database durability

`synchronous=NORMAL` landed in #2142 and changes what a power cut costs. That is an operator facing fact and it was documented nowhere.

The new section states both halves plainly: an application crash loses nothing, because WAL recovery replays the log, while a sudden power loss or OS crash can lose the last few committed transactions that have not been checkpointed, and cannot corrupt the database. It also says what to do if that trade is unwanted, and that backups are unaffected.

## CONTRIBUTING.md: adding a new integration

The three likeliest external contributions are a metadata source, a download client and an indexer, and nothing described how any of them are wired.

They are also wired very differently, which is the part worth knowing before you start: a metadata provider implements an interface, with optional capability interfaces discovered by type assertion, whereas a download client is a string type switched on by hand in several places.

**Every claim in that section was checked against the code, and three of my first drafts were wrong:**

- I listed `health.go` and `api/download_clients.go` as per-type switch sites. `health.go` is qBittorrent only (#2029) and `download_clients.go` only checks for an empty type.
- I described `pathcheck.go` as covering every client. It handles three.
- I called rtorrent the newest client. sabnzbd is.

The section now separates required sites from partial ones, and names `qbittorrent` as the grep target rather than `deluge`, because it is the only client wired into all of them.

## Migration numbering

Sharpened after two branches both claimed `076` today. "Next free" computed against `main` alone is wrong when another branch has claimed a number and not merged, and announcing one in conversation reserves nothing. Only a pushed file is visible to anyone else.

## Scope

Docs only. No Go code, no migration, no behaviour change.