### PR TITLE
fix(hardcover): classify upstream errors instead of pasting the body (#2128)

### DIFF
--- a/changelog.d/2128-hardcover-error-surface.md
+++ b/changelog.d/2128-hardcover-error-surface.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Hardcover errors now say which side failed** (#2128): when Hardcover returns an HTML error page, Bindery no longer pastes that page into the Settings test result and the logs. A rejected token now reads `token rejected (HTTP 401: Invalid or expired token)`, and a Hardcover outage reads `HTTP 500 (upstream returned a non-JSON response, likely an error page, so this is a Hardcover-side failure rather than a token problem)`. Hardcover's `hc_pat_` personal access tokens keep working exactly as before.

--- a/docs/Hardcover-Series-Wiki.md
+++ b/docs/Hardcover-Series-Wiki.md
@@ -67,7 +67,7 @@ The fill action may create new authors and books from Hardcover metadata when th
 ## Troubleshooting
 
 - Enhanced controls are missing: save a Hardcover API token, then enable **Enhanced Hardcover series** in `Settings -> API Keys`. If your operator disabled the deployment-wide feature flag, they must remove `BINDERY_ENHANCED_HARDCOVER_API=false` and restart Bindery.
-- Hardcover test fails: verify the token at [Hardcover API settings](https://hardcover.app/account/api) and make sure Bindery can reach `hardcover.app`.
+- Hardcover test fails: verify the token at [Hardcover API settings](https://hardcover.app/account/api) and make sure Bindery can reach `hardcover.app`. Both `hc_pat_` personal access tokens and the older JWTs are accepted. The test tells you which side failed: `token rejected (HTTP 401: ...)` is a token to reissue, while `HTTP 500 (upstream returned a non-JSON response ...)` is a Hardcover outage to wait out. See [Troubleshooting](./Troubleshooting-Wiki.md#hardcover-fails-with-http-500-or-the-token-test-shows-a-hardcover-error-page).
 - Search finds the wrong series: choose a different result manually, or remove the link and search again with a more specific local series name.
 - Fill gaps adds nothing: check whether the missing books already exist locally, are excluded, or whether the linked Hardcover catalog has no missing entries relative to the local series.
 - Searches are not queued after fill: verify your indexers and download-client search flow are working for normal wanted books.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -136,6 +136,27 @@ The catch is that **Hardcover's GraphQL API requires an API token for every quer
 
 If results still don't appear with a token saved, confirm the instance has outbound HTTPS access to `api.hardcover.app` and that the token is valid (a bad token produces the same "Unable to verify token" error, which is logged and skipped).
 
+## Hardcover fails with HTTP 500, or the token test shows a Hardcover error page
+
+```
+hardcover search books: HTTP 500 (upstream returned a non-JSON response, likely an error page,
+so this is a Hardcover-side failure rather than a token problem)
+```
+
+This means `api.hardcover.app` answered with something that wasn't JSON, almost always its own HTML error page. It's an outage on Hardcover's side: no token change, reinstall or setting fixes it. Wait for Hardcover to recover, then press **Test** again. Bindery deliberately doesn't print the page it received, because pasting Hardcover's markup into the Settings UI made an upstream outage read like a bad token (#2128).
+
+The error tells you which side failed:
+
+| Message | Meaning | What to do |
+|---|---|---|
+| `token rejected (HTTP 401: ...)` | Hardcover read the token and refused it | Reissue the token at [Hardcover API settings](https://hardcover.app/account/api) and save it again |
+| `HTTP 400: ...` / `HTTP 403: ...` plus text from Hardcover | Hardcover rejected the request and said why | Act on the quoted reason; the token itself is fine |
+| `HTTP 5xx (upstream returned a non-JSON response, likely an error page, ...)` | Hardcover served an error page | Nothing on your side. Retry later |
+| `HTTP 5xx (upstream returned an empty response body, ...)` | Nothing came back at all | Usually Hardcover, occasionally a proxy in front of your instance. Check `BINDERY_OUTBOUND_PROXY` if you set one |
+| `GraphQL: ...` | Hardcover answered normally but rejected the query | A Bindery bug. Please file an issue with the message |
+
+**On token formats:** Hardcover issues `hc_pat_` personal access tokens alongside the older JWTs, and **both work**. Bindery sends whatever you save as `Authorization: Bearer <token>`, which is the scheme Hardcover accepts for either format, so there is nothing to configure per format. Pasting the whole header is fine too: a leading `Bearer ` or `Authorization: ` is stripped before the token is stored. Verified against the live API on 2026-08-24, a made up `hc_pat_...` value comes back as `401 invalid_token`, so a PAT that fails with 401 is a token to reissue, while a PAT that fails with 500 is an outage to wait out.
+
 ## Why is the metadata button on some authors but not others?
 
 The metadata button on an author's page only appears when Bindery thinks the author's record could be improved, so you'll see it on some authors and not others. Two cases show it:

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -33,6 +33,14 @@ const (
 	editionsMaxCount    = 1000
 
 	hardcoverSuccessResponseBodyLimit = 8 << 20
+
+	// hardcoverErrorResponseBodyLimit caps how much of a non-200 body we read.
+	// Only parsed JSON fields ever reach the error message, so this needs to
+	// cover Hardcover's error envelope and nothing more.
+	hardcoverErrorResponseBodyLimit = 4 << 10
+
+	// hardcoverErrorDetailLimit caps how much upstream text we quote back.
+	hardcoverErrorDetailLimit = 200
 )
 
 // Client implements metadata.Provider for Hardcover.app using its GraphQL API.
@@ -580,8 +588,8 @@ func (c *Client) query(ctx context.Context, q string, vars map[string]any, out i
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, httpsec.RedactSecrets(string(b)))
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, hardcoverErrorResponseBodyLimit))
+		return classifyHTTPError(resp.StatusCode, b)
 	}
 
 	b, err := io.ReadAll(io.LimitReader(resp.Body, hardcoverSuccessResponseBodyLimit))
@@ -604,6 +612,112 @@ func (c *Client) authorizationToken(ctx context.Context) string {
 		}
 	}
 	return NormalizeAPIToken(c.token)
+}
+
+// hcErrorEnvelope is the JSON body Hardcover returns when its edge rejects a
+// request before the GraphQL layer sees it, for example
+// {"error":"invalid_token","error_description":"Invalid or expired token"} for
+// a bad token, or a bare {"error":"ilike and related operations are not
+// permitted on this server."} for a rejected query operator. Errors carries the
+// GraphQL envelope for the rare non-200 that still answers in GraphQL's shape.
+type hcErrorEnvelope struct {
+	Error            string     `json:"error"`
+	ErrorDescription string     `json:"error_description"`
+	Message          string     `json:"message"`
+	Errors           []gqlError `json:"errors"`
+}
+
+// detail picks the most specific human-readable text the envelope carries, in
+// descending order of usefulness, sanitised for inclusion in an error message.
+func (e hcErrorEnvelope) detail() string {
+	for _, candidate := range []string{e.ErrorDescription, e.Message, e.Error} {
+		if d := sanitizeErrorDetail(candidate); d != "" {
+			return d
+		}
+	}
+	if len(e.Errors) > 0 {
+		return sanitizeErrorDetail(formatGraphQLErrors(e.Errors))
+	}
+	return ""
+}
+
+// classifyHTTPError turns a non-200 Hardcover response into something an
+// operator can act on. Until #2128 the body was pasted into the message
+// verbatim, so a Hardcover outage rendered its HTML error page into the
+// Settings UI and read like a token problem. Three cases matter: the token was
+// rejected, the body is a structured JSON error worth quoting, and everything
+// else (HTML error page, plain text, empty), which is reported as an upstream
+// failure without echoing a single byte of it.
+func classifyHTTPError(status int, raw []byte) error {
+	envelope, parsed := parseHardcoverError(raw)
+	detail := envelope.detail()
+	switch {
+	case isTokenRejection(status, envelope, parsed):
+		if detail != "" {
+			return fmt.Errorf("token rejected (HTTP %d: %s)", status, detail)
+		}
+		return fmt.Errorf("token rejected (HTTP %d), check the Hardcover API token in Settings", status)
+	case detail != "":
+		return fmt.Errorf("HTTP %d: %s", status, detail)
+	case parsed:
+		return fmt.Errorf("HTTP %d (upstream returned a JSON error with no description, so this is a Hardcover-side failure rather than a token problem)", status)
+	case len(bytes.TrimSpace(raw)) == 0:
+		return fmt.Errorf("HTTP %d (upstream returned an empty response body, so this is a Hardcover-side failure rather than a token problem)", status)
+	default:
+		return fmt.Errorf("HTTP %d (upstream returned a non-JSON response, likely an error page, so this is a Hardcover-side failure rather than a token problem)", status)
+	}
+}
+
+// parseHardcoverError decodes the error envelope, reporting whether the body
+// was a JSON object at all. A truncated or non-JSON body (an HTML error page
+// being the case that prompted #2128) reports false, and the caller then says
+// what happened instead of quoting it.
+func parseHardcoverError(raw []byte) (hcErrorEnvelope, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return hcErrorEnvelope{}, false
+	}
+	var envelope hcErrorEnvelope
+	if err := json.Unmarshal(trimmed, &envelope); err != nil {
+		return hcErrorEnvelope{}, false
+	}
+	return envelope, true
+}
+
+// isTokenRejection reports whether the response blames the credential rather
+// than the query or the server. 401 always does. 403 only counts when the body
+// carries an auth error: Hardcover also answers 403 for query operators it
+// refuses (see authorContributionFilter), which no token change fixes.
+func isTokenRejection(status int, envelope hcErrorEnvelope, parsed bool) bool {
+	if status == http.StatusUnauthorized {
+		return true
+	}
+	if status != http.StatusForbidden || !parsed {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(envelope.Error)) {
+	case "invalid_token", "invalid_request", "invalid_grant", "unauthorized", "access_denied", "insufficient_scope":
+		return true
+	}
+	return strings.Contains(strings.ToLower(envelope.detail()), "token")
+}
+
+// sanitizeErrorDetail makes upstream text safe to quote back: secrets redacted,
+// collapsed onto one line, angle brackets dropped so markup smuggled into a
+// JSON field cannot reach the UI, and hard-capped.
+func sanitizeErrorDetail(s string) string {
+	s = strings.Join(strings.Fields(httpsec.RedactSecrets(s)), " ")
+	s = strings.Map(func(r rune) rune {
+		if r == '<' || r == '>' {
+			return -1
+		}
+		return r
+	}, s)
+	s = strings.TrimSpace(s)
+	if len(s) > hardcoverErrorDetailLimit {
+		s = strings.TrimSpace(strings.ToValidUTF8(s[:hardcoverErrorDetailLimit], "")) + "…"
+	}
+	return s
 }
 
 func formatGraphQLErrors(errors []gqlError) string {

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -699,7 +699,22 @@ func isTokenRejection(status int, envelope hcErrorEnvelope, parsed bool) bool {
 	case "invalid_token", "invalid_request", "invalid_grant", "unauthorized", "access_denied", "insufficient_scope":
 		return true
 	}
-	return strings.Contains(strings.ToLower(envelope.detail()), "token")
+	// Unknown 403 codes still count when the text names the credential *and*
+	// rejects it, which is how Hardcover phrases an unauthenticated request
+	// ({"error":"Unable to verify token"}). Naming the token is not enough on
+	// its own: "Token bucket exhausted, retry after 30s" is a rate limit, and
+	// telling the operator to reissue a working token would send them the
+	// wrong way.
+	detail := strings.ToLower(envelope.detail())
+	if !strings.Contains(detail, "token") {
+		return false
+	}
+	for _, rejection := range []string{"invalid", "expired", "unable to verify", "not associated", "unauthori", "forbidden", "revoked", "missing"} {
+		if strings.Contains(detail, rejection) {
+			return true
+		}
+	}
+	return false
 }
 
 // sanitizeErrorDetail makes upstream text safe to quote back: secrets redacted,

