### PR TITLE
fix(metadata): page the full OpenLibrary edition list (#1779)

### DIFF
--- a/changelog.d/1779-openlibrary-editions-pagination.md
+++ b/changelog.d/1779-openlibrary-editions-pagination.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Heavily reprinted books no longer go missing from an author's library** (#1779): Bindery read only the first 50 editions of an OpenLibrary work, in an order OpenLibrary does not sort. The **Min pages** and **Skip missing ISBN** metadata profile settings decide from that list, so a title whose page count or ISBN happened to sit further down was skipped on refresh even though it qualified. The full edition list is now read, so those books come back on the next author refresh.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -154,6 +154,13 @@ The usual culprit is the **allowed languages** list on the author's metadata pro
 - **The language list itself.** A work whose language is outside the list is skipped. Foreign-language editions of an English author are the common case.
 - **"When book language is unknown".** OpenLibrary carries no language on many *work* records, so a large tail of an author's catalogue arrives with no language at all. Set to **fail**, every one of those is skipped too — which is what turns "a few translations were dropped" into "most of this author is missing". Setting it to **pass** and refreshing again brings them back.
 
+Two more settings on the same profile drop books by looking at the work's **editions** rather than the work itself:
+
+- **Min pages.** A work is skipped when no edition of it reports a page count at or above the floor. A work whose editions carry no page count at all is treated as unknown and kept, not skipped.
+- **Skip missing ISBN.** A work is skipped when no edition of it carries an ISBN. A work the provider returns no editions for counts as missing and is skipped too.
+
+Both read the full edition list. Older versions fetched only the first 50 editions of an OpenLibrary work, in an order OpenLibrary does not sort, so a heavily reprinted title whose ISBN or page count happened to sit further down the list was skipped even though it qualified. If either setting is on and books went missing that way, refresh the author again after upgrading.
+
 The skip counts are also in the log (`Settings → Logs`): the `author books synced` line carries `added`, `skipped_language`, `skipped_junk` and `skipped_media_type`, and is logged at WARN whenever anything was skipped. Per-book detail (which title, which language) is at DEBUG.
 
 ## Collecting logs for a bug report

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -41,10 +41,14 @@ const (
 // the work language (OpenLibrary works carry none of their own, so the
 // foreign-language filter has to sample editions — #891) and a missing cover
 // (OL attaches covers to editions far more consistently than to works —
-// #1748). The cap is deliberately small: the first handful of editions is
-// enough to establish the dominant language and holds the most-held printing's
-// cover, and the endpoint is expensive enough that OL throttles per-UA, so we
-// keep the round-trip cheap (limit=N) rather than paging the full edition list.
+// #1748). The cap is deliberately small: the endpoint is expensive enough that
+// OL throttles per-UA, so we keep the round trip cheap (limit=N) rather than
+// paging the full edition list the way GetEditions does.
+//
+// The cost of that is accuracy. OpenLibrary returns editions in no meaningful
+// order, so a handful of them is a sample rather than the leading editions, and
+// a work whose first few happen to be translations can be read as
+// foreign-language or pick up a foreign cover (#1779, still open on that half).
 //
 // The two derivations used to be separate samplers with separate caches, which
 // meant a work missing both language and cover cost TWO round trips to the
@@ -68,6 +72,20 @@ const authorWorkSampleConcurrency = 4
 const (
 	authorWorksPageSize = 100
 	authorWorksMaxFetch = 2000
+)
+
+// editionsPageSize is the per-request limit for the /works/{id}/editions.json
+// endpoint, and editionsMaxFetch bounds total pagination so a work with an
+// enormous edition count can't trigger unbounded requests.
+//
+// 200 is chosen so the overwhelming majority of works still cost exactly one
+// round trip: OpenLibrary honours a limit that high (verified against
+// /works/OL45804W/editions.json, size 139, returned in full at limit=200), and
+// works past that are rare enough that paying an extra request for them is the
+// right trade. 1000 covers even the most reprinted titles at five requests.
+const (
+	editionsPageSize = 200
+	editionsMaxFetch = 1000
 )
 
 // workEditionSample is everything one edition-list sample derives for a work.
@@ -607,41 +625,81 @@ func shouldFilterOLNoise(title string, subjects []string) bool {
 	return false
 }
 
+// GetEditions fetches a work's editions from /works/{id}/editions.json.
+//
+// The endpoint is paginated the same way /authors/{id}/works is: it returns at
+// most `limit` entries per call and advertises the work's edition total in
+// Size. This used to request one limit=50 page, so a work with more editions
+// than that reported only 50 of them, in whatever order OpenLibrary happened to
+// return — which is neither publication nor popularity order (#1779).
+//
+// The truncation reached further than a short list. The MinPages and
+// SkipMissingISBN metadata-profile filters ask whether ANY edition carries a
+// page count or an ISBN, so a work whose qualifying editions all sat past
+// position 50 was dropped from the author's library on sync. Fantastic Mr Fox
+// (OL45804W) is the case from the report: 139 editions, 76 of them carrying a
+// page count, and more than half of those past the old cap.
+//
+// Pagination stops on a short page, on reaching the advertised Size, or at
+// editionsMaxFetch. A first-page failure is returned to the caller; a later
+// page failing keeps the editions already collected rather than discarding
+// them, matching authorWorksBackfill.
 func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]models.Edition, error) {
-	u := fmt.Sprintf("%s/works/%s/editions.json?limit=50", baseURL, bookForeignID)
-	var resp editionsResponse
-	if err := c.getJSON(ctx, u, &resp); err != nil {
-		return nil, fmt.Errorf("get editions for %s: %w", bookForeignID, err)
-	}
+	editions := make([]models.Edition, 0, editionsPageSize)
+	for offset := 0; offset < editionsMaxFetch; offset += editionsPageSize {
+		u := fmt.Sprintf("%s/works/%s/editions.json?limit=%d&offset=%d",
+			baseURL, bookForeignID, editionsPageSize, offset)
+		var resp editionsResponse
+		if err := c.getJSON(ctx, u, &resp); err != nil {
+			if offset == 0 {
+				return nil, fmt.Errorf("get editions for %s: %w", bookForeignID, err)
+			}
+			slog.Warn("openlibrary: edition pagination stopped early",
+				"work", bookForeignID, "offset", offset, "error", err)
+			break
+		}
 
-	editions := make([]models.Edition, 0, len(resp.Entries))
-	for _, e := range resp.Entries {
-		editionID := strings.TrimPrefix(e.Key, "/books/")
-		ed := models.Edition{
-			ForeignID: editionID,
-			Title:     e.Title,
-			Publisher: first(e.Publishers),
-			Format:    e.PhysicalFormat,
-			NumPages:  nilIfZero(e.NumberOfPages),
-			Monitored: true,
+		for _, e := range resp.Entries {
+			editions = append(editions, editionFromEntry(e))
 		}
-		if len(e.ISBN13) > 0 {
-			ed.ISBN13 = &e.ISBN13[0]
+
+		if len(resp.Entries) < editionsPageSize ||
+			(resp.Size > 0 && len(editions) >= resp.Size) {
+			break
 		}
-		if len(e.ISBN10) > 0 {
-			ed.ISBN10 = &e.ISBN10[0]
-		}
-		if len(e.Languages) > 0 {
-			ed.Language = strings.TrimPrefix(e.Languages[0].Key, "/languages/")
-		}
-		if len(e.Covers) > 0 && e.Covers[0] > 0 {
-			ed.ImageURL = fmt.Sprintf("%s/b/id/%d-L.jpg", coverURL, e.Covers[0])
-		}
-		format := strings.ToLower(ed.Format)
-		ed.IsEbook = strings.Contains(format, "ebook") || strings.Contains(format, "kindle")
-		editions = append(editions, ed)
+	}
+	if len(editions) >= editionsMaxFetch {
+		slog.Warn("openlibrary: editions hit pagination cap; edition list may be truncated",
+			"work", bookForeignID, "cap", editionsMaxFetch)
 	}
 	return editions, nil
+}
+
+// editionFromEntry maps one /works/{id}/editions.json entry onto an Edition.
+func editionFromEntry(e editionEntry) models.Edition {
+	ed := models.Edition{
+		ForeignID: strings.TrimPrefix(e.Key, "/books/"),
+		Title:     e.Title,
+		Publisher: first(e.Publishers),
+		Format:    e.PhysicalFormat,
+		NumPages:  nilIfZero(e.NumberOfPages),
+		Monitored: true,
+	}
+	if len(e.ISBN13) > 0 {
+		ed.ISBN13 = &e.ISBN13[0]
+	}
+	if len(e.ISBN10) > 0 {
+		ed.ISBN10 = &e.ISBN10[0]
+	}
+	if len(e.Languages) > 0 {
+		ed.Language = strings.TrimPrefix(e.Languages[0].Key, "/languages/")
+	}
+	if len(e.Covers) > 0 && e.Covers[0] > 0 {
+		ed.ImageURL = fmt.Sprintf("%s/b/id/%d-L.jpg", coverURL, e.Covers[0])
+	}
+	format := strings.ToLower(ed.Format)
+	ed.IsEbook = strings.Contains(format, "ebook") || strings.Contains(format, "kindle")
+	return ed
 }
 
 // FillMissingWorkLanguages derives a language for any book that arrived with an
@@ -796,9 +854,18 @@ func (c *Client) FillMissingWorkCovers(ctx context.Context, books []models.Book)
 	return int(filled.Load())
 }
 
-// firstEditionCover returns the cover URL of the first edition that has one, in
-// the order OpenLibrary returns them (most-held printings first), or "" when no
-// sampled edition carries a cover.
+// firstEditionCover returns the cover URL of the first sampled edition that has
+// one, or "" when none of them carries a cover.
+//
+// It used to say the entries arrive "most-held printings first". They do not:
+// /works/{id}/editions.json takes no sort parameter and its order is neither
+// publication nor popularity order, so which edition this lands on is not
+// meaningful (#1779). It is still a reasonable cover for a work that has none
+// of its own, which is the only situation it is consulted in, but a work whose
+// arbitrary first editions are a translation can pick up that translation's
+// cover. Making the choice deterministic is the open half of #1779 and needs a
+// wider sample than editionSampleCap, which is a cost decision rather than a
+// one-line change.
 func firstEditionCover(entries []editionEntry) string {
 	for _, e := range entries {
 		if len(e.Covers) > 0 && e.Covers[0] > 0 {

--- a/internal/metadata/openlibrary/editions_pagination_test.go
+++ b/internal/metadata/openlibrary/editions_pagination_test.go
@@ -1,0 +1,224 @@
+package openlibrary
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+// editionCorpus builds n edition entries, none of which carries an ISBN or a
+// page count unless its index appears in withData. That mirrors the shape of a
+// heavily reprinted OpenLibrary work: most entries are thin stubs and the ones
+// carrying real identifiers sit wherever OL happens to place them.
+func editionCorpus(n int, withData ...int) []editionEntry {
+	rich := make(map[int]bool, len(withData))
+	for _, i := range withData {
+		rich[i] = true
+	}
+	entries := make([]editionEntry, 0, n)
+	for i := range n {
+		e := editionEntry{
+			Key:   fmt.Sprintf("/books/OL%04dM", i),
+			Title: fmt.Sprintf("Edition %d", i),
+		}
+		if rich[i] {
+			e.ISBN13 = []string{fmt.Sprintf("978000000%04d", i)}
+			e.NumberOfPages = 320
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+// pagedEditionsHandler serves a corpus the way OpenLibrary does: `size` is the
+// work's total edition count and `entries` is the limit/offset window into it.
+// requestedOffsets records every offset asked for, in order.
+func pagedEditionsHandler(entries []editionEntry, requestedOffsets *[]int) func(*http.Request) string {
+	return func(r *http.Request) string {
+		q := r.URL.Query()
+		limit, _ := strconv.Atoi(q.Get("limit"))
+		if limit <= 0 {
+			limit = 50
+		}
+		offset, _ := strconv.Atoi(q.Get("offset"))
+		if requestedOffsets != nil {
+			*requestedOffsets = append(*requestedOffsets, offset)
+		}
+		page := []editionEntry{}
+		if offset < len(entries) {
+			end := min(offset+limit, len(entries))
+			page = entries[offset:end]
+		}
+		return jsonStr(editionsResponse{Size: len(entries), Entries: page})
+	}
+}
+
+// A work with more editions than one old page held used to come back truncated
+// to the first 50, in an order OpenLibrary does not sort. That is not just a
+// short list: the MinPages and SkipMissingISBN metadata-profile filters ask
+// whether ANY edition carries a page count or an ISBN, so a work whose only
+// qualifying edition sat past position 50 was skipped on author sync and never
+// entered the library (#1779).
+func TestGetEditions_HTTP_ReturnsEveryEdition(t *testing.T) {
+	const total = 139 // Fantastic Mr Fox (OL45804W), the work in the report.
+	const isbnAt = 120
+
+	entries := editionCorpus(total, isbnAt)
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/works/OL45804W/editions.json": pagedEditionsHandler(entries, nil),
+	})
+
+	editions, err := c.GetEditions(context.Background(), "OL45804W")
+	if err != nil {
+		t.Fatalf("GetEditions: %v", err)
+	}
+	if len(editions) != total {
+		t.Fatalf("got %d editions, want all %d", len(editions), total)
+	}
+
+	// The filters downstream are "does any edition qualify" predicates, so
+	// what matters is that the qualifying edition is reachable at all.
+	var sawISBN, sawPages bool
+	for _, e := range editions {
+		if e.ISBN13 != nil && *e.ISBN13 != "" {
+			sawISBN = true
+		}
+		if e.NumPages != nil && *e.NumPages > 0 {
+			sawPages = true
+		}
+	}
+	if !sawISBN {
+		t.Errorf("the work's only ISBN-bearing edition (index %d) never reached the caller", isbnAt)
+	}
+	if !sawPages {
+		t.Errorf("the work's only page-count-bearing edition (index %d) never reached the caller", isbnAt)
+	}
+
+	want := fmt.Sprintf("OL%04dM", isbnAt)
+	if editions[isbnAt].ForeignID != want {
+		t.Errorf("edition %d: ForeignID = %q, want %q", isbnAt, editions[isbnAt].ForeignID, want)
+	}
+}
+
+// A work large enough to need several requests is paged through rather than
+// cut off at the first response.
+func TestGetEditions_HTTP_PagesBeyondOneRequest(t *testing.T) {
+	const total = editionsPageSize*2 + 50
+
+	var offsets []int
+	entries := editionCorpus(total, total-1)
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/works/OL456W/editions.json": pagedEditionsHandler(entries, &offsets),
+	})
+
+	editions, err := c.GetEditions(context.Background(), "OL456W")
+	if err != nil {
+		t.Fatalf("GetEditions: %v", err)
+	}
+	if len(editions) != total {
+		t.Fatalf("got %d editions, want %d", len(editions), total)
+	}
+	wantOffsets := []int{0, editionsPageSize, editionsPageSize * 2}
+	if len(offsets) != len(wantOffsets) {
+		t.Fatalf("requested offsets %v, want %v", offsets, wantOffsets)
+	}
+	for i, want := range wantOffsets {
+		if offsets[i] != want {
+			t.Fatalf("requested offsets %v, want %v", offsets, wantOffsets)
+		}
+	}
+	if editions[total-1].ISBN13 == nil {
+		t.Error("the last edition's ISBN did not survive pagination")
+	}
+}
+
+// A work whose edition count fits in one response costs exactly one request.
+// Paging must not turn the common case into a second round trip against an
+// endpoint OpenLibrary throttles.
+func TestGetEditions_HTTP_SmallWorkCostsOneRequest(t *testing.T) {
+	var offsets []int
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/works/OL456W/editions.json": pagedEditionsHandler(editionCorpus(12), &offsets),
+	})
+
+	editions, err := c.GetEditions(context.Background(), "OL456W")
+	if err != nil {
+		t.Fatalf("GetEditions: %v", err)
+	}
+	if len(editions) != 12 {
+		t.Fatalf("got %d editions, want 12", len(editions))
+	}
+	if len(offsets) != 1 {
+		t.Fatalf("made %d requests (offsets %v), want 1", len(offsets), offsets)
+	}
+}
+
+// An upstream that never runs out of entries must not loop forever.
+func TestGetEditions_HTTP_StopsAtPaginationCap(t *testing.T) {
+	var requests int
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/works/OL456W/editions.json": func(r *http.Request) string {
+			requests++
+			if requests > 100 {
+				t.Fatal("GetEditions did not stop paginating")
+			}
+			return jsonStr(editionsResponse{
+				Size:    1 << 20,
+				Entries: editionCorpus(editionsPageSize),
+			})
+		},
+	})
+
+	editions, err := c.GetEditions(context.Background(), "OL456W")
+	if err != nil {
+		t.Fatalf("GetEditions: %v", err)
+	}
+	if len(editions) != editionsMaxFetch {
+		t.Fatalf("got %d editions, want the cap of %d", len(editions), editionsMaxFetch)
+	}
+}
+
+// A failure partway through keeps the editions already collected instead of
+// discarding them, matching how the author-works pagination behaves.
+func TestGetEditions_HTTP_LaterPageFailureKeepsWhatWeHave(t *testing.T) {
+	// The transport's status override is per path, not per call, so the later
+	// pages fail by returning a body the JSON decoder rejects instead.
+	var requests int
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/works/OL456W/editions.json": func(r *http.Request) string {
+			requests++
+			if requests > 1 {
+				return `{"entries": [`
+			}
+			return jsonStr(editionsResponse{
+				Size:    editionsPageSize * 3,
+				Entries: editionCorpus(editionsPageSize),
+			})
+		},
+	})
+
+	editions, err := c.GetEditions(context.Background(), "OL456W")
+	if err != nil {
+		t.Fatalf("a later page failing must not fail the lookup, got %v", err)
+	}
+	if len(editions) != editionsPageSize {
+		t.Fatalf("got %d editions, want the %d collected before the failure", len(editions), editionsPageSize)
+	}
+}
+
+// The first page failing is still a failed lookup: callers treat an error as
+// "no edition data for this work" and skip the edition-gated filters, which is
+// the safe reading. Returning an empty list instead would look like a work with
+// zero editions, which SkipMissingISBN drops.
+func TestGetEditions_HTTP_FirstPageFailureIsAnError(t *testing.T) {
+	c := newClientWithStatus(t,
+		map[string]interface{}{"/works/OL456W/editions.json": `{"error":"boom"}`},
+		map[string]int{"/works/OL456W/editions.json": http.StatusInternalServerError},
+	)
+
+	if _, err := c.GetEditions(context.Background(), "OL456W"); err == nil {
+		t.Fatal("expected an error when the first page fails")
+	}
+}

