### PR TITLE
fix(metadata): carry the author through ISBN lookups, and stop the Add button blocking them (#2187)

### DIFF
--- a/changelog.d/2187-isbn-author.md
+++ b/changelog.d/2187-isbn-author.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Adding a book by ISBN no longer loses the author** (#2187) — an OpenLibrary edition that isn't linked to a work now carries its author through the lookup instead of coming back with just a title and cover. The Add button also no longer refuses a result that has no author name: the backend resolves the author from the book itself, so the request goes through.

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -845,6 +845,12 @@ func (c *Client) GetSubjectBooks(ctx context.Context, subject string, limit int)
 	return candidates, nil
 }
 
+// GetBookByISBN resolves an ISBN to a Book. When the edition record links a
+// work, the work is authoritative and is fetched in full. Otherwise the Book is
+// built from the edition record itself, with the author resolved from the
+// edition's author key — the same extra round trip the work path already pays
+// inside GetBook. A 404 means "not in OpenLibrary's catalog" and returns
+// (nil, nil), not an error.
 func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, error) {
 	u := fmt.Sprintf("%s/isbn/%s.json", baseURL, isbn)
 	var resp isbnResponse
@@ -875,6 +881,30 @@ func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, 
 	if len(resp.Covers) > 0 && resp.Covers[0] > 0 {
 		b.ImageURL = fmt.Sprintf("%s/b/id/%d-L.jpg", coverURL, resp.Covers[0])
 	}
+
+	// Resolve the author from the edition record. Editions with no /works/
+	// link still name their authors, and nothing downstream fills this in:
+	// cacheISBNBook and enrichBook cover description, cover, rating, genres
+	// and language, never the author. Without this the result renders
+	// authorless and the caller has no author to add the book under (#2187).
+	//
+	// Best-effort, mirroring GetBook's own author resolution: a missing or
+	// unresolvable author must not sink an otherwise good ISBN lookup, so the
+	// failure is logged and the book returned without one.
+	if len(resp.Authors) > 0 {
+		authorKey := strings.TrimPrefix(resp.Authors[0].Key, "/authors/")
+		if authorKey != "" {
+			author, err := c.GetAuthor(ctx, authorKey)
+			if err != nil {
+				slog.Warn("openlibrary: failed to resolve isbn edition author",
+					"isbn", isbn, "key", authorKey, "error", err)
+			} else {
+				b.Author = author
+				b.AuthorID = author.ID
+			}
+		}
+	}
+
 	return b, nil
 }
 

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -503,6 +503,123 @@ func TestGetBookByISBN_HTTP_FallbackNoWork(t *testing.T) {
 	}
 }
 