--- a/internal/metadata/hardcover/httperror_test.go
+++ b/internal/metadata/hardcover/httperror_test.go
@@ -100,6 +100,21 @@ func TestQueryHTTPErrorClassification(t *testing.T) {
 			want:        []string{"token rejected", "HTTP 403", "Token lacks the required scope"},
 		},
 		{
+			name:        "403 naming a token but rejecting nothing is not a token problem",
+			status:      http.StatusForbidden,
+			contentType: "application/json",
+			body:        `{"error":"rate_limited","error_description":"Token bucket exhausted, retry after 30s"}`,
+			want:        []string{"HTTP 403", "Token bucket exhausted"},
+			notWant:     []string{"token rejected"},
+		},
+		{
+			name:        "403 for an unauthenticated request is a token problem",
+			status:      http.StatusForbidden,
+			contentType: "application/json",
+			body:        `{"error":"Unable to verify token"}`,
+			want:        []string{"token rejected", "HTTP 403", "Unable to verify token"},
+		},
+		{
 			name:        "500 with an HTML error page",
 			status:      http.StatusInternalServerError,
 			contentType: "text/html; charset=utf-8",

--- a/internal/metadata/hardcover/httperror_test.go
+++ b/internal/metadata/hardcover/httperror_test.go
@@ -1,0 +1,326 @@
+package hardcover
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// errorResponse builds a non-200 HTTP response with a verbatim body.
+func errorResponse(status int, contentType, body string) *http.Response {
+	header := make(http.Header)
+	if contentType != "" {
+		header.Set("Content-Type", contentType)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}
+}
+
+// hardcoverHTMLErrorPage is the page Hardcover served during the 2026-08 outage
+// reported in #2128. The old client pasted the first 512 bytes of it into the
+// error, so the Settings UI rendered markup at the operator instead of saying
+// which side had failed.
+const hardcoverHTMLErrorPage = `<!doctype html>
+
+<html lang="en">
+
+<head>
+  <title>Internal Server Error | Hardcover</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+  <h1>Something went wrong</h1>
+  <p>Our team has been notified.</p>
+</body>
+
+</html>`
+
+// TestQueryHTTPErrorClassification pins how a non-200 Hardcover response is
+// reported. The rule the table encodes: a rejected token says so, a structured
+// JSON error is quoted compactly, and anything else is named as an upstream
+// failure without echoing the body (#2128).
+func TestQueryHTTPErrorClassification(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		want        []string
+		notWant     []string
+	}{
+		{
+			name:        "401 with the auth error envelope",
+			status:      http.StatusUnauthorized,
+			contentType: "application/json",
+			body:        `{"error":"invalid_token","error_description":"Invalid or expired token"}`,
+			want:        []string{"token rejected", "HTTP 401", "Invalid or expired token"},
+		},
+		{
+			name:        "401 for a JWT-shaped token",
+			status:      http.StatusUnauthorized,
+			contentType: "application/json",
+			body:        `{"error":"invalid_token","error_description":"Invalid JWT"}`,
+			want:        []string{"token rejected", "HTTP 401", "Invalid JWT"},
+		},
+		{
+			name:   "401 with no body at all",
+			status: http.StatusUnauthorized,
+			body:   "",
+			want:   []string{"token rejected", "HTTP 401", "Hardcover API token"},
+		},
+		{
+			name:        "400 for a malformed Authorization header",
+			status:      http.StatusBadRequest,
+			contentType: "application/json",
+			body:        `{"error":"invalid_request","error_description":"Invalid Authorization format. Use 'Bearer <token>'"}`,
+			want:        []string{"HTTP 400", "Invalid Authorization format"},
+			// Angle brackets never survive into an error message, wherever
+			// upstream put them.
+			notWant: []string{"<", ">"},
+		},
+		{
+			name:        "403 for a refused query operator is not a token problem",
+			status:      http.StatusForbidden,
+			contentType: "application/json",
+			body:        `{"error":"ilike and related operations are not permitted on this server."}`,
+			want:        []string{"HTTP 403", "ilike and related operations are not permitted"},
+			notWant:     []string{"token rejected"},
+		},
+		{
+			name:        "403 carrying an auth error is a token problem",
+			status:      http.StatusForbidden,
+			contentType: "application/json",
+			body:        `{"error":"insufficient_scope","error_description":"Token lacks the required scope"}`,
+			want:        []string{"token rejected", "HTTP 403", "Token lacks the required scope"},
+		},
+		{
+			name:        "500 with an HTML error page",
+			status:      http.StatusInternalServerError,
+			contentType: "text/html; charset=utf-8",
+			body:        hardcoverHTMLErrorPage,
+			want:        []string{"HTTP 500", "non-JSON", "Hardcover-side failure"},
+			// The whole point of #2128: not one byte of the page is quoted.
+			notWant: []string{"<", ">", "doctype", "Internal Server Error", "Something went wrong", "viewport"},
+		},
+		{
+			name:   "500 with an empty body",
+			status: http.StatusInternalServerError,
+			body:   "",
+			want:   []string{"HTTP 500", "empty response body", "Hardcover-side failure"},
+		},
+		{
+			name:        "502 with a plain-text body",
+			status:      http.StatusBadGateway,
+			contentType: "text/plain",
+			body:        "Bad Gateway",
+			want:        []string{"HTTP 502", "non-JSON", "Hardcover-side failure"},
+			notWant:     []string{"Bad Gateway"},
+		},
+		{
+			name:        "503 with JSON that carries no description",
+			status:      http.StatusServiceUnavailable,
+			contentType: "application/json",
+			body:        `{"retry_after":30}`,
+			want:        []string{"HTTP 503", "no description", "Hardcover-side failure"},
+		},
+		{
+			name:        "504 with a truncated HTML page",
+			status:      http.StatusGatewayTimeout,
+			contentType: "text/html",
+			body:        strings.Repeat("<div>gateway timeout</div>", 4096),
+			want:        []string{"HTTP 504", "non-JSON"},
+			notWant:     []string{"<", "gateway timeout"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newMockClient(func(*http.Request) (*http.Response, error) {
+				return errorResponse(tt.status, tt.contentType, tt.body), nil
+			})
+
+			var out struct{}
+			err := c.query(context.Background(), "query Test { __typename }", nil, &out)
+			if err == nil {
+				t.Fatalf("query: want an error for HTTP %d, got nil", tt.status)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(err.Error(), notWant) {
+					t.Errorf("error %q must not contain %q", err, notWant)
+				}
+			}
+		})
+	}
+}
+
+// TestQueryHTTPErrorDetailIsBounded keeps a chatty upstream from pasting an
+// unbounded blob into the Settings UI, even when it arrives as valid JSON.
+func TestQueryHTTPErrorDetailIsBounded(t *testing.T) {
+	c := newMockClient(func(*http.Request) (*http.Response, error) {
+		return errorResponse(http.StatusInternalServerError, "application/json",
+			`{"error":"boom","error_description":"`+strings.Repeat("y", 4000)+`"}`), nil
+	})
+
+	var out struct{}
+	err := c.query(context.Background(), "query Test { __typename }", nil, &out)
+	if err == nil {
+		t.Fatal("query: want an error, got nil")
+	}
+	if len(err.Error()) > 300 {
+		t.Fatalf("error message is %d bytes, want it capped: %q", len(err.Error()), err)
+	}
+	if !strings.Contains(err.Error(), "…") {
+		t.Fatalf("truncated detail should be marked as truncated: %q", err)
+	}
+}
+
+// TestQueryHTTPErrorRedactsSecrets guards the redaction that was already applied
+// to the raw body before #2128 and must still apply to the text we quote.
+func TestQueryHTTPErrorRedactsSecrets(t *testing.T) {
+	c := newMockClient(func(*http.Request) (*http.Response, error) {
+		return errorResponse(http.StatusForbidden, "application/json",
+			`{"error":"denied","error_description":"blocked callback https://hardcover.app/cb?apikey=sup3rsecret"}`), nil
+	})
+
+	var out struct{}
+	err := c.query(context.Background(), "query Test { __typename }", nil, &out)
+	if err == nil {
+		t.Fatal("query: want an error, got nil")
+	}
+	if strings.Contains(err.Error(), "sup3rsecret") {
+		t.Fatalf("error leaks a secret: %q", err)
+	}
+	if !strings.Contains(err.Error(), "REDACTED") {
+		t.Fatalf("error should show the redaction marker: %q", err)
+	}
+}
+
+// TestQueryHTTPErrorBodyReadIsBounded pins the read cap on error bodies: an
+// upstream error page can be arbitrarily large and none of it is used.
+func TestQueryHTTPErrorBodyReadIsBounded(t *testing.T) {
+	body := &countingBodyReader{remaining: hardcoverErrorResponseBodyLimit * 4}
+	c := newMockClient(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(body),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	var out struct{}
+	if err := c.query(context.Background(), "query Test { __typename }", nil, &out); err == nil {
+		t.Fatal("query: want an error, got nil")
+	}
+	if body.read != hardcoverErrorResponseBodyLimit {
+		t.Fatalf("read bytes = %d, want %d", body.read, hardcoverErrorResponseBodyLimit)
+	}
+}
+
+// TestQueryGraphQLErrorEnvelopeUnchanged is a regression guard: a 200 carrying
+// GraphQL errors is a different failure from a non-200 and keeps reporting the
+// upstream messages verbatim.
+func TestQueryGraphQLErrorEnvelopeUnchanged(t *testing.T) {
+	c := newMockClient(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(
+				`{"errors":[{"message":"field 'language' not found in type: 'books'","extensions":{"code":"validation-failed"}}]}`)),
+			Header: make(http.Header),
+		}, nil
+	})
+
+	var out struct{}
+	err := c.query(context.Background(), "query Test { __typename }", nil, &out)
+	if err == nil {
+		t.Fatal("query: want an error for a GraphQL error envelope, got nil")
+	}
+	for _, want := range []string{"GraphQL:", "field 'language' not found in type: 'books'", "validation-failed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
+// TestQuerySuccessStillDecodes proves the classification did not disturb the
+// happy path.
+func TestQuerySuccessStillDecodes(t *testing.T) {
+	c := newMockClient(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"books":[{"id":42,"title":"Dune"}]}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	var out struct {
+		Data struct {
+			Books []struct {
+				ID    int    `json:"id"`
+				Title string `json:"title"`
+			} `json:"books"`
+		} `json:"data"`
+	}
+	if err := c.query(context.Background(), "query Test { __typename }", nil, &out); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(out.Data.Books) != 1 || out.Data.Books[0].Title != "Dune" {
+		t.Fatalf("decoded %+v, want one book titled Dune", out.Data)
+	}
+}
+
+// TestSearchBooksUpstreamErrorMessage is the end-to-end shape of the string the
+// Settings UI shows for a Hardcover outage, caller prefix included.
+func TestSearchBooksUpstreamErrorMessage(t *testing.T) {
+	c := newMockClient(func(*http.Request) (*http.Response, error) {
+		return errorResponse(http.StatusInternalServerError, "text/html", hardcoverHTMLErrorPage), nil
+	})
+
+	_, err := c.SearchBooks(context.Background(), "Dune")
+	if err == nil {
+		t.Fatal("SearchBooks: want an error, got nil")
+	}
+	const want = "hardcover search books: HTTP 500 (upstream returned a non-JSON response, likely an error page, " +
+		"so this is a Hardcover-side failure rather than a token problem)"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err, want)
+	}
+}
+
+// TestQuerySendsPATTokenAsBearer pins the auth scheme against the premise of
+// #2128, which read the outage as Hardcover having moved to a token format the
+// client could not send. hc_pat_ tokens authenticate as ordinary Bearer
+// credentials (verified live against api.hardcover.app on 2026-08-24: a
+// fabricated hc_pat_ value is answered 401 "Invalid or expired token", while a
+// bare non-Bearer Authorization header is answered 400), so the token travels
+// verbatim and no format sniffing exists to drift out of date.
+func TestQuerySendsPATTokenAsBearer(t *testing.T) {
+	const pat = "hc_pat_totallyfakevalue000000000000000000000000"
+	var gotAuth string
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		gotAuth = r.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{}}`)),
+			Header:     make(http.Header),
+		}, nil
+	}).WithToken(pat)
+
+	var out struct{}
+	if err := c.query(context.Background(), "query Test { __typename }", nil, &out); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if gotAuth != "Bearer "+pat {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer "+pat)
+	}
+}


### PR DESCRIPTION
## Summary

A non-200 from `api.hardcover.app` pasted up to 512 raw bytes of the response body into the error, and `TestHardcover` copies `err.Error()` straight into its JSON result, so Hardcover's HTML error page got rendered into the Settings UI during the 2026-08-20 outage. That makes a provider outage look like a broken token and gives the operator nothing to act on. `query()` now classifies the response instead of echoing it. Closes #2128.

## Implementation notes

`classifyHTTPError` in `internal/metadata/hardcover/client.go` splits a non-200 into four outcomes:

| Response | Error string |
|---|---|
| 401, or 403 whose body carries an auth error | `token rejected (HTTP 401: Invalid or expired token)` |
| JSON error envelope | `HTTP 403: ilike and related operations are not permitted on this server.` |
| Empty body | `HTTP 500 (upstream returned an empty response body, so this is a Hardcover-side failure rather than a token problem)` |
| Anything else (HTML page, plain text, truncated JSON) | `HTTP 500 (upstream returned a non-JSON response, likely an error page, so this is a Hardcover-side failure rather than a token problem)` |

- Quoted text comes only from parsed JSON fields, preferring Hardcover's own `error_description`, then `message`, then `error`, then a GraphQL `errors` array. It is redacted through `httpsec.RedactSecrets`, collapsed to one line, stripped of angle brackets and capped at 200 chars. The upstream body is never quoted verbatim.
- 403 is only read as an auth failure when the body says so. Hardcover also answers 403 for query operators it refuses (the `_ilike` case behind `authorContributionFilter`), which no token change fixes.
- The non-200 read limit moved from an inline `512` to a named `hardcoverErrorResponseBodyLimit` (4 KiB), enough to hold the error envelope. Nothing beyond the parsed fields is used.
- No sentinel error. Nothing branches on the classification today, so an exported `ErrInvalidToken` would ship unused. Easy to add later if a caller needs it.
- `TestHardcover` and `HardcoverTestResponse` are untouched: the wire contract is unchanged and the new message is already self-describing once the caller prefix is applied, e.g. `hardcover search series: token rejected (HTTP 401: Invalid or expired token)`.

Before and after for the case in the issue:

```
before: hardcover search books: HTTP 500: <!doctype html>\n\n<html lang="en">\n\n<head>\n  <title>Internal Server Error | Hardcover</title>\n  <meta name="viewport" content="width=device-width, initial-scale=1">\n</head>\n\n<body>\n  <h1>Something went wrong</h1>...
after:  hardcover search books: HTTP 500 (upstream returned a non-JSON response, likely an error page, so this is a Hardcover-side failure rather than a token problem)
```

## Why minimal / scope decisions

**The PAT-format premise in the issue does not hold today.** `Bearer <token>` is the correct scheme and Hardcover validates `hc_pat_` tokens correctly, so no auth-scheme change, no format sniffing, no endpoint change. Probed live against `https://api.hardcover.app/v1/graphql` on 2026-08-24 with fabricated tokens only:

