### PR TITLE
feat(web): add an unmatched manual-import file's book from a metadata search (#1719)

### DIFF
--- a/docs/User-Guide-Wiki.md
+++ b/docs/User-Guide-Wiki.md
@@ -42,7 +42,9 @@ an arbitrary release is unreliable. The escape hatches:
 - **Search Indexers** (the magnifier icon in the header) — free-text search
   across all your indexers; any result can be grabbed.
 - **Manual Import** (`/import`) — point it at a folder of files you already
-  have and match them to books.
+  have and match them to books. A file with no catalogue match gets a metadata
+  search on its row, which creates the book (and its author, if new) and links
+  the file to it, so an unmatched file is no longer a dead end.
 
 Both still end by attaching a file to a catalogue record.
 

--- a/web/src/api/booklookup.ts
+++ b/web/src/api/booklookup.ts
@@ -1,0 +1,27 @@
+import { api } from './client'
+import type { Book } from './client'
+
+// An ISBN-13 (978/979 + 10 digits) or ISBN-10 (9 digits + check digit/X),
+// after hyphens and spaces are stripped.
+const ISBN_RE = /^97[89]\d{10}$|^\d{9}[\dX]$/
+// An Audible/Amazon ASIN: 10 characters starting with B. Checked after ISBN;
+// the two patterns do not overlap.
+const ASIN_RE = /^B[0-9A-Z]{9}$/i
+
+// resolveBookQuery turns one free-text query into provider metadata results,
+// choosing the endpoint by the shape of the query: an ISBN or ASIN goes to
+// /book/lookup (exact, one result), anything else to /search/book.
+//
+// Shared by the Add Book modal and Manual Import's metadata search so the two
+// accept the same inputs. A user who can paste an ISBN into one should not find
+// it treated as a title by the other.
+export async function resolveBookQuery(query: string): Promise<Book[]> {
+  const q = query.trim()
+  if (!q) return []
+  const compact = q.replace(/[-\s]/g, '')
+  if (ISBN_RE.test(compact)) return [await api.lookupISBN(compact)]
+  if (ASIN_RE.test(q)) return [await api.lookupASIN(q.toUpperCase())]
+  // A backend that encodes an empty search as `null` rather than `[]` must not
+  // reach the callers' `.map()`.
+  return (await api.searchBooks(q)) ?? []
+}