+// isbnAuthors builds the anonymous author-key slice of isbnResponse.
+func isbnAuthors(keys ...string) []struct {
+	Key string `json:"key"`
+} {
+	out := make([]struct {
+		Key string `json:"key"`
+	}, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, struct {
+			Key string `json:"key"`
+		}{Key: k})
+	}
+	return out
+}
+
+// An edition with no /works/ link still names its authors. The fallback used to
+// drop them, so an ISBN lookup returned a correct title and cover with no
+// author at all and nothing downstream filled it in (#2187).
+func TestGetBookByISBN_HTTP_FallbackResolvesAuthor(t *testing.T) {
+	isbnResp := isbnResponse{
+		Key:     "/books/OL999M",
+		Title:   "Standalone Edition",
+		Covers:  []int{11111},
+		Authors: isbnAuthors("/authors/OL123A"),
+	}
+	authorResp := authorResponse{
+		Key:  "/authors/OL123A",
+		Name: "Frank Herbert",
+	}
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/isbn/0441013597.json": jsonStr(isbnResp),
+		"/authors/OL123A.json":  jsonStr(authorResp),
+	})
+
+	book, err := c.GetBookByISBN(context.Background(), "0441013597")
+	if err != nil {
+		t.Fatalf("GetBookByISBN: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected non-nil book")
+		return
+	}
+	if book.Author == nil {
+		t.Fatal("expected the edition's author to be resolved, got nil")
+		return
+	}
+	if book.Author.Name != "Frank Herbert" {
+		t.Errorf("Author.Name: want 'Frank Herbert', got %q", book.Author.Name)
+	}
+	if book.Author.ForeignID != "OL123A" {
+		t.Errorf("Author.ForeignID: want 'OL123A', got %q", book.Author.ForeignID)
+	}
+	// The rest of the fallback book is unchanged.
+	if book.Title != "Standalone Edition" {
+		t.Errorf("Title: want 'Standalone Edition', got %q", book.Title)
+	}
+}
+
+// An edition record with an empty authors[] is a real answer, not a failure:
+// the book comes back without an author and without an error.
+func TestGetBookByISBN_HTTP_FallbackNoAuthors(t *testing.T) {
+	isbnResp := isbnResponse{
+		Key:   "/books/OL999M",
+		Title: "Anonymous Edition",
+	}
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/isbn/0441013597.json": jsonStr(isbnResp),
+	})
+
+	book, err := c.GetBookByISBN(context.Background(), "0441013597")
+	if err != nil {
+		t.Fatalf("GetBookByISBN: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected non-nil book")
+		return
+	}
+	if book.Author != nil {
+		t.Errorf("expected no author, got %+v", book.Author)
+	}
+	if book.Title != "Anonymous Edition" {
+		t.Errorf("Title: want 'Anonymous Edition', got %q", book.Title)
+	}
+}
+
+// A failing author fetch must not sink the ISBN lookup — the author is
+// best-effort, exactly as in GetBook.
+func TestGetBookByISBN_HTTP_FallbackAuthorFetchFails(t *testing.T) {
+	isbnResp := isbnResponse{
+		Key:     "/books/OL999M",
+		Title:   "Standalone Edition",
+		Authors: isbnAuthors("/authors/OL123A"),
+	}
+	c := newClientWithStatus(t,
+		map[string]interface{}{
+			"/isbn/0441013597.json": jsonStr(isbnResp),
+			"/authors/OL123A.json":  `{"error":"boom"}`,
+		},
+		map[string]int{"/authors/OL123A.json": http.StatusInternalServerError},
+	)
+
+	book, err := c.GetBookByISBN(context.Background(), "0441013597")
+	if err != nil {
+		t.Fatalf("author fetch failure must not fail the lookup, got %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected the book despite the author fetch failing")
+		return
+	}
+	if book.Author != nil {
+		t.Errorf("expected no author after a failed fetch, got %+v", book.Author)
+	}
+	if book.Title != "Standalone Edition" {
+		t.Errorf("Title: want 'Standalone Edition', got %q", book.Title)
+	}
+}
+
 // A 404 from OpenLibrary means "this ISBN is not in their catalog" — not an
 // upstream failure. GetBookByISBN returns (nil, nil) so the API layer can
 // respond with a user-friendly "no book found" message (see issue #284).

