### PR TITLE
fix(series): keep the fill's chosen format off Hardcover's widening (#1802)

### DIFF
--- a/changelog.d/1802-series-fill-format-pin.md
+++ b/changelog.d/1802-series-fill-format-pin.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Series fill now respects the format you picked** (#1802) — with enhanced Hardcover series enabled, "add all" and the per row "add" created every book as a dual format book whenever Hardcover listed an audiobook edition, so choosing "Ebook" still queued and grabbed an audiobook as well. The chosen format is now kept, and only that format is searched for.

--- a/docs/Hardcover-Series-Wiki.md
+++ b/docs/Hardcover-Series-Wiki.md
@@ -56,6 +56,8 @@ Missing-book fill uses the linked Hardcover catalog as the source of truth for m
 
 The fill action may create new authors and books from Hardcover metadata when the catalog entry is not already in Bindery. Those books are linked back to the series with the catalog position.
 
+The format dropdown beside **add all** sets the media type of every book the fill creates. Pick **Ebook** and the created books are ebook only, even when Hardcover lists an audiobook edition of the same work, so only one search is queued per book. Pick **Both** if you want Bindery to look for both formats. Books that are already in the series keep whatever media type they were added with, so change those on the book itself.
+
 ## Known Behavior
 
 - Hardcover-backed controls require outbound HTTPS access to Hardcover.

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -104,7 +104,10 @@ func (h *SeriesHandler) WithEditionFetcher(fetcher bookhydrate.EditionFetcher) *
 	return h
 }
 
-func (h *SeriesHandler) hydrateHardcoverEditions(ctx context.Context, book *models.Book) {
+// hydrateHardcoverEditions fills the book's editions from Hardcover.
+// mediaTypePinned forwards the caller's "this format was chosen, not guessed"
+// signal so hydration leaves the media type alone (#1802).
+func (h *SeriesHandler) hydrateHardcoverEditions(ctx context.Context, book *models.Book, mediaTypePinned bool) {
 	if book == nil || h.editions == nil {
 		return
 	}
@@ -121,6 +124,11 @@ func (h *SeriesHandler) hydrateHardcoverEditions(ctx context.Context, book *mode
 		Books:         h.books,
 		FetchEditions: fetcher,
 		Enricher:      h.meta,
+		// The series fill sets MediaType from the format dropdown, so an
+		// audio edition on Hardcover must not widen an "ebook" book to
+		// "both" — that queued a grab for both formats when the user had
+		// asked for one (#1802).
+		MediaTypePinned: mediaTypePinned,
 	})
 }
 
@@ -383,6 +391,22 @@ func (r seriesFillRequest) validMediaType() bool {
 	}
 }
 
+// requestedFormat is the media type a fill creates its books with. pinned marks
+// it as a deliberate caller choice, which is what stops Hardcover hydration
+// widening an "ebook" book to "both" the moment the work has an audio edition.
+type requestedFormat struct {
+	mediaType string
+	pinned    bool
+}
+
+// format bundles the requested media type with whether the caller actually
+// named one. The two must travel together: hydration may only refuse to widen
+// a single-format book when the media type is the caller's choice rather than
+// the endpoint's default (#1802, same distinction as #1732).
+func (r seriesFillRequest) format() requestedFormat {
+	return requestedFormat{mediaType: r.mediaType(), pinned: r.MediaType != ""}
+}
+
 func (r seriesFillRequest) hasBookSelector() bool {
 	return r.ForeignBookID != "" || r.ProviderID != "" || r.Position != ""
 }