--- a/internal/metadata/openlibrary/types.go
+++ b/internal/metadata/openlibrary/types.go
@@ -119,6 +119,11 @@ type authorResponse struct {
 }
 
 type editionsResponse struct {
+	// Size is the work's total edition count, which OpenLibrary reports
+	// alongside the (limit-truncated) Entries page. Pagination uses it as the
+	// authoritative terminator; older or partial responses omit it, in which
+	// case a short page is the signal instead.
+	Size    int            `json:"size"`
 	Entries []editionEntry `json:"entries"`
 }
 


### PR DESCRIPTION
## Summary

`GetEditions` asked OpenLibrary for a single `limit=50` page of `/works/{id}/editions.json`. That endpoint takes no sort parameter and its order is neither publication nor popularity order, so the 50 were an arbitrary slice of what can be several hundred editions. It now pages the whole list.

The truncation reached further than a short edition list. **Min pages** and **Skip missing ISBN** on a metadata profile are "does any edition qualify" predicates over exactly this list, so a work whose qualifying editions all sat past position 50 was skipped on author sync and never entered the library. Refs #1779.

## Why the reporter's own example is the proof

`https://openlibrary.org/works/OL45804W/editions.json` (Fantastic Mr Fox), checked live while writing this:

| Request | `size` | entries returned |
|---|---|---|
| `?limit=50` | 139 | 50, plus a `links.next` nobody followed |
| `?limit=200` | 139 | 139 |
| `?limit=200&offset=100` | 139 | 39 |