| Request | Response |
|---|---|
| `Authorization: Bearer eyJ...` (junk JWT) | `401 {"error":"invalid_token","error_description":"Invalid JWT"}` |
| `Authorization: Bearer hc_pat_totallyfakevalue00...` | `401 {"error":"invalid_token","error_description":"Invalid or expired token"}` |
| `Authorization: hc_pat_...` (no `Bearer`) | `400 {"error":"invalid_request","error_description":"Invalid Authorization format. Use 'Bearer <token>'"}` |
| No `Authorization` header | `400 {"error":"invalid_request","error_description":"No Authorization header"}` |
| 20 consecutive PAT requests | all 401, no 5xx |

A PAT-shaped token now reaches credential validation and is answered 401 like any other bad credential, which is exactly what the reporter saw for JWTs and not for PATs on 2026-08-20. The 500 plus HTML was an upstream failure that no longer reproduces. `TestQuerySendsPATTokenAsBearer` pins the scheme so this stays true.

What is left is the real Bindery-side defect: the client turned that outage into a message that blamed the token and dumped markup into the UI. Fixing the surfacing is the whole change.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (see `commits` skill: `docs/`, `README.md`, godoc, Helm values)
- [x] Wiki pages updated if user-facing behaviour changed

`docs/Troubleshooting-Wiki.md` gains a section that decodes each new message and states that `hc_pat_` tokens work; `docs/Hardcover-Series-Wiki.md` points at it from its "Hardcover test fails" bullet.

## Test plan

- [x] `go test ./internal/...`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `golangci-lint run ./internal/metadata/hardcover/...` (0 issues)
- [x] Reverted the classification locally and confirmed the new table cases fail against the old code, so the tests are not green by accident
- [ ] `cd web && npm run build` (no frontend change in this PR)
