### PR TITLE
fix(db): render the tracked book file that still exists on disk (#2186)

### DIFF
--- a/changelog.d/2186-stale-book-file-rows.md
+++ b/changelog.d/2186-stale-book-file-rows.md
@@ -1,0 +1,2 @@
+### Fixed
+- **A moved book file left the book pointing at a path that was gone** (#2186). After a file moved on disk, a scan registered it at its new location but the book kept showing the old, dead path while still reporting Imported, and no amount of rescanning corrected it. A book now shows whichever of its tracked files still exists on disk, and a library scan repairs books that were already stuck this way. The entry for the old location is not deleted: it stays listed under the book's Files, where **Forget this file** clears it without touching anything on disk.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -156,6 +156,21 @@ The usual culprit is the **allowed languages** list on the author's metadata pro
 
 The skip counts are also in the log (`Settings → Logs`): the `author books synced` line carries `added`, `skipped_language`, `skipped_junk` and `skipped_media_type`, and is logged at WARN whenever anything was skipped. Per-book detail (which title, which language) is at DEBUG.
 
+## A book shows a file path that no longer exists
+
+Symptom: you moved or renamed a book's file (or the folder holding it), scanned, and the book still shows the old path. It keeps saying **In Library**, download and delete act on a file that isn't there, and rescanning changes nothing.
+
+What happens: Bindery tracks files as rows, and registering a file at a new location *adds* a row rather than replacing the old one, so the book ends up owning both. Older versions always rendered the oldest row, so once the old path was dead it stayed on screen ([#2186](https://github.com/vavallee/bindery/issues/2186)).
+
+Fixed (#2186): a book now renders whichever of its tracked files still exists on disk, and a **Scan Library** run also repairs books that were already stuck this way, so on a current version the fix is to scan once. The row for the old location is deliberately *not* deleted. To clear it, open the book, find the dead path in the **Files** list, and use **Forget this file**, which drops the tracking row only and never touches the filesystem.
+
+Two things this does not do:
+
+- It does not find the file for you. Bindery only knows about the new location once a scan (or an import) has registered it, and a scan only matches files to books already in your catalogue (see rule 1 in the [User Guide](User-Guide-Wiki.md#1-library-scan-is-a-reconciler-not-an-importer)). A file moved *outside* your library root is not found at all.
+- It does not react to a storage outage. If a mount is temporarily unavailable then every path under it looks missing at once, so Bindery deliberately keeps showing what it showed before rather than acting on the absence. Nothing is deleted or reset, and the books come back as they were when the mount does.
+
+If you reshape your library regularly, **Rename files** on the book or author page is the supported way to do it: it moves the file *and* repoints the same tracking row at the new location, so there is never a second row to clean up.
+
 ## Collecting logs for a bug report
 
 `Settings → Logs` is the whole log store, so you don't need shell access to the container (rootless images give you nowhere to `cat` a file anyway).

--- a/docs/User-Guide-Wiki.md
+++ b/docs/User-Guide-Wiki.md
@@ -304,6 +304,14 @@ Rule 1 — the catalogue is empty or the authors don't exist yet. Populate
 first ([Bringing in an existing library](#bringing-in-an-existing-library)),
 then scan.
 
+**I moved my files and a book still shows the old path.**
+Fixed (#2186). A book now shows whichever of its tracked files still exists,
+and a **Scan Library** run repairs books that were already stuck on a dead
+path. The old entry stays listed under the book's **Files**; **Forget this
+file** clears it without touching the disk. Use **Rename files** rather than
+moving things by hand and it never happens.
+([troubleshooting](Troubleshooting-Wiki.md))
+
 **I added one book and got the author's whole back catalogue.**
 Fixed (#1816). Adding one book adds one book; a refresh only adds
 newly-discovered works for an author you monitor and have set to take new

--- a/internal/db/book_files_stale_path_test.go
+++ b/internal/db/book_files_stale_path_test.go
@@ -1,0 +1,199 @@
+package db
+
+// Regression tests for #2186: BookFileRepo.Add is INSERT OR IGNORE, so
+// registering a file at a new location appends a row instead of replacing the
+// old one. The derivation used to take the lowest id unconditionally, so a
+// book whose folder had been renamed rendered the dead path forever while
+// still reporting Imported.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// writeFileAt creates path and any missing parents.
+func writeFileAt(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("book"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// TestRefreshBookStatus_MovedFileRendersLivePath is the issue repro: register
+// a path, rename the folder on disk, register the new path, and the book must
+// render the file that is actually there.
+func TestRefreshBookStatus_MovedFileRendersLivePath(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	root := t.TempDir()
+	oldDir := filepath.Join(root, "Old Folder")
+	oldPath := writeFileAt(t, filepath.Join(oldDir, "Neuromancer.epub"))
+
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, oldPath); err != nil {
+		t.Fatalf("AddBookFile old path: %v", err)
+	}
+
+	// The user renames the folder on disk; the scan finds the file at its new
+	// location and registers it.
+	newDir := filepath.Join(root, "New Folder")
+	if err := os.Rename(oldDir, newDir); err != nil {
+		t.Fatalf("rename folder: %v", err)
+	}
+	newPath := filepath.Join(newDir, "Neuromancer.epub")
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, newPath); err != nil {
+		t.Fatalf("AddBookFile new path: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.EbookFilePath != newPath {
+		t.Errorf("EbookFilePath = %q, want the live path %q", got.EbookFilePath, newPath)
+	}
+	if got.FilePath != newPath {
+		t.Errorf("legacy FilePath = %q, want the live path %q", got.FilePath, newPath)
+	}
+	if _, err := os.Stat(got.EbookFilePath); err != nil {
+		t.Errorf("rendered path does not exist on disk: %v", err)
+	}
+	if got.Status != models.BookStatusImported {
+		t.Errorf("Status = %q, want imported", got.Status)
+	}
+
+	// The stale row is kept, not deleted: it stays visible on the book's Files
+	// tab so the user can deregister it.
+	files, err := repo.ListFiles(ctx, book.ID)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("want both rows kept, got %d", len(files))
+	}
+}
+
+// TestRefreshBookStatus_AllFilesMissingKeepsRenderedPath is the hazard test for
+// this fix: an unmounted volume makes every path under it vanish at once. The
+// derivation must fall back to the pre-fix answer rather than blanking the
+// field, so the book keeps its path, keeps reporting Imported, and keeps every
+// row. Nothing here may look like "this book lost its files".
+func TestRefreshBookStatus_AllFilesMissingKeepsRenderedPath(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	root := t.TempDir()
+	mount := filepath.Join(root, "mnt", "nas")
+	first := writeFileAt(t, filepath.Join(mount, "Neuromancer.epub"))
+	second := writeFileAt(t, filepath.Join(mount, "Neuromancer.mobi"))
+
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, first); err != nil {
+		t.Fatalf("AddBookFile first: %v", err)
+	}
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, second); err != nil {
+		t.Fatalf("AddBookFile second: %v", err)
+	}
+
+	// The share drops: every tracked path under it stats as ENOENT at once.
+	if err := os.RemoveAll(filepath.Join(root, "mnt")); err != nil {
+		t.Fatalf("remove mount: %v", err)
+	}
+
+	// Something touches the book and forces a re-derivation. Re-registering a
+	// path the book already tracks is the real-world shape of that: the row is
+	// a no-op (INSERT OR IGNORE) but the status refresh still runs.
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, first); err != nil {
+		t.Fatalf("re-register first: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.EbookFilePath != first {
+		t.Errorf("EbookFilePath = %q, want the unchanged %q", got.EbookFilePath, first)
+	}
+	if got.Status != models.BookStatusImported {
+		t.Errorf("Status = %q, want imported (a missing mount must not flip the book back to wanted)", got.Status)
+	}
+	files, err := repo.ListFiles(ctx, book.ID)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("want 2 rows kept after the mount vanished, got %d", len(files))
+	}
+}
+
+// TestRefreshBookStatus_UnprovableAbsenceKeepsRow pins the asymmetry the fix
+// relies on: only a definite "does not exist" demotes a row. Here the first
+// row's parent is a regular file, so os.Stat returns ENOTDIR — "we cannot read
+// this", not "this moved" — and the row must keep winning even though a later
+// row resolves cleanly. This is what stops a stalled mount from silently
+// re-pointing a library at the wrong rows.
+func TestRefreshBookStatus_UnprovableAbsenceKeepsRow(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	root := t.TempDir()
+	blocker := writeFileAt(t, filepath.Join(root, "not-a-dir"))
+	unreadable := filepath.Join(blocker, "Neuromancer.epub")
+	if _, err := os.Stat(unreadable); os.IsNotExist(err) {
+		t.Skipf("platform reports ENOENT rather than ENOTDIR for %q", unreadable)
+	}
+	live := writeFileAt(t, filepath.Join(root, "Library", "Neuromancer.epub"))
+
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, unreadable); err != nil {
+		t.Fatalf("AddBookFile unreadable: %v", err)
+	}
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, live); err != nil {
+		t.Fatalf("AddBookFile live: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.EbookFilePath != unreadable {
+		t.Errorf("EbookFilePath = %q, want %q kept: an unreadable path is not a vanished one",
+			got.EbookFilePath, unreadable)
+	}
+}
+
+// TestBookColumns_FallsBackToBookFilesRow guards the read-path precedence
+// change. Migration 028 backfilled an 'ebook' book_files row from the legacy
+// untyped file_path column without filling ebook_file_path, so a book can have
+// rows while the column is empty. Reading the column first must still fall
+// through to the row for that shape.
+func TestBookColumns_FallsBackToBookFilesRow(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+	files := NewBookFileRepo(database)
+
+	// Add the row directly, bypassing refreshBookStatus, so books.ebook_file_path
+	// stays empty exactly as the 028 backfill leaves it.
+	if err := files.Add(ctx, book.ID, models.MediaTypeEbook, "/legacy/Neuromancer.epub"); err != nil {
+		t.Fatalf("files.Add: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.EbookFilePath != "/legacy/Neuromancer.epub" {
+		t.Errorf("EbookFilePath = %q, want the book_files row to fill the empty column",
+			got.EbookFilePath)
+	}
+}

--- a/internal/db/book_files_stale_path_test.go
+++ b/internal/db/book_files_stale_path_test.go
@@ -197,3 +197,124 @@ func TestBookColumns_FallsBackToBookFilesRow(t *testing.T) {
 			got.EbookFilePath)
 	}
 }
+
+func TestBookFilePathResolves(t *testing.T) {
+	root := t.TempDir()
+	present := writeFileAt(t, filepath.Join(root, "Neuromancer.epub"))
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"a file that exists", present, true},
+		{"a directory that exists", root, true},
+		{"a path that does not exist", filepath.Join(root, "gone.epub"), false},
+		{"the empty path", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BookFilePathResolves(tc.path); got != tc.want {
+				t.Errorf("BookFilePathResolves(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMultiFileBookPaths_OnlyBooksWithSameFormatSiblings pins the sweep's
+// candidate query: it must find the book that owns two rows of one format and
+// skip the book whose two rows are one of each.
+func TestMultiFileBookPaths_OnlyBooksWithSameFormatSiblings(t *testing.T) {
+	database, author, single := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	dual := &models.Book{
+		ForeignID: "OL88888W", AuthorID: author.ID, Title: "Dual", SortTitle: "Dual",
+		Monitored: true, Status: models.BookStatusWanted, MediaType: models.MediaTypeBoth,
+	}
+	if err := repo.Create(ctx, dual); err != nil {
+		t.Fatalf("create dual book: %v", err)
+	}
+
+	root := t.TempDir()
+	// One book with two ebooks: a candidate.
+	epub := writeFileAt(t, filepath.Join(root, "Neuromancer.epub"))
+	mobi := writeFileAt(t, filepath.Join(root, "Neuromancer.mobi"))
+	if err := repo.AddBookFile(ctx, single.ID, models.MediaTypeEbook, epub); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.AddBookFile(ctx, single.ID, models.MediaTypeEbook, mobi); err != nil {
+		t.Fatal(err)
+	}
+	// One book with an ebook and an audiobook: not a candidate, because
+	// neither format has a sibling that could have outranked it.
+	other := writeFileAt(t, filepath.Join(root, "Dual.epub"))
+	audio := writeFileAt(t, filepath.Join(root, "Dual.m4b"))
+	if err := repo.AddBookFile(ctx, dual.ID, models.MediaTypeEbook, other); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.AddBookFile(ctx, dual.ID, models.MediaTypeAudiobook, audio); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.MultiFileBookPaths(ctx)
+	if err != nil {
+		t.Fatalf("MultiFileBookPaths: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 candidate, got %d (%+v)", len(got), got)
+	}
+	if got[0].BookID != single.ID {
+		t.Errorf("candidate BookID = %d, want %d", got[0].BookID, single.ID)
+	}
+	if got[0].EbookPath != epub {
+		t.Errorf("candidate EbookPath = %q, want %q", got[0].EbookPath, epub)
+	}
+	if got[0].AudiobookPath != "" {
+		t.Errorf("candidate AudiobookPath = %q, want empty", got[0].AudiobookPath)
+	}
+}
+
+// TestRefreshBookStatus_ExportedEntryPointRederivesPaths covers the entry point
+// the library scan's sweep calls: no file is registered or removed, the rows
+// are untouched, and the book still moves onto the one that resolves.
+func TestRefreshBookStatus_ExportedEntryPointRederivesPaths(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	root := t.TempDir()
+	first := writeFileAt(t, filepath.Join(root, "Old", "Neuromancer.epub"))
+	second := writeFileAt(t, filepath.Join(root, "New", "Neuromancer.epub"))
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, second); err != nil {
+		t.Fatal(err)
+	}
+	// Both resolved at registration, so the older row won. That is the state a
+	// library broken before this fix is left in.
+	before, err := repo.GetByID(ctx, book.ID)
+	if err != nil || before == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if before.EbookFilePath != first {
+		t.Fatalf("fixture: EbookFilePath = %q, want %q", before.EbookFilePath, first)
+	}
+
+	if err := os.RemoveAll(filepath.Join(root, "Old")); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.RefreshBookStatus(ctx, book.ID); err != nil {
+		t.Fatalf("RefreshBookStatus: %v", err)
+	}
+
+	after, err := repo.GetByID(ctx, book.ID)
+	if err != nil || after == nil {
+		t.Fatalf("GetByID after refresh: %v", err)
+	}
+	if after.EbookFilePath != second {
+		t.Errorf("EbookFilePath = %q, want the live path %q", after.EbookFilePath, second)
+	}
+}

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -133,10 +133,21 @@ first_audiobook AS (
 )`
 
 // bookColumns is the canonical column list for book SELECT queries.
-// ebook_file_path and audiobook_file_path are derived from book_files first
-// (so multi-file books see the first registered path), with the legacy column
-// as a fallback for rows that pre-date the migration and have not yet been
-// re-imported via AddBookFile.
+//
+// ebook_file_path and audiobook_file_path read the stored column first and
+// fall back to the first_ebook / first_audiobook CTE. That order is load
+// bearing (#2186). The column is not user-writable and is not stale: every
+// mutation of book_files goes through refreshBookStatus, which recomputes it
+// from the rows and writes it back. The CTE cannot do the same job, because
+// choosing the right row means asking the filesystem which paths still
+// resolve and SQL cannot stat. Reading the CTE first therefore overrode the
+// answer refreshBookStatus had already worked out, and a book whose file had
+// moved kept rendering the dead path.
+//
+// The CTE remains the fallback for the shape migration 028 leaves behind: a
+// book backfilled from the legacy untyped file_path column got an 'ebook'
+// book_files row while books.ebook_file_path stayed empty, and it also covers
+// any book whose column was never written.
 //
 // The trailing author columns hydrate book.Author for List/Get responses
 // (#882): the frontend's Books page and Book detail page read
@@ -151,8 +162,8 @@ const bookColumns = `books.id, books.foreign_id, books.author_id, books.title, b
 	books.media_type, books.narrator, books.duration_seconds, books.asin,
 	books.calibre_id, books.metadata_provider, books.last_metadata_refresh_at,
 	books.created_at, books.updated_at,
-	COALESCE(fe.path, COALESCE(books.ebook_file_path, '')),
-	COALESCE(fa.path, COALESCE(books.audiobook_file_path, '')),
+	COALESCE(NULLIF(books.ebook_file_path, ''), fe.path, ''),
+	COALESCE(NULLIF(books.audiobook_file_path, ''), fa.path, ''),
 	books.excluded, COALESCE(books.dedup_key, ''),
 	au.id, au.foreign_id, au.name, au.sort_name,
 	COALESCE(books.owner_user_id, 0),
@@ -712,18 +723,16 @@ func (r *BookRepo) refreshBookStatus(ctx context.Context, bookID int64) error {
 		return nil
 	}
 
-	// Query book_files directly to get the true first path per format.
-	// This bypasses the COALESCE legacy-column fallback in bookColumns so
-	// removing the last book_files entry correctly clears the field.
-	var ebookPath, audiobookPath string
-	if err := r.db.QueryRowContext(ctx,
-		`SELECT COALESCE(path,'') FROM book_files WHERE book_id=? AND format='ebook' ORDER BY id LIMIT 1`,
-		bookID).Scan(&ebookPath); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	// Query book_files directly to get the path each format should render.
+	// Reading the rows rather than the book we just loaded is what lets
+	// removing the last book_files entry correctly clear the field, and it is
+	// the value bookColumns now reads back (see its comment).
+	ebookPath, err := r.derivedFormatPath(ctx, bookID, models.MediaTypeEbook)
+	if err != nil {
 		return fmt.Errorf("refreshBookStatus: read ebook path: %w", err)
 	}
-	if err := r.db.QueryRowContext(ctx,
-		`SELECT COALESCE(path,'') FROM book_files WHERE book_id=? AND format='audiobook' ORDER BY id LIMIT 1`,
-		bookID).Scan(&audiobookPath); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	audiobookPath, err := r.derivedFormatPath(ctx, bookID, models.MediaTypeAudiobook)
+	if err != nil {
 		return fmt.Errorf("refreshBookStatus: read audiobook path: %w", err)
 	}
 
@@ -760,6 +769,136 @@ func (r *BookRepo) refreshBookStatus(ctx context.Context, bookID int64) error {
 	b.FilePath = legacyFilePathFor(b.MediaType, ebookPath, audiobookPath)
 
 	return r.Update(ctx, b)
+}
+
+// BookFilePathResolves reports whether a tracked book file path still points
+// at something on disk. Exported so the library scan's stale-path sweep
+// decides with exactly the same test refreshBookStatus will apply.
+//
+// It is deliberately asymmetric: only a definite "does not exist" counts as
+// gone. A permission error, an I/O error or a stalled network mount all leave
+// the row trusted, because those say "we cannot read this right now", not
+// "this file moved". That is the same rule the ABS importer's prune uses
+// (pruneVanishedFormatPaths, #1692), and it is what keeps a flaky share from
+// changing which row a whole library renders.
+func BookFilePathResolves(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}
+
+// derivedFormatPath picks the path a book renders for one format: the
+// lowest-id book_files row whose file still resolves on disk.
+//
+// The plain "lowest id wins" rule this replaces is what made #2186 visible.
+// BookFileRepo.Add is INSERT OR IGNORE, so registering a file at a new
+// location appends a row instead of replacing the old one; the older row kept
+// the lower id, so a book whose folder had been renamed rendered the dead path
+// forever while still reporting Imported.
+//
+// When no row resolves the lowest-id row is returned unchanged, which is the
+// pre-#2186 answer. That fallback is the whole reason this is safe to run on
+// the write path: an unmounted volume makes every path under it vanish at
+// once, and the right response to "all of this book's files are missing" is to
+// keep rendering what we always rendered, not to blank the field and flip a
+// library back to Wanted. Nothing is deleted either way — a row whose file is
+// gone stays in book_files, listed on the book's Files tab, where the
+// DB-only deregister action (#1692) can remove it.
+//
+// Cost: one os.Stat per format for the single-file books that are the norm,
+// and it runs only from refreshBookStatus (AddBookFile, RemoveBookFile,
+// UpdateBookFilePath), never on a read.
+func (r *BookRepo) derivedFormatPath(ctx context.Context, bookID int64, format string) (string, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT COALESCE(path,'') FROM book_files WHERE book_id=? AND format=? ORDER BY id`,
+		bookID, format)
+	if err != nil {
+		return "", fmt.Errorf("derivedFormatPath: query %s files: %w", format, err)
+	}
+	defer rows.Close()
+
+	var first string
+	var vanished []string
+	live := ""
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return "", fmt.Errorf("derivedFormatPath: scan %s path: %w", format, err)
+		}
+		if first == "" {
+			first = path
+		}
+		if BookFilePathResolves(path) {
+			live = path
+			break
+		}
+		vanished = append(vanished, path)
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("derivedFormatPath: read %s files: %w", format, err)
+	}
+
+	if live == "" {
+		// Either the book has no rows for this format, or none of them
+		// resolve. Both cases keep the old answer.
+		return first, nil
+	}
+	for _, stale := range vanished {
+		// Warn, not Debug: this is a row the user has to deregister by hand,
+		// and the in-app log view is where they will find out it exists.
+		slog.Warn("book file row points at a path that no longer exists",
+			"book_id", bookID, "format", format, "missing", stale, "rendering", live)
+	}
+	return live, nil
+}
+
+// RefreshBookStatus recomputes a book's aggregate status and the file paths it
+// renders from its current book_files rows. Exported for the library scan's
+// stale-path sweep (#2186): a book that broke before this fix shipped has no
+// pending AddBookFile to trigger the recompute, so the scan re-derives it.
+func (r *BookRepo) RefreshBookStatus(ctx context.Context, bookID int64) error {
+	return r.refreshBookStatus(ctx, bookID)
+}
+
+// MultiFileBookPaths returns, for every book that tracks more than one file of
+// the same format, the paths that book currently renders. Used by the library
+// scan's stale-path sweep (#2186) to find the books worth re-deriving without
+// writing to every book in the library: only a book with a same-format sibling
+// can have had a live row outranked by a dead one.
+func (r *BookRepo) MultiFileBookPaths(ctx context.Context) ([]BookRenderedPaths, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT b.id, COALESCE(b.ebook_file_path, ''), COALESCE(b.audiobook_file_path, '')
+		 FROM books b
+		 WHERE b.id IN (
+		     SELECT book_id FROM book_files GROUP BY book_id, format HAVING COUNT(*) > 1
+		 )`)
+	if err != nil {
+		return nil, fmt.Errorf("multi-file book paths: %w", err)
+	}
+	defer rows.Close()
+
+	var out []BookRenderedPaths
+	for rows.Next() {
+		var p BookRenderedPaths
+		if err := rows.Scan(&p.BookID, &p.EbookPath, &p.AudiobookPath); err != nil {
+			return nil, fmt.Errorf("multi-file book paths scan: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("multi-file book paths rows: %w", err)
+	}
+	return out, nil
+}
+
+// BookRenderedPaths is one row of MultiFileBookPaths: the paths a book
+// currently renders for each format.
+type BookRenderedPaths struct {
+	BookID        int64
+	EbookPath     string
+	AudiobookPath string
 }
 
 // SetFormatFilePath records the on-disk path for a specific format and

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2853,6 +2853,10 @@ func (s *Scanner) scanLibrary(ctx context.Context) {
 		}
 	}
 
+	// Books already stuck on a vanished path have nothing left to register,
+	// so re-derive them here rather than leaving the rescan a no-op (#2186).
+	s.refreshStaleRenderedPaths(ctx)
+
 	// Surface every walked root in the completion log. The scan can union
 	// the audiobook root with the library root (see ScanLibrary), and the
 	// pre-fix log only showed s.libraryDir, which let users with separate
@@ -2866,6 +2870,54 @@ func (s *Scanner) scanLibrary(ctx context.Context) {
 		"reconciled", reconciled, "unmatched", unmatched, "tagReadFailed", tagReadFailed)
 
 	s.writeScanResult(ctx, len(foundFiles), reconciled, unmatched, alreadyTracked, tagReadFailed, unmatchedFiles)
+}
+
+// refreshStaleRenderedPaths re-derives the file path shown for books that
+// track more than one file of the same format and are currently rendering one
+// that has vanished (#2186).
+//
+// The derivation fix in BookRepo lands whenever a file is registered or
+// removed, which covers every future move. It does not reach a library that
+// broke before the fix shipped: the moved file is already tracked, so the scan
+// records it as such and never calls AddBookFile, and nothing else recomputes
+// the book. That is why "no number of rescans corrects it" was in the report.
+// This sweep is what makes a rescan correct it.
+//
+// It is scoped to stay cheap on a large library: only books with a same-format
+// sibling can have had a live row outranked by a dead one, and each candidate
+// costs at most two os.Stat calls. A book whose rendered paths still resolve
+// is skipped without a write, so a healthy library does no database work here
+// at all. Nothing is deleted — the stale row stays on the book's Files tab for
+// the user to deregister.
+//
+// Best-effort: a scan that has already done its real work must not fail here.
+func (s *Scanner) refreshStaleRenderedPaths(ctx context.Context) {
+	candidates, err := s.books.MultiFileBookPaths(ctx)
+	if err != nil {
+		slog.Warn("library scan: could not list multi-file books for stale-path sweep", "error", err)
+		return
+	}
+	repaired := 0
+	for _, c := range candidates {
+		if ctx.Err() != nil {
+			return
+		}
+		stale := (c.EbookPath != "" && !db.BookFilePathResolves(c.EbookPath)) ||
+			(c.AudiobookPath != "" && !db.BookFilePathResolves(c.AudiobookPath))
+		if !stale {
+			continue
+		}
+		if err := s.books.RefreshBookStatus(ctx, c.BookID); err != nil {
+			slog.Warn("library scan: could not refresh book after stale path",
+				"book_id", c.BookID, "error", err)
+			continue
+		}
+		repaired++
+	}
+	if repaired > 0 {
+		slog.Info("library scan: re-derived file paths for books rendering a vanished file",
+			"books", repaired)
+	}
 }
 
 // isReconcileCandidate reports whether a book should be considered for

--- a/internal/importer/scanner_stale_path_test.go
+++ b/internal/importer/scanner_stale_path_test.go
@@ -1,0 +1,121 @@
+package importer
+
+// #2186: a library that broke before the derivation fix shipped has no pending
+// AddBookFile to trigger a re-derivation — the moved file is already tracked,
+// so the scan records it as such and never registers anything. That is why the
+// reporter saw "no number of rescans corrects it". The scan's stale-path sweep
+// is what makes a rescan correct it.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestScanLibrary_RepairsBookRenderingAVanishedPath builds the pre-fix state
+// directly — two registered rows, both live at registration time, then the
+// first file disappears — and asserts a scan moves the book onto the row that
+// still resolves.
+func TestScanLibrary_RepairsBookRenderingAVanishedPath(t *testing.T) {
+	s, books, authors, _, libDir, ctx := trackedPathsFixture(t)
+	author := createScanAuthor(t, ctx, authors)
+
+	authorDir := filepath.Join(libDir, "Jane Doe")
+	oldDir := filepath.Join(authorDir, "Old Folder")
+	newDir := filepath.Join(authorDir, "New Folder")
+	for _, d := range []string{oldDir, newDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldPath := filepath.Join(oldDir, "Alpha Adventure.epub")
+	newPath := filepath.Join(newDir, "Alpha Adventure.epub")
+	for _, p := range []string{oldPath, newPath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	book := createScanBook(t, ctx, books, author.ID, "ol:alpha", "Alpha Adventure",
+		models.BookStatusImported, models.MediaTypeEbook)
+	// Both paths resolve at registration time, so the older row wins — exactly
+	// the state a pre-fix install is left in after a folder rename.
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, oldPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, newPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(oldDir); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := books.GetByID(ctx, book.ID)
+	if err != nil || before == nil {
+		t.Fatalf("GetByID before scan: %v", err)
+	}
+	if before.EbookFilePath != oldPath {
+		t.Fatalf("fixture did not reproduce the broken state: EbookFilePath = %q, want %q",
+			before.EbookFilePath, oldPath)
+	}
+
+	s.ScanLibrary(ctx)
+
+	after, err := books.GetByID(ctx, book.ID)
+	if err != nil || after == nil {
+		t.Fatalf("GetByID after scan: %v", err)
+	}
+	if after.EbookFilePath != newPath {
+		t.Errorf("EbookFilePath after scan = %q, want the live path %q", after.EbookFilePath, newPath)
+	}
+	if after.Status != models.BookStatusImported {
+		t.Errorf("Status after scan = %q, want imported", after.Status)
+	}
+	files, err := books.ListFiles(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Errorf("want both rows kept (the sweep does not delete), got %d", len(files))
+	}
+}
+
+// TestScanLibrary_LeavesHealthyMultiFileBookAlone: a book with several formats
+// that all resolve is the common case, and the sweep must not touch it.
+func TestScanLibrary_LeavesHealthyMultiFileBookAlone(t *testing.T) {
+	s, books, authors, _, libDir, ctx := trackedPathsFixture(t)
+	author := createScanAuthor(t, ctx, authors)
+
+	dir := filepath.Join(libDir, "Jane Doe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	epub := filepath.Join(dir, "Alpha Adventure.epub")
+	mobi := filepath.Join(dir, "Alpha Adventure.mobi")
+	for _, p := range []string{epub, mobi} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	book := createScanBook(t, ctx, books, author.ID, "ol:alpha", "Alpha Adventure",
+		models.BookStatusImported, models.MediaTypeEbook)
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, epub); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, mobi); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	after, err := books.GetByID(ctx, book.ID)
+	if err != nil || after == nil {
+		t.Fatalf("GetByID after scan: %v", err)
+	}
+	if after.EbookFilePath != epub {
+		t.Errorf("EbookFilePath after scan = %q, want the unchanged %q", after.EbookFilePath, epub)
+	}
+}

--- a/internal/importer/scanner_stale_path_test.go
+++ b/internal/importer/scanner_stale_path_test.go
@@ -7,6 +7,7 @@ package importer
 // is what makes a rescan correct it.
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -118,4 +119,17 @@ func TestScanLibrary_LeavesHealthyMultiFileBookAlone(t *testing.T) {
 	if after.EbookFilePath != epub {
 		t.Errorf("EbookFilePath after scan = %q, want the unchanged %q", after.EbookFilePath, epub)
 	}
+}
+
+// TestRefreshStaleRenderedPaths_SurvivesAFailedLookup: the sweep runs after the
+// scan has already done its real work, so a database error there has to be
+// logged and swallowed rather than taken as a scan failure.
+func TestRefreshStaleRenderedPaths_SurvivesAFailedLookup(t *testing.T) {
+	s, _, _, _, _, ctx := trackedPathsFixture(t)
+
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+
+	// Must not panic and must return: the candidate query fails outright.
+	s.refreshStaleRenderedPaths(cancelled)
 }


### PR DESCRIPTION
## Summary

Move a tracked file on disk, rescan, and the book kept rendering the path that no longer existed while still reporting Imported. `BookFileRepo.Add` is `INSERT OR IGNORE`, so registering the file at its new location appends a row, and the derivation took the lowest id, which is the dead one. A book now renders whichever of its tracked files still resolves on disk, and a library scan repairs books already stuck this way. Closes #2186.

## Why minimal / scope decisions

**Chose fix (2), preferring a row that stats clean, not fix (1), pruning on registration.** Three things decided it.

1. **Fix (1) cannot be guarded the way the issue proposes.** The suggested guard is to refuse to prune when the directory holding the vanished file is itself unreachable. That guard is self-defeating on the reported repro: the folder was *renamed*, so the old directory is gone, so the guard fires and the bug stays unfixed. The alternative guard, "the new path is on the same mount", needs `syscall.Stat_t.Dev` behind build tags and still does not separate the cases, because an unmounted share usually leaves an empty local mountpoint directory that looks like an ordinary same-device parent.

2. **Fix (1) loses data that nothing restores.** The prune deletes rows, not files, and my first instinct was that a rescan would simply re-add them. It would not: `isReconcileCandidate` (`scanner.go:2925`) returns false as soon as any one of a book's paths resolves, so a book that keeps its epub never becomes a candidate again and a wrongly pruned mobi stays untracked permanently, surfacing only in the unmatched list. The realistic trigger is a book with same-format files across two roots when one root is briefly away, which is a plain multi-root NAS setup.

3. **Fix (2) as written in the issue does not actually fix the bug, and that is worth knowing.** `refreshBookStatus` writes its answer into `books.ebook_file_path`, but every read derives the rendered path from the `first_ebook` / `first_audiobook` CTE (`MIN(id)`) and treats the stored column as a mere fallback. So the CTE overrode the answer the write path had already computed, and changing only `refreshBookStatus` would have left `GET /api/v1/book/{id}` showing the dead path exactly as before. Fixing the read path is not optional, and SQL cannot stat, so the read path has to defer to the value the write path computed.

The read-path change is the one line to squint at: `COALESCE(fe.path, books.ebook_file_path)` becomes `COALESCE(NULLIF(books.ebook_file_path, ''), fe.path, '')`. It is safe because the column is not stale and not client-writable. Every mutation of `book_files` goes through `refreshBookStatus`, which recomputes the column from the rows; `BookFileRepo.DeleteByBook` is the only bypass and has no production caller; and the API `Update` handler deliberately refuses to accept file paths from clients. The CTE stays as the fallback for the one shape where the two legitimately differ: migration 028 backfilled an `ebook` row from the legacy untyped `file_path` column without filling `ebook_file_path`. `TestBookColumns_FallsBackToBookFilesRow` pins that.

**Not doing both.** Nothing in this PR deletes a row. The stale row stays listed on the book's Files tab, which already has the DB-only "Forget this file" action from #1692, so the user can clear it without touching the disk. That is the surfacing the issue asked about, at zero cost: the row was already displayed, it just had no reason to be looked at. A `missing` badge on that row is a real improvement and is listed as a follow-up rather than bundled here.

**Why the scan sweep is in scope.** Without it the fix only prevents new occurrences. A library already broken has no pending `AddBookFile` to trigger a recompute: the moved file is already tracked, so the scan counts it as tracked and registers nothing. The reporter's actual complaint, "no number of rescans corrects it", would have survived the fix. The sweep is what makes a rescan correct it.

## Stat cost on the hot path

`refreshBookStatus` runs on every `AddBookFile` and `RemoveBookFile`, so this matters.

| Operation | Added `os.Stat` calls |
|-----------|----------------------|
| `AddBookFile` / `RemoveBookFile`, single-format book | 1 |
| Same, dual-format book | 2 |
| Same, book with N dead rows before a live one | N+1 (bounded by that book's row count) |
| Any book read (`List`, `ListPage`, `GetByID`, search) | 0 |
| Library scan sweep, per book with a same-format sibling | at most 2, and no write unless a rendered path has vanished |

The derivation stops at the first row that resolves, so the common case is one stat per format. The scanner already stats every file it walks and every legacy path in `isReconcileCandidate`, so an import pays roughly two more stats against work already dominated by the walk. A healthy library does no database work at all in the sweep.

## Behaviour under an unavailable volume

This is the hazard fix (2) carries, so it is explicit in the code and pinned by tests.

- Only a definite `ENOENT` demotes a row. A permission error, an I/O error or a stalled mount says "we cannot read this", not "this moved", and leaves the row trusted. Same asymmetry the ABS prune uses.
- When no row for a format resolves, the derivation returns the lowest-id row unchanged, which is the pre-fix answer. The book keeps its path, keeps reporting Imported, and keeps every row. A missing mount cannot blank a field or flip a library back to Wanted.
- Nothing is deleted on any path.

## ABS importer

Untouched. `pruneVanishedFormatPaths` stays private to `internal/abs` and still runs exactly when it did. Its existing tests are unmodified and pass.

## What this does NOT fix

- **A file moved outside the library root.** Bindery only learns the new location when a scan or import registers it, and a scan only matches files to books already in the catalogue. Nothing here searches for a file.
- **The stale row itself.** It stays in `book_files` by design. The book stops rendering it, and it is listed under Files for the user to forget, but no automatic cleanup removes it. That is the deliberate trade for being safe under a missing mount.
- **A book whose files are all missing.** It keeps reporting Imported against a dead path. Distinguishing "deleted" from "unreachable" needs more than a stat, and guessing wrong in that direction is the expensive mistake.
- **Surfacing which row is dead in the UI.** The Files list shows both rows with no visual difference. A `missing` flag on the API row plus a badge is the natural follow-up.
- **The append itself.** `AddBookFile` still appends rather than repointing. `Rename files` already repoints via `UpdateBookFilePath`, so the append only bites when files move outside Bindery.

## Follow-ups (not in this PR)

- Expose `missing` on the `BookFile` API row and badge it in the Files list, so the dead row is visible rather than just harmless.
- Consider whether an all-missing book should surface anywhere other than the log.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (see `commits` skill: `docs/`, `README.md`, godoc, Helm values)
- [x] Wiki pages updated if user-facing behaviour changed

`docs/Troubleshooting-Wiki.md` gains a symptom section, and `docs/User-Guide-Wiki.md` a Quick answer. No env vars, Helm values or API shapes changed.

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `gofmt -l`, `go vet ./...`, `go build ./...`
- [x] Both repro tests verified failing against `origin/main` (source stashed, tests kept), passing with the fix
- [ ] `cd web && npm run build`, not run: no frontend changes in this PR

Before, on `origin/main`:

```
--- FAIL: TestRefreshBookStatus_MovedFileRendersLivePath
    EbookFilePath = ".../Old Folder/Neuromancer.epub", want the live path ".../New Folder/Neuromancer.epub"
    legacy FilePath = ".../Old Folder/Neuromancer.epub", want the live path ".../New Folder/Neuromancer.epub"
    rendered path does not exist on disk: stat .../Old Folder/Neuromancer.epub: no such file or directory
--- FAIL: TestScanLibrary_RepairsBookRenderingAVanishedPath
    EbookFilePath after scan = ".../Jane Doe/Old Folder/Alpha Adventure.epub", want the live path ".../Jane Doe/New Folder/Alpha Adventure.epub"
--- PASS: TestRefreshBookStatus_AllFilesMissingKeepsRenderedPath
--- PASS: TestBookColumns_FallsBackToBookFilesRow
--- PASS: TestScanLibrary_LeavesHealthyMultiFileBookAlone
```

After:

```
ok  	github.com/vavallee/bindery/internal/db	19.891s
ok  	github.com/vavallee/bindery/internal/importer	18.766s
ok  	github.com/vavallee/bindery/internal/api	108.478s
ok  	github.com/vavallee/bindery/internal/abs	4.742s
```

Tests added:

| Test | Covers |
|------|--------|
| `TestRefreshBookStatus_MovedFileRendersLivePath` | the issue repro, end to end through `GetByID` |
| `TestRefreshBookStatus_AllFilesMissingKeepsRenderedPath` | the hazard: a vanished mount changes nothing and deletes nothing |
| `TestRefreshBookStatus_UnprovableAbsenceKeepsRow` | only `ENOENT` demotes a row, `ENOTDIR` does not |
| `TestBookColumns_FallsBackToBookFilesRow` | the read-path precedence change keeps the migration 028 shape working |
| `TestScanLibrary_RepairsBookRenderingAVanishedPath` | a rescan repairs an already-broken book |
| `TestScanLibrary_LeavesHealthyMultiFileBookAlone` | the sweep leaves a healthy multi-format book alone |