@@ -471,7 +495,7 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.enhancedHardcoverEnabled(r.Context()) {
-		if err := h.createMissingHardcoverBooks(r.Context(), id, body.mediaType()); err != nil {
+		if err := h.createMissingHardcoverBooks(r.Context(), id, body.format()); err != nil {
 			if !errors.Is(err, errSeriesMetadataProvider) {
 				writeServerError(w, r, err)
 				return
@@ -1218,7 +1242,7 @@ func localDiffBook(local models.SeriesBook) seriesHardcoverDiffBook {
 	return item
 }
 
-func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesID int64, mediaType string) error {
+func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesID int64, format requestedFormat) error {
 	if !h.enhancedHardcoverEnabled(ctx) {
 		return nil
 	}
@@ -1247,7 +1271,7 @@ func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesI
 		if !ok {
 			continue
 		}
-		if _, err := h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook, mediaType); err != nil {
+		if _, err := h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook, format); err != nil {
 			// One bad volume must not truncate the rest of the series
 			// (#1682). This used to return, so a single failure part-way
 			// through silently abandoned every remaining volume and the user
@@ -1301,7 +1325,7 @@ func (h *SeriesHandler) createMissingHardcoverBook(ctx context.Context, seriesID
 		if !ok {
 			return nil, errSeriesCatalogBookNotFound
 		}
-		return h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook, selector.mediaType())
+		return h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook, selector.format())
 	}
 	return nil, errSeriesCatalogBookNotFound
 }
@@ -1318,7 +1342,7 @@ func findCatalogBook(books []metadata.SeriesCatalogBook, foreignID, position str
 	return metadata.SeriesCatalogBook{}, false
 }
 
-func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *models.Series, fallbackAuthor string, catalogBook metadata.SeriesCatalogBook, mediaType string) (*models.Book, error) {
+func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *models.Series, fallbackAuthor string, catalogBook metadata.SeriesCatalogBook, format requestedFormat) (*models.Book, error) {
 	if series == nil {
 		return nil, errSeriesNotFound
 	}
@@ -1452,7 +1476,7 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *
 	book.AnyEditionOK = true
 	// The caller's requested media type wins over the catalog default; it has
 	// already been validated and defaults to ebook when omitted.
-	book.MediaType = firstNonEmpty(mediaType, models.MediaTypeEbook)
+	book.MediaType = firstNonEmpty(format.mediaType, models.MediaTypeEbook)
 	book.Language = firstNonEmpty(book.Language, "eng")
 	book.MetadataProvider = firstNonEmpty(book.MetadataProvider, "hardcover")
 	if series.GenreOverrideSet {
@@ -1465,7 +1489,7 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *
 	if err := h.books.Create(ctx, &book); err != nil {
 		return nil, err
 	}
-	h.hydrateHardcoverEditions(ctx, &book)
+	h.hydrateHardcoverEditions(ctx, &book, format.pinned)
 	if _, err := h.series.LinkBookIfMissing(ctx, series.ID, book.ID, catalogBook.Position, true); err != nil {
 		return nil, err
 	}

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -1605,6 +1605,81 @@ func TestSeriesFillHydratesHardcoverEditionsBeforeQueue(t *testing.T) {
 	}
 }
 
+// TestSeriesFillKeepsSelectedFormat pins #1802: the format dropdown on the
+// Series tab constrains what the fill creates, so a book created for "ebook"
+// must stay ebook even when Hardcover offers an audio edition for the same
+// work. Before the fix, hydration widened it to "both" and the fill queued a
+// grab for both formats. Covers both fill shapes, "add all" and one row.
+func TestSeriesFillKeepsSelectedFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "add all", body: `{"mediaType":"ebook"}`},
+		{name: "single book", body: `{"foreignBookId":"hc:the-way-of-kings","mediaType":"ebook"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			catalog := stormlightCatalog()
+			searcher := newMockBookSearcher()
+			h, seriesRepo, _, bookRepo, _ := seriesFixtureWithProviderAndEditions(t, &stubSeriesProvider{
+				catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+			}, searcher)
+			audioASIN := "B000STORML"
+			h.WithEditionFetcher(func(context.Context, string) ([]models.Edition, error) {
+				return []models.Edition{{
+					ForeignID: "hc:stormlight-audio",
+					Title:     "The Way of Kings",
+					ASIN:      &audioASIN,
+					Format:    "Audiobook",
+					Monitored: true,
+				}}, nil
+			})
+			series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+			if err := seriesRepo.Create(context.Background(), series); err != nil {
+				t.Fatal(err)
+			}
+			if err := seriesRepo.UpsertHardcoverLink(context.Background(), &models.SeriesHardcoverLink{
+				SeriesID:            series.ID,
+				HardcoverSeriesID:   catalog.ForeignID,
+				HardcoverProviderID: catalog.ProviderID,
+				HardcoverTitle:      catalog.Title,
+				HardcoverAuthorName: catalog.AuthorName,
+				HardcoverBookCount:  catalog.BookCount,
+				Confidence:          1,
+				LinkedBy:            "manual",
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", bytes.NewBufferString(tc.body))
+			h.Fill(rec, withURLParam(req, "id", strconv.FormatInt(series.ID, 10)))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+
+			queued := searcher.waitForCall(t, time.Second)
+			if queued.MediaType != models.MediaTypeEbook {
+				t.Errorf("queued book mediaType = %q, want %q", queued.MediaType, models.MediaTypeEbook)
+			}
+			if queued.NeedsAudiobook() {
+				t.Error("queued book still wants an audiobook; the fill will grab both formats")
+			}
+			created, err := bookRepo.GetByForeignID(context.Background(), "hc:the-way-of-kings")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if created == nil {
+				t.Fatal("expected the Hardcover book to be created")
+			}
+			if created.MediaType != models.MediaTypeEbook {
+				t.Errorf("persisted mediaType = %q, want %q", created.MediaType, models.MediaTypeEbook)
+			}
+		})
+	}
+}
+
 func TestSeriesFillReusesCrossProviderAuthorAndExistingBook(t *testing.T) {
 	catalog := stormlightCatalog()
 	searcher := newMockBookSearcher()


### PR DESCRIPTION
## Summary

The Series tab's format dropdown decides the media type of every book a fill creates, but the Hardcover edition hydration that runs immediately after was free to widen it. `deriveAudiobookMetadataFromEdition` promotes an `ebook` book to `both` as soon as the work has any audio edition, which is true of most popular titles, and the widened row is persisted before the fill queues its searches. So picking "Ebook" grabbed an audiobook as well and left the book wanted for both formats, exactly as reported. Closes #1802.

## Where it went wrong

| Step | Code |
|---|---|
| Fill validates the requested format and defaults it to ebook | `internal/api/series.go` `seriesFillRequest.mediaType()` |
| The created book takes that media type | `series.go:1476` `book.MediaType = firstNonEmpty(...)` |
| Hydration runs and may widen it | `series.go:1489` to `bookhydrate.deriveAudiobookMetadataFromEdition` |
| The widened value is written back | `HydrateHardcoverEditions` calls `opts.Books.Update` when derivation changed the book |
| The fill searches per format | `Scheduler.SearchAndGrabBook` fires once for `NeedsEbook` and once for `NeedsAudiobook` |

#1740 fixed the identical widening on the Hardcover import list by adding `bookhydrate.Options.MediaTypePinned`, and its body named series fill as a caller it deliberately did not cover. This is that caller.

## Why the pin is conditional

`MediaTypePinned` is set only when the request actually named a media type. The endpoint documents its `""` case as "default to ebook to preserve the historical behaviour", which makes the default a fallback rather than a caller choice, so an API client that omits the field keeps today's behaviour byte for byte. `TestSeriesFillHydratesHardcoverEditionsBeforeQueue`, which fills with no body and expects the ASIN promotion that only an audio-typed book gets, still passes unchanged and pins that.

The web UI always sends the dropdown value (`SeriesPage.tsx` passes `fillMediaType[series.id] ?? 'ebook'` for both "add all" and the per row "add"), so the reported flow is fully covered.

`requestedFormat` carries the media type and the pin together through `createMissingHardcoverBooks` and `ensureHardcoverCatalogBook` so the two cannot drift apart at a call site.

## Not in this PR

The issue also asks that the dropdown constrain books **already** in the series, not only the ones the fill creates. It does not: `queueSeriesBook` marks an existing series book wanted without touching its media type. Rewriting a stored media type from a fill button is a larger product decision than a format pin, so it is left alone here and the wiki now says so.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (see `commits` skill: `docs/`, `README.md`, godoc, Helm values) — `docs/Hardcover-Series-Wiki.md` gains a paragraph on what the format dropdown does
- [x] Wiki pages updated if user-facing behaviour changed
- [x] Changelog fragment added (`changelog.d/1802-series-fill-format-pin.md`)

## Test plan

- [x] `go test ./internal/...`
- [x] `go vet ./...`, `gofmt -l .`, `go build ./...`
- [x] Repro test verified failing on `origin/main` (source change stashed, test kept), passing with the fix
- [ ] `cd web && npm run build` not run: no frontend change

`TestSeriesFillKeepsSelectedFormat` covers both fill shapes, "add all" and one row, with a Hardcover fetcher returning an audiobook edition.

Before, on `origin/main`:

```
--- FAIL: TestSeriesFillKeepsSelectedFormat (0.15s)
    --- FAIL: TestSeriesFillKeepsSelectedFormat/add_all (0.07s)
        series_test.go:1664: queued book mediaType = "both", want "ebook"
        series_test.go:1667: queued book still wants an audiobook; the fill will grab both formats
        series_test.go:1677: persisted mediaType = "both", want "ebook"
    --- FAIL: TestSeriesFillKeepsSelectedFormat/single_book (0.07s)
        series_test.go:1664: queued book mediaType = "both", want "ebook"
        series_test.go:1667: queued book still wants an audiobook; the fill will grab both formats
        series_test.go:1677: persisted mediaType = "both", want "ebook"
FAIL
```

After:

```
ok  	github.com/vavallee/bindery/internal/api	2.140s
```
