### PR TITLE
feat(api): let a queue item be dropped without touching the download client (#2167)

### DIFF
--- a/changelog.d/2167-queue-remove-from-client.md
+++ b/changelog.d/2167-queue-remove-from-client.md
@@ -1,0 +1,5 @@
+### Added
+- **Clear a queue item without touching the download client** (#2167) — `DELETE /api/v1/queue/{id}?removeFromClient=false`, and `"removeFromClient": false` on `POST /api/v1/queue/bulk-delete`. Removing a queue item has always told the client to drop the job, which for a torrent ends the seed, so a stale row left behind by an out-of-band import could not be cleared without losing the release. The default is unchanged, and `deleteFiles=true` alongside `removeFromClient=false` is rejected with a 400 rather than silently ignoring one of them.
+
+### Fixed
+- **Corrected the queue-removal doc comment** (#2167) — it claimed removing an item "preserves the seed" for torrent clients. The data survives on disk, but the torrent itself was deleted from the client, so nothing was seeding it.

--- a/docs/API.md
+++ b/docs/API.md
@@ -137,7 +137,10 @@ POST   /api/v1/downloadclient/{id}/test           probe connectivity (admin)
 GET    /api/v1/queue                              active downloads with live downloader overlay
 POST   /api/v1/queue/grab                         submit a search result to the download client
 POST   /api/v1/queue/{id}/retry-import           retry an importFailed item without re-downloading
-DELETE /api/v1/queue/{id}                         remove (also from downloader)
+DELETE /api/v1/queue/{id}                         remove (also from the download client)
+       ?deleteFiles=true                          have the client destroy the data too
+       ?removeFromClient=false                    forget Bindery's row only, leave the torrent/NZB in the client
+POST   /api/v1/queue/bulk-delete                  remove many; {"ids":[..],"deleteFiles":false,"unmonitorBooks":false,"removeFromClient":true}
 
 GET    /api/v1/pending                            grabs awaiting delay-profile clearance
 POST   /api/v1/pending/{id}/grab                  promote pending to queue immediately

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -1083,28 +1083,74 @@ func (h *QueueHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Removing an item from the queue keeps the downloaded data on disk by
-	// default: for torrent clients this also preserves the seed. Destroying
-	// the files is opt-in via `?deleteFiles=true`, mirroring book Delete.
-	deleteFiles := r.URL.Query().Get("deleteFiles") == "true"
+	// default. Destroying the files is opt-in via `?deleteFiles=true`,
+	// mirroring book Delete. It does NOT preserve a torrent's seed — the
+	// client is told to delete the torrent either way, and data left on disk
+	// with no torrent is not seeding. `?removeFromClient=false` is what keeps
+	// the release where it is (#2167).
+	opts := queueRemoveOptions{
+		DeleteFiles:      r.URL.Query().Get("deleteFiles") == "true",
+		RemoveFromClient: r.URL.Query().Get("removeFromClient") != "false",
+	}
+	if err := opts.validate(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 
-	if err := h.removeQueueItem(r.Context(), target, deleteFiles, false); err != nil {
+	if err := h.removeQueueItem(r.Context(), target, opts); err != nil {
 		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// removeQueueItem removes one download from its client and the local DB. The
-// downloaded data stays on disk unless deleteFiles is set. A downloading/
-// downloaded book is reset to wanted so it doesn't look stuck. When
-// unmonitorBook is true the linked book is also unmonitored, so the scheduler's
-// wanted-search loop won't immediately re-grab it — the key to making a bulk
-// "clear the queue" actually stick after an accidental mass import (#Daize).
-func (h *QueueHandler) removeQueueItem(ctx context.Context, target *models.Download, deleteFiles, unmonitorBook bool) error {
-	if target.DownloadClientID != nil {
+// queueRemoveOptions carries the choices a queue removal offers. They are
+// separate decisions and were previously two positional bools; a third would
+// have made every call site a row of unlabelled true/false.
+type queueRemoveOptions struct {
+	// DeleteFiles asks the download client to destroy the downloaded data as
+	// well as the job. Only meaningful when RemoveFromClient is true, since it
+	// is passed to the client and nowhere else.
+	DeleteFiles bool
+	// UnmonitorBook also unmonitors the linked book, so the scheduler's
+	// wanted-search loop does not immediately re-grab it.
+	UnmonitorBook bool
+	// RemoveFromClient tells the download client to drop the job. Defaults to
+	// true, which is what every caller did before #2167. Setting it false
+	// forgets the download on Bindery's side and leaves the torrent or NZB
+	// alone — the integration case: an item imported through the API mints a
+	// new download row and leaves the earlier attempt in the queue, and
+	// clearing that stale row should not end the seed.
+	RemoveFromClient bool
+}
+
+// validate rejects the one incoherent combination. deleteFiles is only ever
+// handed to the download client, so asking for it while telling Bindery not to
+// contact the client cannot be honoured — better a 400 than silently dropping
+// half of what was asked for.
+func (o queueRemoveOptions) validate() error {
+	if o.DeleteFiles && !o.RemoveFromClient {
+		return errors.New("deleteFiles requires removeFromClient: the files are deleted by the download client")
+	}
+	return nil
+}
+
+// removeQueueItem removes one download from the local DB, and from its client
+// unless opts.RemoveFromClient is false. The downloaded data stays on disk
+// unless opts.DeleteFiles is set. A downloading/downloaded book is reset to
+// wanted so it doesn't look stuck. When opts.UnmonitorBook is true the linked
+// book is also unmonitored, so the scheduler's wanted-search loop won't
+// immediately re-grab it — the key to making a bulk "clear the queue" actually
+// stick after an accidental mass import (#Daize).
+//
+// Everything other than the client call runs either way: the point of
+// RemoveFromClient=false is to forget the download, not to pretend it never
+// happened.
+func (h *QueueHandler) removeQueueItem(ctx context.Context, target *models.Download, opts queueRemoveOptions) error {
+	if opts.RemoveFromClient && target.DownloadClientID != nil {
 		client, err := h.clients.GetByID(ctx, *target.DownloadClientID)
 		if err == nil && client != nil {
-			if err := downloader.RemoveDownload(ctx, client, target, deleteFiles, h.downloadPathRemap); err != nil {
+			if err := downloader.RemoveDownload(ctx, client, target, opts.DeleteFiles, h.downloadPathRemap); err != nil {
 				slog.Warn("failed to remove download from client", "download_id", target.ID, "client_id", client.ID, "error", err)
 			}
 		} else if err != nil {
@@ -1122,7 +1168,7 @@ func (h *QueueHandler) removeQueueItem(ctx context.Context, target *models.Downl
 				book.Status = models.BookStatusWanted
 				changed = true
 			}
-			if unmonitorBook && book.Monitored {
+			if opts.UnmonitorBook && book.Monitored {
 				book.Monitored = false
 				changed = true
 			}
@@ -1145,7 +1191,8 @@ const bulkDeleteConcurrency = 6
 
 // BulkDelete removes many queue items in one request. Body:
 //
-//	{"ids": [1,2,3], "deleteFiles": false, "unmonitorBooks": true}
+//	{"ids": [1,2,3], "deleteFiles": false, "unmonitorBooks": true,
+//	 "removeFromClient": true}
 //
 // Per-ID results mirror the author/book bulk endpoints: a stale or not-owned id
 // is reported inline (as "download not found", the same opaque message the
@@ -1157,6 +1204,9 @@ func (h *QueueHandler) BulkDelete(w http.ResponseWriter, r *http.Request) {
 		IDs            []int64 `json:"ids"`
 		DeleteFiles    bool    `json:"deleteFiles"`
 		UnmonitorBooks bool    `json:"unmonitorBooks"`
+		// Pointer so an absent field keeps the pre-#2167 behaviour of always
+		// removing from the client, while an explicit false is honoured.
+		RemoveFromClient *bool `json:"removeFromClient"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -1180,6 +1230,16 @@ func (h *QueueHandler) BulkDelete(w http.ResponseWriter, r *http.Request) {
 		byID[d.ID] = d
 	}
 
+	opts := queueRemoveOptions{
+		DeleteFiles:      req.DeleteFiles,
+		UnmonitorBook:    req.UnmonitorBooks,
+		RemoveFromClient: req.RemoveFromClient == nil || *req.RemoveFromClient,
+	}
+	if err := opts.validate(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
 	results := make(map[string]bulkItemResult, len(req.IDs))
 	var mu sync.Mutex
 	setResult := func(id int64, res bulkItemResult) {
@@ -1194,7 +1254,7 @@ func (h *QueueHandler) BulkDelete(w http.ResponseWriter, r *http.Request) {
 			setResult(id, bulkItemResult{Error: "download not found"})
 			return
 		}
-		if err := h.removeQueueItem(ctx, &target, req.DeleteFiles, req.UnmonitorBooks); err != nil {
+		if err := h.removeQueueItem(ctx, &target, opts); err != nil {
 			setResult(id, bulkItemResult{Error: err.Error()})
 			return
 		}

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -576,6 +576,78 @@ func TestQueueBulkDelete_KeepsMonitoringByDefault(t *testing.T) {
 }
 
 // TestQueueBulkDelete_RequiresIDs rejects an empty batch.
+// TestQueueBulkDelete_HonoursRemoveFromClient covers the bulk half of #2167:
+// the field is a pointer, so an absent one keeps the old always-remove
+// behaviour while an explicit false is honoured, and the incoherent
+// deleteFiles + removeFromClient:false pair is rejected rather than half-applied.
+func TestQueueBulkDelete_HonoursRemoveFromClient(t *testing.T) {
+	var called int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/torrents/delete" {
+			called++
+		}
+		if r.URL.Path == "/api/v2/auth/login" {
+			_, _ = w.Write([]byte("Ok."))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h, _, downloads, clients, _, ctx := queueFixture(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name: "qb", Type: "qbittorrent", Host: host, Port: port,
+		Username: "user", Password: "pass", Enabled: true,
+	}
+	if err := clients.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	newDownload := func(guid string) int64 {
+		dl := &models.Download{
+			GUID: guid, DownloadClientID: &client.ID, Title: guid,
+			NZBURL: "magnet:?xt=urn:btih:" + guid, Status: models.StateCompleted,
+			Protocol: "torrent", TorrentID: strPtr(guid),
+		}
+		if err := downloads.Create(ctx, dl); err != nil {
+			t.Fatalf("create download: %v", err)
+		}
+		return dl.ID
+	}
+
+	keepID := newDownload("bulk-keep")
+	body := fmt.Sprintf(`{"ids":[%d],"removeFromClient":false}`, keepID)
+	rec := httptest.NewRecorder()
+	h.BulkDelete(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/bulk-delete", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if called != 0 {
+		t.Errorf("client delete called %d times with removeFromClient:false, want 0", called)
+	}
+	if got, _ := downloads.GetByGUID(ctx, "bulk-keep"); got != nil {
+		t.Error("the Bindery row should still have been deleted")
+	}
+
+	dropID := newDownload("bulk-drop")
+	body = fmt.Sprintf(`{"ids":[%d]}`, dropID)
+	rec = httptest.NewRecorder()
+	h.BulkDelete(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/bulk-delete", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if called != 1 {
+		t.Errorf("client delete called %d times with the field absent, want 1", called)
+	}
+
+	rec = httptest.NewRecorder()
+	h.BulkDelete(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/bulk-delete",
+		bytes.NewBufferString(fmt.Sprintf(`{"ids":[%d],"deleteFiles":true,"removeFromClient":false}`, dropID))))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for deleteFiles with removeFromClient:false, got %d", rec.Code)
+	}
+}
+
 func TestQueueBulkDelete_RequiresIDs(t *testing.T) {
 	h, _, _, _, _, _ := queueFixture(t)
 	rec := httptest.NewRecorder()
@@ -722,6 +794,97 @@ func TestQueueDelete_DefaultsToKeepingFiles(t *testing.T) {
 func TestQueueDelete_OptInDeletesFiles(t *testing.T) {
 	if got := queueDeleteFilesProbe(t, "?deleteFiles=true"); got != "true" {
 		t.Fatalf("deleteFiles should be true with opt-in, got %q", got)
+	}
+}
+
+// queueClientCallProbe spins up a qBittorrent stub, runs Queue.Delete with the
+// given query suffix, and reports whether the client's delete endpoint was
+// called and whether Bindery's own row went away.
+func queueClientCallProbe(t *testing.T, urlSuffix string) (clientCalled bool, rowDeleted bool, status int) {
+	t.Helper()
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/delete":
+			called = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	h, _, downloads, clients, _, ctx := queueFixture(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name: "qb", Type: "qbittorrent", Host: host, Port: port,
+		Username: "user", Password: "pass", Enabled: true,
+	}
+	if err := clients.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	dl := &models.Download{
+		GUID: "keep-guid", DownloadClientID: &client.ID, Title: "Seeding Book",
+		NZBURL: "magnet:?xt=urn:btih:abcdef", Status: models.StateCompleted,
+		Protocol: "torrent", TorrentID: strPtr("abcdef"),
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatalf("create download: %v", err)
+	}
+
+	path := "/api/v1/queue/" + strconv.FormatInt(dl.ID, 10) + urlSuffix
+	req := withURLParam(httptest.NewRequest(http.MethodDelete, path, nil), "id", strconv.FormatInt(dl.ID, 10))
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+
+	got, err := downloads.GetByGUID(ctx, "keep-guid")
+	if err != nil {
+		t.Fatalf("reload download: %v", err)
+	}
+	return called, got == nil, rec.Code
+}
+
+// TestQueueDelete_RemovesFromClientByDefault pins the pre-#2167 behaviour: with
+// no flag, the download client is still told to drop the job.
+func TestQueueDelete_RemovesFromClientByDefault(t *testing.T) {
+	called, rowDeleted, status := queueClientCallProbe(t, "")
+	if status != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", status)
+	}
+	if !called {
+		t.Error("the download client should have been called")
+	}
+	if !rowDeleted {
+		t.Error("the Bindery row should have been deleted")
+	}
+}
+
+// TestQueueDelete_RemoveFromClientFalseLeavesTheTorrentAlone is #2167: clearing
+// a stale queue row must be able to leave the release in the download client,
+// so a torrent keeps seeding. Bindery's own row still goes away — the point is
+// to forget the download, not to pretend it never happened.
+func TestQueueDelete_RemoveFromClientFalseLeavesTheTorrentAlone(t *testing.T) {
+	called, rowDeleted, status := queueClientCallProbe(t, "?removeFromClient=false")
+	if status != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", status)
+	}
+	if called {
+		t.Error("the download client must NOT be called with removeFromClient=false")
+	}
+	if !rowDeleted {
+		t.Error("the Bindery row should still have been deleted")
+	}
+}
+
+// deleteFiles is only ever handed to the download client, so asking for it
+// while refusing to contact the client cannot be honoured. Reject it rather
+// than silently dropping half the request.
+func TestQueueDelete_RejectsDeleteFilesWithoutRemoveFromClient(t *testing.T) {
+	_, _, status := queueClientCallProbe(t, "?deleteFiles=true&removeFromClient=false")
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", status)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `removeFromClient=false` so a stale queue row can be cleared without the download client dropping the release. Closes #2167.

`removeQueueItem` called the client whenever the row carried a client id. The only knob was `?deleteFiles`, which decides something else — whether the client also destroys the data — so either way `RemoveDownload` issued the client's delete call and a torrent stopped seeding. The reported workflow is an item imported out of band through the API: that mints a new download row and leaves the earlier attempt in the queue, and clearing that row is exactly what `DELETE /queue/{id}` is for.

## Where it's wired

| Surface | Form | Default |
|---|---|---|
| `DELETE /api/v1/queue/{id}` | `?removeFromClient=false` | `true` (absent or any value but `false`) |
| `POST /api/v1/queue/bulk-delete` | `"removeFromClient": false` | `true` (field is a pointer, so absent keeps the old behaviour) |

`deleteFiles=true` together with `removeFromClient=false` returns 400. `deleteFiles` is only ever handed to the client, so it cannot be honoured while refusing to contact it, and silently dropping half a request is worse than refusing it.

Everything else in the removal still runs either way: resetting a downloading or downloaded book to wanted, the optional unmonitor, and `downloads.Delete`. The point is to forget the download, not to pretend it never happened.

## Implementation notes

The three choices became `queueRemoveOptions` rather than a third positional bool — `removeQueueItem(ctx, target, false, true, false)` would have been unreadable at both call sites.

Also corrects the doc comment above `Delete`, which claimed that removing an item "for torrent clients this also preserves the seed". The data survives on disk, but the torrent was deleted from the client, so nothing was seeding it. That comment promised precisely the behaviour this issue had to ask for.

## Follow-ups (not in this PR)

No UI action. The issue notes a "Remove from Bindery only" entry on the queue page would be worth having; the API is what the Harpoon integration needs and can land first.

## Test plan

- [x] `go test ./internal/api/` — full package green
- [x] `go vet ./internal/api/`
- [x] `TestQueueDelete_RemovesFromClientByDefault` — the pre-existing behaviour is pinned, not just the new flag
- [x] `TestQueueDelete_RemoveFromClientFalseLeavesTheTorrentAlone` — qBittorrent stub records that `/api/v2/torrents/delete` is never called, and the Bindery row is still gone
- [x] `TestQueueDelete_RejectsDeleteFilesWithoutRemoveFromClient` — 400
- [x] `TestQueueBulkDelete_HonoursRemoveFromClient` — absent field still calls the client, explicit false does not, incoherent pair is 400
- [x] Existing `TestQueueDelete_DefaultsToKeepingFiles` / `_OptInDeletesFiles` unchanged and passing

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — `docs/API.md` now lists both flags and the bulk body
- [x] Wiki pages updated if user-facing behaviour changed (API-only change; no wiki page describes queue removal)