--- a/web/src/components/AddBookModal.tsx
+++ b/web/src/components/AddBookModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, Book } from '../api/client'
+import { resolveBookQuery } from '../api/booklookup'
 
 interface Props {
   onClose: () => void
@@ -27,21 +28,9 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
     setSearchError(null)
     setAddError(null)
     try {
-      // ISBN lookup takes priority when the query looks like an ISBN.
-      if (/^97[89]\d{10}$|^\d{9}[\dX]$/.test(q.replace(/[-\s]/g, ''))) {
-        const book = await api.lookupISBN(q.replace(/[-\s]/g, ''))
-        setResults([book])
-      } else if (/^B[0-9A-Z]{9}$/i.test(q)) {
-        // ASIN (Audible/Amazon) lookup — a 10-char token starting with B.
-        // Checked after ISBN; the two patterns don't overlap.
-        const book = await api.lookupASIN(q.toUpperCase())
-        setResults([book])
-      } else {
-        const books = await api.searchBooks(q)
-        // Guard against a `null` body (e.g. an empty search the backend
-        // encoded as `null` instead of `[]`) so the render's `.map()` can't crash.
-        setResults(books ?? [])
-      }
+      // ISBN / ASIN / free-text dispatch lives in resolveBookQuery so Manual
+      // Import's metadata search accepts exactly the same inputs.
+      setResults(await resolveBookQuery(q))
     } catch (err) {
       setSearchError(err instanceof Error ? err.message : t('addBookModal.searchFailed'))
       setResults([])

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -74,7 +74,7 @@
   },
   "manualImport": {
     "title": "Manual Import",
-    "description": "Scan a folder of files already on disk, match each book to your library, and import them. Matching is against books already in your library.",
+    "description": "Scan a folder of files already on disk, match each book to your library, and import them. A file with no match can be added from a metadata search.",
     "pathLabel": "Folder to scan",
     "pathPlaceholder": "/downloads/books",
     "scan": "Scan folder",
@@ -102,7 +102,17 @@
     "failed": "Failed: {{error}}",
     "searchLabel": "Search your library",
     "searchPlaceholder": "Search your library for the book…",
-    "noResults": "No matching books in your library. Add the book first, then rescan."
+    "noResults": "No matching books in your library. Search metadata below to add it.",
+    "metadataOpen": "Not in your library? Search metadata",
+    "metadataLabel": "Search metadata",
+    "metadataPlaceholder": "Title, author, ISBN, or ASIN",
+    "metadataSearch": "Search",
+    "metadataSearching": "Searching…",
+    "metadataHint": "Adds the book to your library and links this file to it. No indexer search is started.",
+    "metadataNoResults": "No metadata results for that search.",
+    "metadataAuthorMissing": "Author name missing on this result",
+    "metadataAdd": "Add and use",
+    "metadataAdding": "Adding…"
   },
   "search": {
     "heading": "Search Indexers",

--- a/web/src/pages/ManualImportPage.test.tsx
+++ b/web/src/pages/ManualImportPage.test.tsx
@@ -22,6 +22,11 @@ vi.mock('../api/client', () => ({
     scanFolder: vi.fn(),
     batchImport: vi.fn(),
     listBooks: vi.fn(),
+    // Reached through resolveBookQuery / CatalogueAdder (#1719).
+    searchBooks: vi.fn(),
+    lookupISBN: vi.fn(),
+    lookupASIN: vi.fn(),
+    addBook: vi.fn(),
   },
 }))
 
@@ -32,6 +37,9 @@ import ManualImportPage from './ManualImportPage'
 const mockScan = api.scanFolder as ReturnType<typeof vi.fn>
 const mockBatch = api.batchImport as ReturnType<typeof vi.fn>
 const mockListBooks = api.listBooks as ReturnType<typeof vi.fn>
+const mockSearchBooks = api.searchBooks as ReturnType<typeof vi.fn>
+const mockLookupISBN = api.lookupISBN as ReturnType<typeof vi.fn>
+const mockAddBook = api.addBook as ReturnType<typeof vi.fn>
 
 function scanResult(): FolderScanResponse {
   return {
@@ -174,5 +182,78 @@ describe('ManualImportPage', () => {
     expect(mockBatch).toHaveBeenCalledWith(
       expect.arrayContaining([{ path: '/dl/Orphan', bookId: 99, format: 'audiobook' }]),
     )
+  })
+
+  it('creates an unmatched unit\'s book from a metadata search and imports against it', async () => {
+    await scan()
+
+    // The metadata search is offered only on the unresolved `none` unit.
+    fireEvent.click(screen.getByText('manualImport.metadataOpen'))
+
+    // Prefilled from what the scan parsed out of the file, so the user edits a
+    // query instead of retyping one.
+    const term = screen.getByPlaceholderText('manualImport.metadataPlaceholder') as HTMLInputElement
+    expect(term.value).toBe('Orphan')
+
+    mockSearchBooks.mockResolvedValue([
+      { foreignBookId: 'OL1W', title: 'Orphan Works', author: { authorName: 'A. Writer', foreignAuthorId: 'OL9A' } },
+    ])
+    fireEvent.click(screen.getByText('manualImport.metadataSearch'))
+    await screen.findByText('Orphan Works')
+
+    mockAddBook.mockResolvedValue({ id: 77, title: 'Orphan Works', author: { authorName: 'A. Writer' } })
+    fireEvent.click(screen.getByText('manualImport.metadataAdd'))
+    await waitFor(() => expect(mockAddBook).toHaveBeenCalledTimes(1))
+
+    // searchOnAdd MUST be false: the file is already on disk, so searching
+    // indexers for it would grab a second copy.
+    expect(mockAddBook).toHaveBeenCalledWith({
+      foreignBookId: 'OL1W',
+      foreignAuthorId: 'OL9A',
+      authorName: 'A. Writer',
+      searchOnAdd: false,
+    })
+
+    // The created book resolves the unit, which now imports like any other.
+    expect(screen.getByText(/manualImport\.importSelected count=2/)).toBeInTheDocument()
+    mockBatch.mockResolvedValue({
+      accepted: 2, failed: 0,
+      results: [
+        { path: '/dl/Confident Book', accepted: true, downloadId: 5 },
+        { path: '/dl/Orphan', accepted: true, downloadId: 7 },
+      ],
+    })
+    fireEvent.click(screen.getByText(/manualImport\.importSelected count=2/))
+    await waitFor(() => expect(mockBatch).toHaveBeenCalledTimes(1))
+    expect(mockBatch).toHaveBeenCalledWith(
+      expect.arrayContaining([{ path: '/dl/Orphan', bookId: 77, format: 'audiobook' }]),
+    )
+  })
+
+  it('routes an ISBN query to the lookup endpoint rather than the term search', async () => {
+    await scan()
+    fireEvent.click(screen.getByText('manualImport.metadataOpen'))
+    fireEvent.change(screen.getByPlaceholderText('manualImport.metadataPlaceholder'), {
+      target: { value: '978-0-441-47812-5' },
+    })
+    mockLookupISBN.mockResolvedValue({ foreignBookId: 'OL2W', title: 'Dune', author: { authorName: 'Frank Herbert' } })
+    fireEvent.click(screen.getByText('manualImport.metadataSearch'))
+
+    await screen.findByText('Dune')
+    expect(mockLookupISBN).toHaveBeenCalledWith('9780441478125')
+    expect(mockSearchBooks).not.toHaveBeenCalled()
+  })
+
+  it('refuses to add a metadata result that carries no author name', async () => {
+    await scan()
+    fireEvent.click(screen.getByText('manualImport.metadataOpen'))
+    mockSearchBooks.mockResolvedValue([{ foreignBookId: 'OL3W', title: 'Authorless', author: undefined }])
+    fireEvent.click(screen.getByText('manualImport.metadataSearch'))
+
+    await screen.findByText('Authorless')
+    const addBtn = screen.getByText('manualImport.metadataAdd') as HTMLButtonElement
+    expect(addBtn.disabled).toBe(true)
+    fireEvent.click(addBtn)
+    expect(mockAddBook).not.toHaveBeenCalled()
   })
 })

--- a/web/src/pages/ManualImportPage.tsx
+++ b/web/src/pages/ManualImportPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../api/client'
+import { resolveBookQuery } from '../api/booklookup'
 import type { BatchImportItem, BatchImportResult, Book, ScanItem } from '../api/client'
 import { btn, btnSize } from '../components/buttons'
 
@@ -9,12 +10,11 @@ import { btn, btnSize } from '../components/buttons'
 // confidence, and lets the user resolve each one before importing:
 //   - confident: a preselected catalogue match, deselectable and overridable;
 //   - ambiguous: a candidate picker over the returned catalogue candidates;
-//   - none: a search box to bind the unit to an EXISTING catalogue book.
+//   - none: a search box to bind the unit to an EXISTING catalogue book, plus
+//     a metadata search that creates the book (and its author) when the library
+//     has no row to bind to (#1719).
 // Resolved units are imported (per-unit or in bulk) through the batch endpoint,
 // which reports per-item success/failure.
-//
-// OUT OF SCOPE (follow-up): creating a brand-new book/author from file metadata.
-// `none` units resolve to an existing catalogue book only.
 
 const MATCH_ORDER: ScanItem['match'][] = ['confident', 'ambiguous', 'none']
 
@@ -166,7 +166,7 @@ export default function ManualImportPage() {
           {t('manualImport.title', 'Manual Import')}
         </h2>
         <p className="mt-1 text-sm text-slate-600 dark:text-zinc-400">
-          {t('manualImport.description', 'Scan a folder of files already on disk, match each book to your library, and import them. Matching is against books already in your library.')}
+          {t('manualImport.description', 'Scan a folder of files already on disk, match each book to your library, and import them. A file with no match can be added from a metadata search.')}
         </p>
       </div>
 
@@ -348,12 +348,19 @@ function ImportRow({ item, row, result, importing, onPick, onToggle, onFormat, o
               </fieldset>
             )}
 
-            {/* None / override: search the existing catalogue */}
+            {/* None / override: search the existing catalogue, or add the book
+                from provider metadata when the library has nothing to bind to. */}
             {((item.match === 'none' && !chosen) || overriding) && (
-              <BookPicker
-                onPick={b => { onPick(b); setOverriding(false) }}
-                onCancel={overriding ? () => setOverriding(false) : undefined}
-              />
+              <>
+                <BookPicker
+                  onPick={b => { onPick(b); setOverriding(false) }}
+                  onCancel={overriding ? () => setOverriding(false) : undefined}
+                />
+                <CatalogueAdder
+                  item={item}
+                  onAdded={b => { onPick(b); setOverriding(false) }}
+                />
+              </>
             )}
           </div>
         </div>
@@ -393,9 +400,10 @@ function ImportRow({ item, row, result, importing, onPick, onToggle, onFormat, o
 }
 
 // BookPicker is a debounced search over the EXISTING catalogue (reuses the same
-// /book?search= endpoint FixMatchModal uses). It resolves a `none` unit — or an
-// override on a matched one — to a book already in the library. Creating a new
-// book from metadata is a deferred follow-up and deliberately not offered here.
+// /book?search= endpoint FixMatchModal uses). It resolves a `none` unit, or an
+// override on a matched one, to a book already in the library. A unit whose
+// book is not in the library at all is CatalogueAdder's job, rendered directly
+// below this picker.
 function BookPicker({ onPick, onCancel }: { onPick: (b: Book) => void; onCancel?: () => void }) {
   const { t } = useTranslation()
   const [term, setTerm] = useState('')
@@ -448,7 +456,7 @@ function BookPicker({ onPick, onCancel }: { onPick: (b: Book) => void; onCancel?
         {loading && <p className="py-2 text-xs text-slate-500 dark:text-zinc-500">{t('common.loading', 'Loading...')}</p>}
         {!loading && term.trim().length >= 2 && results.length === 0 && (
           <p className="py-2 text-xs text-slate-500 dark:text-zinc-500">
-            {t('manualImport.noResults', 'No matching books in your library. Add the book first, then rescan.')}
+            {t('manualImport.noResults', 'No matching books in your library. Search metadata below to add it.')}
           </p>
         )}
         {results.map(b => (
@@ -464,6 +472,146 @@ function BookPicker({ onPick, onCancel }: { onPick: (b: Book) => void; onCancel?
             )}
           </button>
         ))}
+      </div>
+    </div>
+  )
+}
+
+// CatalogueAdder resolves the case BookPicker cannot: the file is for a book
+// that is not in the library at all, so there is no row to bind it to (#1719).
+// It searches provider metadata (the same ISBN / ASIN / free-text dispatch the
+// Add Book modal uses) and creates the picked result through POST /author/book,
+// which creates the author too when it is new. The created book is handed back
+// so the unit resolves like any other and imports through the existing batch
+// call.
+//
+// searchOnAdd is deliberately false: the user is importing a file they already
+// have, so kicking off an indexer search for it would grab a second copy.
+function CatalogueAdder({ item, onAdded }: { item: ScanItem; onAdded: (b: Book) => void }) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  // Prefilled from what the scan already read out of the file, so the user is
+  // correcting a query rather than retyping one.
+  const [term, setTerm] = useState(() => [item.parsedTitle, item.parsedAuthor].filter(Boolean).join(' '))
+  const [results, setResults] = useState<Book[]>([])
+  const [searching, setSearching] = useState(false)
+  const [searched, setSearched] = useState(false)
+  const [adding, setAdding] = useState('')
+  const [error, setError] = useState('')
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="text-xs text-slate-500 dark:text-zinc-400 hover:underline"
+      >
+        {t('manualImport.metadataOpen', 'Not in your library? Search metadata')}
+      </button>
+    )
+  }
+
+  const search = async () => {
+    const q = term.trim()
+    if (!q) return
+    setSearching(true)
+    setError('')
+    try {
+      setResults(await resolveBookQuery(q))
+      setSearched(true)
+    } catch (e) {
+      setResults([])
+      setError(e instanceof Error ? e.message : 'Metadata search failed')
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  const add = async (b: Book) => {
+    if (!b.foreignBookId || !b.author?.authorName) return
+    setAdding(b.foreignBookId)
+    setError('')
+    try {
+      const created = await api.addBook({
+        foreignBookId: b.foreignBookId,
+        // May be empty (e.g. a Google Books or DNB result carries a name but no
+        // author id); the backend resolves the author by name in that case.
+        foreignAuthorId: b.author.foreignAuthorId ?? '',
+        authorName: b.author.authorName,
+        searchOnAdd: false,
+      })
+      onAdded(created)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not add the book')
+    } finally {
+      setAdding('')
+    }
+  }
+
+  return (
+    <div className="rounded border border-slate-200 dark:border-zinc-800 p-2">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={term}
+          onChange={e => setTerm(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') search() }}
+          placeholder={t('manualImport.metadataPlaceholder', 'Title, author, ISBN, or ASIN')}
+          aria-label={t('manualImport.metadataLabel', 'Search metadata')}
+          className="flex-1 px-2 py-1 rounded border border-slate-300 dark:border-zinc-700 bg-white dark:bg-zinc-950 text-xs"
+        />
+        <button
+          type="button"
+          onClick={search}
+          disabled={searching || !term.trim()}
+          className={`${btn.secondary} ${btnSize.sm}`}
+        >
+          {searching ? t('manualImport.metadataSearching', 'Searching…') : t('manualImport.metadataSearch', 'Search')}
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-xs text-slate-500 dark:text-zinc-400 hover:underline"
+        >
+          {t('common.cancel', 'Cancel')}
+        </button>
+      </div>
+      <p className="mt-1 text-[11px] text-slate-500 dark:text-zinc-500">
+        {t('manualImport.metadataHint', 'Adds the book to your library and links this file to it. No indexer search is started.')}
+      </p>
+      {error && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{error}</p>}
+      <div className="mt-2 max-h-48 overflow-y-auto divide-y divide-slate-100 dark:divide-zinc-800">
+        {!searching && searched && results.length === 0 && !error && (
+          <p className="py-2 text-xs text-slate-500 dark:text-zinc-500">
+            {t('manualImport.metadataNoResults', 'No metadata results for that search.')}
+          </p>
+        )}
+        {results.map(b => {
+          // An author NAME is enough; the backend resolves a missing author id.
+          // Without one there is nothing to create the book under.
+          const canAdd = Boolean(b.author?.authorName)
+          return (
+            <div key={b.foreignBookId || b.title} className="flex items-center gap-2 py-1.5">
+              <div className="min-w-0 flex-1">
+                <span className="text-xs font-medium text-slate-900 dark:text-white">{b.title}</span>
+                {b.author?.authorName && (
+                  <span className="text-[11px] text-slate-500 dark:text-zinc-500"> · {b.author.authorName}</span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => add(b)}
+                disabled={!canAdd || adding !== ''}
+                title={canAdd ? undefined : t('manualImport.metadataAuthorMissing', 'Author name missing on this result')}
+                className={`${btn.secondary} ${btnSize.sm} flex-shrink-0`}
+              >
+                {adding === b.foreignBookId
+                  ? t('manualImport.metadataAdding', 'Adding…')
+                  : t('manualImport.metadataAdd', 'Add and use')}
+              </button>
+            </div>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Manual Import's Unmatched group had no action on it: `BookPicker` searches books already in the library, so a file for a book nobody had added yet dead ended on the page that found it. Unmatched rows now also get a metadata search that creates the book, and its author when new, then resolves the row against it. Closes #1719.

## Implementation notes

Frontend only. Both endpoints it needs are already registered and reachable by the admin who can open this page (`cmd/bindery/main.go:839` `GET /book/lookup`, `:844` `POST /author/book`; manual-import routes are the admin-gated group at `:897`).

| Piece | Where |
|---|---|
| `CatalogueAdder` | `web/src/pages/ManualImportPage.tsx` — collapsed link per unmatched row, opens a search + result list with an Add and use button |
| Query dispatch | `web/src/api/booklookup.ts` `resolveBookQuery` — ISBN to `lookupISBN`, ASIN to `lookupASIN`, anything else to `searchBooks` |
| Book creation | `api.addBook({foreignBookId, foreignAuthorId, authorName, searchOnAdd: false})` |
| Import | unchanged: the created book's id flows into the existing `batchImport` call |

Details worth reviewing:

- **`searchOnAdd: false`** is the one non obvious argument. The user is importing a file they already hold; sending true would have `AuthorHandler.AddBook` kick off `SearchAndGrabBook` and fetch a second copy. Asserted in a test rather than left to a comment.
- **Query prefill** comes from `item.parsedTitle` / `item.parsedAuthor`, which the scan already extracted, so the user edits a query instead of retyping one.
- **Author name gate**: a result with no author name cannot be added, matching `AddBookModal` (`AddBook` returns 422 there, and the backend needs a name to resolve or create the author).
- **`resolveBookQuery` is shared** with `AddBookModal`, whose inline copy of the same regex dispatch it replaces. Both callers now accept identical input. It calls through the `api` object, so existing module mocks are unaffected.

## Scope decisions

- **Author monitoring** was the open question in the issue. `AddBook` already decides this: a newly created author takes the install wide default via `db.ApplyAuthorMonitorDefaults` (#1666), and the added book is set monitored. Adding a second monitoring policy for this one entry point would put two answers in the codebase, so this PR takes the existing one. If you want unmonitored specifically for file driven adds, that is a backend flag on `AddBook` and its own change.
- **No edition or metadata profile picker.** The ROADMAP entry for #1719 mentions both; this PR is the dead end removal only, matching the issue's own scope note.
- **Reachable from the override path too.** A confidently matched row that the user overrides gets the same search, since the same block renders it.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (`docs/User-Guide-Wiki.md` described Manual Import as matching only; new i18n keys added to `en.json`, which is what renders)
- [x] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `cd web && npm test` — 62 files, 593 tests pass, including 3 new cases: the create-and-import round trip with the `searchOnAdd: false` assertion, ISBN routing to the lookup endpoint, and the author-less result being unaddable
- [x] `cd web && npm run typecheck`
- [x] `cd web && npx eslint` on the touched files — clean
- [x] `cd web && npm run build`
- [ ] Go suites not run: no Go files changed