Of those 139 editions, 131 carry an ISBN and 76 carry a page count, and more than half of the page counts sit past index 50. So the profile filters were deciding from a third of the evidence.

## Implementation notes

- Pages at `editionsPageSize = 200`, capped at `editionsMaxFetch = 1000`, mirroring `authorWorksBackfill` in the same file. 200 was picked so the overwhelming majority of works still cost exactly one round trip, which matters because this endpoint is throttled per user agent.
- Stops on a short page, on reaching the advertised `size`, or at the cap.
- A first page failure is still returned as an error. Callers read an error as "no edition data, do not enforce the edition-gated filters", which is the safe reading; returning an empty list would look like a work with zero editions, which **Skip missing ISBN** drops. A later page failing keeps what was already collected and logs a warning, same as the author works pagination.
- The entry to model mapping moved out to `editionFromEntry` so the loop reads as pagination rather than as mapping.

## Why minimal / scope decisions

#1779 reports four things. This PR fixes the truncation and corrects the false premise; it does not close the issue.

| Bullet | Status here |
|---|---|
| `editions.json` read truncated and unordered | Fixed |
| The `firstEditionCover` doc comment claims "most-held printings first" | Corrected, in both places that asserted it |
| `cover_edition` never read | Not done, and worth a look before anyone does. I sampled 180 works live (120 from five author catalogues, 60 popular works by edition count): 5 carried `cover_edition` and **every one of them already had a usable work level `covers` entry**. There was no work in the sample where reading `cover_edition` would have produced a cover Bindery does not already get. |
| Cover and language sampling over an arbitrary 5 editions | Not done. `sampleWorkEditions` is on the author refresh hot path and #1888 was specifically about its cost, so widening the sample is a cost decision rather than a one line change. Both doc comments now say so instead of claiming the order is meaningful. |

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (see `commits` skill: `docs/`, `README.md`, godoc, Helm values)
- [x] Wiki pages updated if user-facing behaviour changed

