### PR TITLE
feat(telemetry): log new_install on each ping

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -1274,13 +1274,20 @@ func (s *server) handlePing(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := time.Now().UTC()
+	// newInstall is true when the upsert inserted a row rather than
+	// updating one. RETURNING sees the row as stored after the statement,
+	// so first_seen == last_seen only on the insert path (both bound to
+	// the same `now`); on the update path first_seen keeps its original
+	// value. Surfaced in the ping log line so new installs can be spotted
+	// in k8s logs without querying the DB.
+	var newInstall bool
 	err := func() error {
 		tx, err := s.db.BeginTx(r.Context(), nil)
 		if err != nil {
 			return err
 		}
 		defer func() { _ = tx.Rollback() }()
-		if _, err := tx.ExecContext(r.Context(), `
+		if err := tx.QueryRowContext(r.Context(), `
 			INSERT INTO installs (install_id, version, os, arch, deploy, features, first_seen, last_seen)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(install_id) DO UPDATE SET
@@ -1290,7 +1297,8 @@ func (s *server) handlePing(w http.ResponseWriter, r *http.Request) {
 				deploy    = excluded.deploy,
 				features  = excluded.features,
 				last_seen = excluded.last_seen
-		`, req.InstallID, req.Version, req.OS, req.Arch, req.Deploy, featuresJSON, now, now); err != nil {
+			RETURNING first_seen = last_seen
+		`, req.InstallID, req.Version, req.OS, req.Arch, req.Deploy, featuresJSON, now, now).Scan(&newInstall); err != nil {
 			return err
 		}
 		// Activity ledger: attribute this install to today. Unlike
@@ -1313,7 +1321,7 @@ func (s *server) handlePing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("ping", "id", req.InstallID[:min(8, len(req.InstallID))], "version", req.Version, "os", req.OS, "arch", req.Arch, "features", featuresJSON.Valid)
+	slog.Info("ping", "id", req.InstallID[:min(8, len(req.InstallID))], "version", req.Version, "os", req.OS, "arch", req.Arch, "features", featuresJSON.Valid, "new_install", newInstall)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(pingResponse{LatestVersion: s.latest()})

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1317,6 +1318,49 @@ func TestHandlePing_WritesLedger(t *testing.T) {
 	}
 	if version != "1.15.3" {
 		t.Errorf("ledger version = %q, want 1.15.3 (last ping of the day wins)", version)
+	}
+}
+
+// TestHandlePing_LogsNewInstall verifies the ping log line carries
+// new_install=true on the first ping from an install_id and false on every
+// later one. The flag comes from the upsert's RETURNING clause, so this
+// also pins that first_seen = last_seen compares equal on the insert path
+// under modernc's time binding.
+func TestHandlePing_LogsNewInstall(t *testing.T) {
+	s := newTestServer(t, "v1.15.3")
+	s.limiter = newRateLimiter(time.Hour, time.Minute)
+
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	ping := func(installID, remoteAddr string) string {
+		t.Helper()
+		logs.Reset()
+		body, _ := json.Marshal(pingRequest{
+			InstallID: installID, Version: "1.15.3", OS: "linux", Arch: "amd64",
+		})
+		r := httptest.NewRequest(http.MethodPost, "/api/ping", bytes.NewReader(body))
+		r.RemoteAddr = remoteAddr
+		w := httptest.NewRecorder()
+		s.handlePing(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("ping status = %d, body = %s", w.Code, w.Body.String())
+		}
+		return logs.String()
+	}
+
+	const a = "11111111-1111-1111-1111-111111111111"
+	const b = "22222222-2222-2222-2222-222222222222"
+	if got := ping(a, "192.0.2.10:1234"); !strings.Contains(got, "new_install=true") {
+		t.Errorf("first ping from %s: log = %q, want new_install=true", a[:8], got)
+	}
+	if got := ping(a, "192.0.2.11:1234"); !strings.Contains(got, "new_install=false") {
+		t.Errorf("second ping from %s: log = %q, want new_install=false", a[:8], got)
+	}
+	if got := ping(b, "192.0.2.12:1234"); !strings.Contains(got, "new_install=true") {
+		t.Errorf("first ping from %s: log = %q, want new_install=true", b[:8], got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `new_install=true|false` to the `ping` log line in `cmd/telemetry-server`, so a first-time install shows up directly in the `bindery-ping` pod logs.

## Implementation notes

The installs upsert now ends with `RETURNING first_seen = last_seen`. On the insert path both columns are bound to the same `now`, so the comparison is true; on the update path `first_seen` keeps its original value, so it is false. No extra query, no schema change. `modernc.org/sqlite` v1.56.0 bundles a SQLite new enough for `RETURNING`.

## Checklist

- [x] Tests added or updated (`TestHandlePing_LogsNewInstall`: first ping true, second ping false, different install true)
- [x] Doc-update gate cleared (no docs reference the ping log fields)
- [x] Wiki pages updated if user-facing behaviour changed (not user-facing)

## Test plan

- [x] `go vet ./cmd/telemetry-server/`
- [x] `go test -count=1 ./cmd/telemetry-server/`