--- a/web/src/components/AddBookModal.test.tsx
+++ b/web/src/components/AddBookModal.test.tsx
@@ -16,7 +16,7 @@ vi.mock('react-i18next', () => ({
       'addBookModal.searchPlaceholder': 'Title, ISBN, or ASIN (for example, Dune, 9780441478125, B0DBJBFHGT)',
       'addBookModal.searching': 'Searching...',
       'addBookModal.searchFailed': 'Search failed',
-      'addBookModal.authorMissing': 'Author name missing on this result',
+      'addBookModal.idMissing': 'This result has no book ID and cannot be added',
       'addBookModal.added': 'Added',
       'addBookModal.adding': 'Adding...',
       'addBookModal.addFailed': 'Failed to add book',
@@ -145,6 +145,70 @@ describe('AddBookModal — ASIN lookup (#1189)', () => {
     expect(api.searchBooks).toHaveBeenCalledWith('Dune')
     expect(api.lookupASIN).not.toHaveBeenCalled()
     expect(api.lookupISBN).not.toHaveBeenCalled()
+  })
+})
+
+describe('AddBookModal — authorless ISBN result (#2187)', () => {
+  const onClose = vi.fn()
+  const onAdded = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const lookupAndFind = async () => {
+    fireEvent.change(screen.getByPlaceholderText(/Title, ISBN, or ASIN/i), {
+      target: { value: '9780441013593' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+    await waitFor(() => expect(screen.getByText('Standalone Edition')).toBeInTheDocument())
+  }
+
+  it('lets a result with no author be added, and sends empty author fields', async () => {
+    // An OpenLibrary edition with no /works/ link and no resolvable author.
+    // The backend only requires foreignBookId — it resolves the author from
+    // the book id — so the modal must not refuse to send the request.
+    vi.mocked(api.lookupISBN).mockResolvedValue({
+      foreignBookId: 'OL999M',
+      title: 'Standalone Edition',
+    } as never)
+    vi.mocked(api.addBook).mockResolvedValue({ id: 7, title: 'Standalone Edition' } as never)
+
+    render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
+    await lookupAndFind()
+
+    const addButton = screen.getByRole('button', { name: /^add$/i })
+    expect(addButton).toBeEnabled()
+
+    fireEvent.click(addButton)
+    await waitFor(() => expect(api.addBook).toHaveBeenCalled())
+    expect(vi.mocked(api.addBook).mock.calls[0][0]).toMatchObject({
+      foreignBookId: 'OL999M',
+      foreignAuthorId: '',
+      authorName: '',
+      searchOnAdd: true,
+    })
+    expect(onAdded).toHaveBeenCalledTimes(1)
+  })
+
+  it('still sends the author name when the result carries one but no author id (DNB)', async () => {
+    vi.mocked(api.lookupISBN).mockResolvedValue({
+      foreignBookId: 'DNB-123',
+      title: 'Standalone Edition',
+      author: { authorName: 'Frank Herbert' },
+    } as never)
+    vi.mocked(api.addBook).mockResolvedValue({ id: 8, title: 'Standalone Edition' } as never)
+
+    render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
+    await lookupAndFind()
+
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+    await waitFor(() => expect(api.addBook).toHaveBeenCalled())
+    expect(vi.mocked(api.addBook).mock.calls[0][0]).toMatchObject({
+      foreignBookId: 'DNB-123',
+      foreignAuthorId: '',
+      authorName: 'Frank Herbert',
+    })
   })
 })
 

--- a/web/src/components/AddBookModal.tsx
+++ b/web/src/components/AddBookModal.tsx
@@ -51,7 +51,7 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
   }
 
   const addBook = async (book: Book) => {
-    if (!book.foreignBookId || !book.author?.authorName) return
+    if (!book.foreignBookId) return
     setAdding(book.foreignBookId)
     setAddError(null)
     try {
@@ -59,8 +59,12 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
         foreignBookId: book.foreignBookId,
         // foreignAuthorId may be empty (e.g. DNB results) — the backend
         // resolves the author by ISBN against OpenLibrary in that case.
-        foreignAuthorId: book.author.foreignAuthorId ?? '',
-        authorName: book.author.authorName,
+        // authorName may be empty too (an ISBN edition whose provider record
+        // carries no author): the backend falls back to the book id, and
+        // answers 422 with a "add the author manually first" hint when even
+        // that fails. That is a better outcome than refusing to send (#2187).
+        foreignAuthorId: book.author?.foreignAuthorId ?? '',
+        authorName: book.author?.authorName ?? '',
         searchOnAdd,
         ...(mediaType ? { mediaType } : {}),
       })
@@ -135,9 +139,14 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
               const key = book.foreignBookId || book.title
               const isAdded = added.has(book.foreignBookId)
               const isAdding = adding === book.foreignBookId
-              // Author *name* is enough — when foreignAuthorId is missing
-              // (DNB results), the backend resolves it by ISBN at add-time.
-              const canAdd = !!book.author?.authorName
+              // A book id is all the backend requires. With no
+              // foreignAuthorId it resolves the author from the book id
+              // itself, and falls back to the author *name* only when that
+              // fails (DNB and Google Books results, which carry a name but
+              // no author id, still rely on that fallback — it is unchanged).
+              // Gating on the name blocked ISBN results the API would have
+              // accepted (#2187).
+              const canAdd = !!book.foreignBookId
               return (
                 <div key={key} className="flex items-center gap-3 p-3 rounded-md bg-slate-200/50 dark:bg-zinc-800/50 hover:bg-slate-200 dark:hover:bg-zinc-800">
                   {book.imageUrl && (
@@ -156,7 +165,7 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
                     onClick={() => addBook(book)}
                     disabled={isAdded || isAdding || !canAdd}
                     className={`px-3 py-1 rounded text-xs font-medium flex-shrink-0 ${isAdded ? 'bg-emerald-700 text-white opacity-75 cursor-default' : 'bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50'}`}
-                    title={!canAdd ? t('addBookModal.authorMissing') : undefined}
+                    title={!canAdd ? t('addBookModal.idMissing') : undefined}
                   >
                     {isAdded ? t('addBookModal.added') : isAdding ? t('addBookModal.adding') : t('common.add')}
                   </button>

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -469,7 +469,7 @@
     "searchPlaceholder": "Titel, ISBN oder ASIN (zum Beispiel Dune, 9780441478125, B0DBJBFHGT)",
     "searching": "Suche läuft...",
     "searchFailed": "Suche fehlgeschlagen",
-    "authorMissing": "Bei diesem Ergebnis fehlt der Autorenname",
+    "idMissing": "Dieses Ergebnis hat keine Buch-ID und kann nicht hinzugefügt werden",
     "added": "Hinzugefügt",
     "adding": "Wird hinzugefügt...",
     "addFailed": "Buch konnte nicht hinzugefügt werden"

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -985,7 +985,7 @@
     "searchPlaceholder": "Title, ISBN, or ASIN (for example, Dune, 9780441478125, B0DBJBFHGT)",
     "searching": "Searching...",
     "searchFailed": "Search failed",
-    "authorMissing": "Author name missing on this result",
+    "idMissing": "This result has no book ID and cannot be added",
     "added": "Added",
     "adding": "Adding...",
     "addFailed": "Failed to add book"

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -512,7 +512,7 @@
     "searchPlaceholder": "Título, ISBN o ASIN (por ejemplo, Dune, 9780441478125, B0DBJBFHGT)",
     "searching": "Buscando...",
     "searchFailed": "Error en la búsqueda",
-    "authorMissing": "Falta el nombre del autor en este resultado",
+    "idMissing": "Este resultado no tiene ID de libro y no se puede añadir",
     "added": "Añadido",
     "adding": "Añadiendo...",
     "addFailed": "Error al añadir el libro"

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -469,7 +469,7 @@
     "searchPlaceholder": "Titre, ISBN ou ASIN (par exemple Dune, 9780441478125, B0DBJBFHGT)",
     "searching": "Recherche en cours...",
     "searchFailed": "Échec de la recherche",
-    "authorMissing": "Le nom de l'auteur manque dans ce résultat",
+    "idMissing": "Ce résultat n'a pas d'identifiant de livre et ne peut pas être ajouté",
     "added": "Ajouté",
     "adding": "Ajout en cours...",
     "addFailed": "Échec de l'ajout du livre"

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -512,7 +512,7 @@
     "searchPlaceholder": "Judul, ISBN, atau ASIN (misalnya Dune, 9780441478125, B0DBJBFHGT)",
     "searching": "Mencari...",
     "searchFailed": "Pencarian gagal",
-    "authorMissing": "Nama penulis tidak ada pada hasil ini",
+    "idMissing": "Hasil ini tidak memiliki ID buku dan tidak dapat ditambahkan",
     "added": "Ditambahkan",
     "adding": "Menambahkan...",
     "addFailed": "Gagal menambah buku"

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -777,7 +777,7 @@
     "searchPlaceholder": "제목, ISBN 또는 ASIN (예: Dune, 9780441478125, B0DBJBFHGT)",
     "searching": "검색 중...",
     "searchFailed": "검색 실패",
-    "authorMissing": "이 결과에 저자 이름이 없습니다",
+    "idMissing": "이 결과에는 책 ID가 없어 추가할 수 없습니다",
     "added": "추가됨",
     "adding": "추가 중...",
     "addFailed": "도서 추가 실패"

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -469,7 +469,7 @@
     "searchPlaceholder": "Titel, ISBN of ASIN (bijvoorbeeld Dune, 9780441478125, B0DBJBFHGT)",
     "searching": "Zoeken...",
     "searchFailed": "Zoeken mislukt",
-    "authorMissing": "De auteursnaam ontbreekt bij dit resultaat",
+    "idMissing": "Dit resultaat heeft geen boek-ID en kan niet worden toegevoegd",
     "added": "Toegevoegd",
     "adding": "Toevoegen...",
     "addFailed": "Boek toevoegen mislukt"

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -512,7 +512,7 @@
     "searchPlaceholder": "Pamagat, ISBN, o ASIN (halimbawa, Dune, 9780441478125, B0DBJBFHGT)",
     "searching": "Naghahanap...",
     "searchFailed": "Nabigo ang paghahanap",
-    "authorMissing": "Walang pangalan ng may-akda sa resultang ito",
+    "idMissing": "Walang book ID ang resultang ito kaya hindi ito maidaragdag",
     "added": "Naidagdag",
     "adding": "Idinadagdag...",
     "addFailed": "Nabigong idagdag ang libro"


### PR DESCRIPTION
## Summary

An ISBN lookup could return the right book with no author attached, and the Add button was then permanently disabled, so the book could not be added at all. Two independent defects stacked: `GetBookByISBN`'s no-work fallback never set an author even though the edition record names one, and the Add Book modal gated on the author name rather than on what the API actually requires. Both halves are fixed. Closes #2187.

## Implementation notes

**Backend** (`internal/metadata/openlibrary/client.go`). When the edition record links a work, `GetBookByISBN` delegates to `GetBook`, which resolves the author from the work's author key. When it does not, the fallback built the Book from title, cover and id and stopped there, even though `isbnResponse.Authors` was parsed and unused. Nothing downstream covered for it: `cacheISBNBook` and `enrichBook` fill description, cover, rating, genres and language, never `Author`.

The fallback now resolves `resp.Authors[0].Key` through the existing `GetAuthor`, mirroring `GetBook`'s own author resolution line for line, including its failure posture:

| Edition record | Result |
|---|---|
| `authors[]` populated, author fetch OK | Author resolved and set on the Book |
| `authors[]` empty | No author, no error — same as today |
| Author fetch fails or 404s | Logged at WARN, book returned without an author |

**Frontend** (`web/src/components/AddBookModal.tsx`). `canAdd` was `!!book.author?.authorName`. `AuthorHandler.AddBook` requires only `foreignBookId`: with an empty `foreignAuthorId` it calls `resolveAuthorForBook` on the book id, falls back to name-based resolution, and answers 422 with an actionable "add the author manually first" hint when even that fails. The modal was refusing to send a request the API can service, and the 422 hint is a better outcome for the user than a disabled button with no way forward. `canAdd` now gates on `foreignBookId`, and the author fields go out as empty strings when absent.

## Caching and rate limiting for the extra request

Asked for explicitly, so: the OpenLibrary client has **no rate limiter and no request cache** for this. Its only cache is `workSampleCache`, which memoizes edition-list samples keyed on work id — a different endpoint, and not something an author fetch could route through. `authorWorkSampleConcurrency` and `editionSampleCap` are the package's conventions for *bounding fan-out and pagination*, not for deduplicating single point lookups; neither applies to one author fetch on a single-ISBN path.

`GetBook` resolves its author with a bare `c.GetAuthor` call and no memoization, so the fix follows the convention that is actually there rather than inventing one. The cost framing matters: this is not a new round trip relative to the common path, it is the round trip the work path *already* pays. The fallback branch only fires for editions with an empty `works[]`, and it now costs 2 requests where the work path costs 3 (isbn + work + author). If author lookups ever want caching, that belongs on `GetAuthor` where every caller benefits, not bolted onto this branch.

## Is the DNB case still handled

Yes, and it was never the case the gate was protecting. DNB and Google Books results carry an author **name** with no author **id**; the load-bearing part for them is the backend's name-based resolution (`findLibraryAuthorByName`, then `ResolveCanonicalAuthor`), which is untouched. The modal still sends `authorName` whenever the result has one — there is a test for exactly that. What changed is only that a result with *neither* is no longer refused client-side.

## i18n

The tooltip now describes the only condition that disables the button, so `addBookModal.authorMissing` is replaced by `addBookModal.idMissing` in all eight locales (`de`, `en`, `es`, `fr`, `id`, `ko`, `nl`, `tl`). The old key has no remaining references.

## Doc gate

Checked `docs/` for anything covering add-by-ISBN. The only hit is the entry-points table in `docs/User-Guide-Wiki.md` ("Authors → Add Book (title/ISBN/ASIN) — One book, and only that book, silently creating its author if needed"), which describes the intended behaviour and is accurate both before and after. No doc describes the disabled-button behaviour, so nothing needed updating.

## Test plan

New tests were verified to fail on `origin/main` (source changes stashed, tests kept) and pass with the fix.

Before, Go:

```
--- FAIL: TestGetBookByISBN_HTTP_FallbackResolvesAuthor (0.00s)
    client_http_test.go:549: expected the edition's author to be resolved, got nil
```

Before, frontend:

```
FAIL  AddBookModal — authorless ISBN result (#2187) > lets a result with no author be added
Received element is not enabled:
  <button ... disabled="" title="addBookModal.authorMissing" />
```

After, both green (`TestGetBookByISBN_*` 6/6, `AddBookModal.test.tsx` 10/10).

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./internal ./cmd` (clean)
- [x] `go test ./internal/...`
- [x] `cd web && npm run build`
- [x] `cd web && npx vitest run src/components/AddBookModal.test.tsx src/i18n/inlineDefaults.test.ts`
- [x] `cd web && npx eslint src/components/AddBookModal.tsx src/components/AddBookModal.test.tsx`

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (see `commits` skill — nothing to update, see above)
- [x] Wiki pages updated if user-facing behaviour changed (no change needed — the wiki describes the intended behaviour already)

## Follow-ups (not in this PR)

- The fallback Book's `ForeignID` is an *edition* id (`OL999M`), not a work id. That is pre-existing and out of scope here, but it is worth a look: `resolveAuthorForBook` calls `GetBook` with whatever id it is handed, and a work id is what that expects.