`docs/Troubleshooting-Wiki.md` gained the two edition-gated filters under "An author has far fewer books than they should after a refresh", which listed only the language filters before. No env vars, Helm values or API surface changed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./internal/...`
- [x] New tests verified failing on `origin/main` behaviour, not just passing here. With the paging loop reverted to the old single `limit=50` request:

```
--- FAIL: TestGetEditions_HTTP_ReturnsEveryEdition
    got 50 editions, want all 139
--- FAIL: TestGetEditions_HTTP_PagesBeyondOneRequest
    got 50 editions, want 450
--- FAIL: TestGetEditions_HTTP_StopsAtPaginationCap
    got 200 editions, want the cap of 1000
```

and with the change in place, the same run:

```
--- PASS: TestGetEditions_HTTP_ReturnsEveryEdition
--- PASS: TestGetEditions_HTTP_PagesBeyondOneRequest
--- PASS: TestGetEditions_HTTP_SmallWorkCostsOneRequest
--- PASS: TestGetEditions_HTTP_StopsAtPaginationCap
--- PASS: TestGetEditions_HTTP_LaterPageFailureKeepsWhatWeHave
--- PASS: TestGetEditions_HTTP_FirstPageFailureIsAnError
```

`TestGetEditions_HTTP_SmallWorkCostsOneRequest` is the guard in the other direction: a work that fits in one response must not start costing two.

No `web/` changes, so no frontend suites were run.

## Notes for the reviewer

New tests live in `internal/metadata/openlibrary/editions_pagination_test.go` rather than in `client_http_test.go`, which open PR #2189 is editing, so the two rebase cleanly. This branch is off `origin/main` at 300e38a6 and touches no line either #2189 or #2182 touches.
