### PR TITLE
fix(downloader): reject a URL in a download client's Host field (#2203)

### DIFF
--- a/changelog.d/2203-download-client-host-validation.md
+++ b/changelog.d/2203-download-client-host-validation.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Download client Host field rejects a pasted URL instead of saving something that cannot work** (#2203). Pasting a value like `192.168.1.50:8080/#/` out of a browser address bar used to save fine and test green, then fail on every poll with `invalid character '<' looking for beginning of value`. Bindery now says which part of the value belongs in the Port field and which belongs in URL Base, fails **Test** for a client already saved with one, and marks it unhealthy in the client list.
+- **qBittorrent errors say what came back** (#2203). A response that is not JSON is now reported as an HTML page from the WebUI, along with the two settings that route a request away from the API, rather than as a JSON parser message about a stray `<`.
+- **IPv6 download client hosts work in both spellings** (#2203). `::1` and `[::1]` now reach the same address whichever client type you use; previously each spelling worked for only half of them.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -423,6 +423,21 @@ If a same-host service still isn't reachable, the usual cause is that the servic
 
 **Outbound proxy interaction.** When `BINDERY_OUTBOUND_PROXY` is set, in-scope requests are dialled to the proxy and the proxy resolves the destination, so the destination-URL SSRF validation still runs up front. The per-connection dial re-check (the DNS-rebind guard) can then only see the proxy's own address, not the target's — so for the strict-policy cover-image proxy that re-check is skipped whenever a proxy is configured; otherwise it would reject a LAN/loopback proxy and block every cover fetch. Local destinations skip the proxy entirely per `BINDERY_OUTBOUND_PROXY_BYPASS_LOCAL` (see [Environment variables](#environment-variables)), which is also what keeps a LAN indexer manager (Jackett/Prowlarr) reachable.
 
+### What goes in a download client's Host field
+
+Host takes a hostname or an IP address and nothing else. The scheme comes from the **Use SSL** checkbox, the port from the **Port** box beside it, and any reverse proxy prefix from **URL Base**. A URL copied out of a browser address bar carries all three, so Bindery rejects it on save rather than storing a value that cannot work (#2203):
+
+| Typed into Host | Rejected because | Enter instead |
+|---|---|---|
+| `192.168.1.50:8080/#/` | it carries a port and a path | Host `192.168.1.50`, Port `8080` |
+| `192.168.1.50:8080` | it carries a port | Host `192.168.1.50`, Port `8080` |
+| `192.168.1.50/qbittorrent` | it carries a reverse proxy path | Host `192.168.1.50`, URL Base `/qbittorrent` |
+| `admin:secret@192.168.1.50` | it carries credentials | Host `192.168.1.50`, plus the Username and Password fields |
+
+Two inputs are cleaned up rather than rejected, because neither changes where the request goes: a leading `http://` or `https://`, and a single trailing slash.
+
+IPv6 works in either spelling. `::1` and `[::1]` are both accepted and both reach the same address.
+
 ### Running Bindery behind a VPN (network_mode: service:*)
 
 When Bindery shares a VPN container's network namespace (for example `network_mode: service:gluetun`), all of Bindery's outbound traffic egresses through the VPN. gluetun's killswitch firewall blocks LAN bound traffic by default, so "Test connection" to on LAN services (Audiobookshelf, Calibre, download clients) times out with `Client.Timeout exceeded while awaiting headers`, even though those same services load fine from a browser on the LAN. That contrast is the tell: the browser reaches the service directly because it is on the LAN, but Bindery is inside the VPN namespace and its LAN bound requests are dropped by the killswitch.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -90,6 +90,22 @@ This happened on Bindery **1.22.1 and earlier**: Bindery sent the category **and
 
 **Fix:** upgrade to the current release. Bindery now enables auto_tmm and omits the explicit save path whenever a category is set, so qBittorrent places files at the category's configured save path (the source of truth for Bindery's health checks). On an older version, work around it by enabling **Automatic Torrent Management** for the category in qBittorrent, or by setting the category's save path to match Bindery's download root.
 
+## A download client tests fine but every poll logs "invalid character '<'"
+
+```
+qBittorrent category path check failed: decode categories: invalid character '<' looking for beginning of value
+```
+
+The client answered with a web page where Bindery expected JSON. Almost always the **Host** field holds more than a hostname, so every API request lands on the client's own web UI index page instead of its API. That page is served with a perfectly healthy HTTP 200, which is why **Test** used to report the connection verified: something did answer.
+
+The value behind the message above was `192.168.1.50:8080/#/`, copied straight out of a browser address bar. Bindery appended its own port and path to it, so requests went to `http://192.168.1.50:8080/#/:8080/api/v2/...`, and the `#` threw away everything after it (#2203).
+
+**Fix:** open **Settings → Download clients**, edit the client, and leave a bare hostname or IP in Host. The port belongs in **Port**, a reverse proxy prefix belongs in **URL Base**, and `https` is the **Use SSL** checkbox. See [What goes in a download client's Host field](./DEPLOYMENT.md#what-goes-in-a-download-clients-host-field) for the full table.
+
+Current releases refuse to save a Host like that, fail **Test** with a message naming the port and path to move, and turn the client's health dot red, so a client carried over from an older version reports the problem the moment you press Test rather than at the next poll.
+
+If Host is already a bare hostname and the message persists, something in front of the client is serving its own page: check that **URL Base** matches the path your reverse proxy serves the client on.
+
 ## The job stays in the download client after Bindery imports it
 
 The book imports fine and shows **Imported** in the Queue, but the job is still sitting in SABnzbd's history (or NZBGet's, or still listed in your torrent client). Once Bindery has taken ownership of the files it asks the client to forget the job, and the client is allowed to say no.

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -6,29 +6,42 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader"
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/telemetry"
 )
 
-// sanitizeHost strips any scheme prefix a user may have accidentally included
-// (e.g. "http://192.168.1.50" → "192.168.1.50"). The Host field expects a
-// bare hostname or IP; the scheme is determined by the UseSSL flag.
-func sanitizeHost(host string) string {
-	if after, ok := strings.CutPrefix(host, "https://"); ok {
-		return after
+// sanitizeHost normalises a submitted Host field, or reports why it cannot be
+// used. It strips a scheme prefix a user may have accidentally included
+// (e.g. "http://192.168.1.50" → "192.168.1.50") and rejects a value that
+// carries a port, a path, a query or a fragment: the Host field expects a
+// bare hostname or IP, the scheme comes from the UseSSL flag, the port from
+// the Port field and any reverse-proxy prefix from URLBase.
+//
+// Until #2203 everything but the scheme prefix was kept verbatim, so a URL
+// pasted out of a browser address bar was stored whole and then interpolated
+// into another URL. See clienthost.Normalize for what that produced.
+func sanitizeHost(host string) (string, error) {
+	return clienthost.Normalize(host)
+}
+
+// applyHostToClient normalises c.Host in place and writes the 400 that names
+// the problem when it cannot be used. Reports whether the caller may proceed.
+func applyHostToClient(w http.ResponseWriter, c *models.DownloadClient) bool {
+	host, err := sanitizeHost(c.Host)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return false
 	}
-	if after, ok := strings.CutPrefix(host, "http://"); ok {
-		return after
-	}
-	return host
+	c.Host = host
+	return true
 }
 
 // downloadClientURL assembles the effective URL that would be hit for a
@@ -42,7 +55,7 @@ func downloadClientURL(c *models.DownloadClient) string {
 	if port == 0 {
 		port = 8080
 	}
-	return fmt.Sprintf("%s://%s:%d/", scheme, c.Host, port)
+	return fmt.Sprintf("%s://%s/", scheme, clienthost.Authority(c.Host, port))
 }
 
 type DownloadClientHandler struct {
@@ -146,7 +159,9 @@ func (h *DownloadClientHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and host required"})
 		return
 	}
-	c.Host = sanitizeHost(c.Host)
+	if !applyHostToClient(w, &c) {
+		return
+	}
 	if c.Type == "" {
 		c.Type = "sabnzbd"
 	}
@@ -185,7 +200,9 @@ func (h *DownloadClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if c.Host != "" {
-		c.Host = sanitizeHost(c.Host)
+		if !applyHostToClient(w, &c) {
+			return
+		}
 		if err := httpsec.ValidateOutboundURL(downloadClientURL(&c), httpsec.PolicyLANLoopback); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -228,6 +245,15 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 	client, err := h.clients.GetByID(r.Context(), id)
 	if err != nil || client == nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download client not found"})
+		return
+	}
+	// Re-check the stored Host. Clients saved before #2203 were never
+	// validated, and a Host that carries a port or a path still reaches a web
+	// server, so the connection probe below happily reports success for a
+	// client that can never return JSON. Failing here is the only way an
+	// operator learns which field to fix.
+	if _, err := sanitizeHost(client.Host); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
 	if err := httpsec.ValidateOutboundURL(downloadClientURL(client), httpsec.PolicyLANLoopback); err != nil {
@@ -276,7 +302,9 @@ func (h *DownloadClientHandler) TestConfig(w http.ResponseWriter, r *http.Reques
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "host required"})
 		return
 	}
-	c.Host = sanitizeHost(c.Host)
+	if !applyHostToClient(w, &c) {
+		return
+	}
 	if c.Type == "" {
 		c.Type = "sabnzbd"
 	}

--- a/internal/api/download_clients_test.go
+++ b/internal/api/download_clients_test.go
@@ -426,3 +426,157 @@ func TestDownloadClientHandler_LifetimeCtxFallsBackToBackground(t *testing.T) {
 		t.Error("WithLifetimeCtx(nil) must not clobber a previously installed ctx")
 	}
 }
+
+// TestDownloadClientCreate_RejectsMalformedHost covers #2203: a Host copied
+// out of a browser address bar was stored whole, interpolated into
+// "http://<host>:<port>/" and then quietly reached the client's web UI
+// instead of its API. Every rejection has to name the field to fix.
+func TestDownloadClientCreate_RejectsMalformedHost(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		host     string
+		contains []string
+	}{
+		// The exact value from the report.
+		{"address bar paste", "10.1.2.3:8080/#/", []string{"a port and a path", "8080 as the port"}},
+		{"embedded port", "10.1.2.3:9091", []string{"a port", "9091 as the port"}},
+		{"trailing path", "10.1.2.3/qbittorrent", []string{"a path"}},
+		{"fragment", "10.1.2.3#/downloads", []string{"a fragment"}},
+		{"credentials", "admin:pw@10.1.2.3", []string{"Username and Password"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, clients := downloadClientFixture(t)
+			body, err := json.Marshal(map[string]any{"name": "qBit", "type": "qbittorrent", "host": tc.host, "port": 8080})
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec := httptest.NewRecorder()
+			h.Create(rec, httptest.NewRequest(http.MethodPost, "/downloadclient", bytes.NewReader(body)))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(rec.Body.String(), want) {
+					t.Errorf("response %s does not mention %q", rec.Body.String(), want)
+				}
+			}
+			list, err := clients.List(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(list) != 0 {
+				t.Errorf("rejected client was saved anyway: %+v", list)
+			}
+		})
+	}
+}
+
+// TestDownloadClientCreate_AcceptsPlainHosts guards the other direction: the
+// host forms a working install already holds must still save, with only the
+// scheme prefix and a lone trailing slash removed.
+func TestDownloadClientCreate_AcceptsPlainHosts(t *testing.T) {
+	for _, tc := range []struct{ name, host, want string }{
+		{"ip", "10.1.2.3", "10.1.2.3"},
+		{"http prefix", "http://10.1.2.3", "10.1.2.3"},
+		{"https prefix", "https://10.1.2.3", "10.1.2.3"},
+		{"trailing slash", "10.1.2.3/", "10.1.2.3"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, clients := downloadClientFixture(t)
+			body, err := json.Marshal(map[string]any{"name": "qBit", "type": "qbittorrent", "host": tc.host, "port": 8080})
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec := httptest.NewRecorder()
+			h.Create(rec, httptest.NewRequest(http.MethodPost, "/downloadclient", bytes.NewReader(body)))
+			if rec.Code != http.StatusCreated {
+				t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+			}
+			list, err := clients.List(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(list) != 1 || list[0].Host != tc.want {
+				t.Fatalf("stored host = %+v, want %q", list, tc.want)
+			}
+		})
+	}
+}
+
+func TestDownloadClientUpdate_RejectsMalformedHost(t *testing.T) {
+	h, clients := downloadClientFixture(t)
+	ctx := context.Background()
+	client := &models.DownloadClient{Name: "qBit", Type: "qbittorrent", Host: "10.1.2.3", Port: 8080, Enabled: true}
+	if err := clients.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"name":"qBit","type":"qbittorrent","host":"10.1.2.3:8080/#/","port":8080}`
+	rec := httptest.NewRecorder()
+	h.Update(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/downloadclient/1", bytes.NewBufferString(body)), "id", "1"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := clients.GetByID(ctx, client.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Host != "10.1.2.3" {
+		t.Errorf("host was overwritten with a rejected value: %q", got.Host)
+	}
+}
+
+// TestDownloadClientTest_RejectsSavedBadHost is the reporter's other
+// complaint: the client had already been saved (before this validation
+// existed), so Test is the only place left that can tell them what is wrong.
+// It used to report "Connection verified" because the malformed URL still
+// reached qBittorrent's web UI.
+func TestDownloadClientTest_RejectsSavedBadHost(t *testing.T) {
+	h, clients := downloadClientFixture(t)
+	// Written through the repo, not the handler, so it stands in for a row
+	// saved by an earlier version.
+	client := &models.DownloadClient{Name: "qBit", Type: "qbittorrent", Host: "10.1.2.3:8080/#/", Port: 8080, Enabled: true}
+	if err := clients.Create(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/downloadclient/1/test", nil), "id", "1"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "8080 as the port") {
+		t.Errorf("response %s does not say which field to fix", rec.Body.String())
+	}
+}
+
+// TestDownloadClientTestConfig_RejectsMalformedHost covers the inline Test
+// button on the add/edit form, which probes an unsaved configuration.
+func TestDownloadClientTestConfig_RejectsMalformedHost(t *testing.T) {
+	h, _ := downloadClientFixture(t)
+	body := `{"name":"qBit","type":"qbittorrent","host":"10.1.2.3:8080/#/","port":8080}`
+	rec := httptest.NewRecorder()
+	h.TestConfig(rec, httptest.NewRequest(http.MethodPost, "/downloadclient/test", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "hostname or IP address only") {
+		t.Errorf("response %s does not explain the host", rec.Body.String())
+	}
+}
+
+// TestDownloadClientURL_IPv6 checks the SSRF pre-check URL is well formed for
+// both spellings of an IPv6 literal the Host field accepts. Before #2203 the
+// bare form produced "http://::1:8080/", which is not a URL at all.
+func TestDownloadClientURL_IPv6(t *testing.T) {
+	for _, tc := range []struct{ host, want string }{
+		{"::1", "http://[::1]:8080/"},
+		{"[::1]", "http://[::1]:8080/"},
+		{"10.1.2.3", "http://10.1.2.3:8080/"},
+	} {
+		got := downloadClientURL(&models.DownloadClient{Host: tc.host, Port: 8080})
+		if got != tc.want {
+			t.Errorf("downloadClientURL(%q) = %q, want %q", tc.host, got, tc.want)
+		}
+	}
+}

--- a/internal/downloader/clienthost/clienthost.go
+++ b/internal/downloader/clienthost/clienthost.go
@@ -1,0 +1,201 @@
+// Package clienthost validates and renders the Host field of a download-client
+// connection.
+package clienthost
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// ErrEmpty reports a Host field that is blank once trimmed.
+var ErrEmpty = errors.New("host is required")
+
+// invalidHostChars are the characters that cannot appear in the reg-name of a
+// URL authority once the scheme, userinfo, port and path have been split off.
+// A denylist rather than an allowlist on purpose: the set of hostnames that
+// already work in the field is wide (Docker service names carry underscores,
+// internal domains carry whatever a resolver accepts) and a stricter rule
+// would reject saved connections that work today.
+const invalidHostChars = " \t\r\n\v\f/?#@:[]\\%\"'<>{}|^`"
+
+// Normalize returns the value to store in a download client's Host field, or
+// an error naming what is wrong with what was typed.
+//
+// Host is a bare hostname or IP address. The scheme comes from the Use SSL
+// flag, the port from the Port field and any reverse-proxy prefix from URL
+// Base, so a Host that carries those inline is rejected rather than
+// reinterpreted: the Port field is visibly populated on the same form, and
+// silently overriding it with a number lifted out of another field is a worse
+// outcome than an error saying which box to move it to.
+//
+// #2203 is what nothing checking costs. "1.2.3.4:8080/#/" pasted from a
+// browser address bar became "http://1.2.3.4:8080/#/:8080/", whose fragment
+// swallowed the API path, so every request landed on the qBittorrent WebUI's
+// index page instead. The Test button reported success and the failure only
+// surfaced later, in the poller, as "invalid character '<' looking for
+// beginning of value".
+//
+// Two inputs are normalised instead of rejected because neither is ambiguous:
+// a leading "http://" or "https://", which the form already asks operators to
+// leave out, and a single trailing slash, which carries nothing. An IPv6
+// literal is accepted in either the bare ("::1") or bracketed ("[::1]") form
+// and returned as written; Authority renders both correctly.
+func Normalize(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", ErrEmpty
+	}
+
+	rest := trimmed
+	if i := strings.Index(rest, "://"); i >= 0 {
+		switch scheme := strings.ToLower(rest[:i]); scheme {
+		case "http", "https":
+			rest = rest[i+3:]
+		default:
+			return "", fmt.Errorf("host must be a hostname or IP address, not a URL: %q starts with a scheme Bindery cannot use. Use the Use SSL checkbox to choose between http and https", trimmed)
+		}
+	}
+	if strings.Contains(rest, "@") {
+		return "", fmt.Errorf("host must be a hostname or IP address only: %q includes a username. Put credentials in the Username and Password fields", trimmed)
+	}
+
+	authority, extra := cutExtra(rest)
+	host, port, err := splitPort(authority, trimmed)
+	if err != nil {
+		return "", err
+	}
+	if err := checkHost(host, trimmed); err != nil {
+		return "", err
+	}
+
+	var problems []string
+	if port != "" {
+		problems = append(problems, "a port")
+	}
+	if extra != "" {
+		problems = append(problems, describeExtra(extra))
+	}
+	if len(problems) == 0 {
+		return host, nil
+	}
+
+	advice := ""
+	if port != "" {
+		advice = fmt.Sprintf(" and %s as the port", port)
+	}
+	return "", fmt.Errorf("host must be a hostname or IP address only, with no port and no path: %q includes %s. Use %q as the host%s",
+		trimmed, strings.Join(problems, " and "), host, advice)
+}
+
+// Authority renders host and port as a URL authority, bracketing an IPv6
+// literal exactly once whichever form the Host field holds. Stored hosts
+// predate any single convention: the field has accepted "::1" and "[::1]"
+// alike, and the two spellings broke on opposite halves of the codebase,
+// because fmt.Sprintf("%s:%d") needs the brackets while net.JoinHostPort adds
+// a second pair to a host that already carries them.
+func Authority(host string, port int) string {
+	return net.JoinHostPort(Unbracket(strings.TrimSpace(host)), strconv.Itoa(port))
+}
+
+// Unbracket strips the brackets from an IPv6 literal, leaving every other
+// host untouched.
+func Unbracket(host string) string {
+	if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {
+		return host[1 : len(host)-1]
+	}
+	return host
+}
+
+// cutExtra splits an authority from whatever path, query or fragment follows
+// it. A lone trailing slash is dropped rather than reported: "10.0.0.5/" and
+// "10.0.0.5" are the same address, and browsers append the slash themselves.
+func cutExtra(s string) (authority, extra string) {
+	i := strings.IndexAny(s, "/?#")
+	if i < 0 {
+		return s, ""
+	}
+	if s[i:] == "/" {
+		return s[:i], ""
+	}
+	return s[:i], s[i:]
+}
+
+// splitPort separates a trailing ":port" from the host. An IPv6 literal is
+// the reason this cannot be a plain LastIndex on ":": "::1" is a whole
+// address, not a host of ":" and a port of "1".
+func splitPort(authority, original string) (host, port string, err error) {
+	if authority == "" {
+		return "", "", ErrEmpty
+	}
+	if strings.HasPrefix(authority, "[") {
+		end := strings.Index(authority, "]")
+		if end < 0 || net.ParseIP(authority[1:end]) == nil {
+			return "", "", fmt.Errorf("host must be a hostname or IP address: %q is not a valid bracketed IPv6 address", original)
+		}
+		switch tail := authority[end+1:]; {
+		case tail == "":
+			return authority, "", nil
+		case strings.HasPrefix(tail, ":") && validPort(tail[1:]):
+			return authority[:end+1], tail[1:], nil
+		default:
+			return "", "", fmt.Errorf("host must be a hostname or IP address: %q is not a valid bracketed IPv6 address", original)
+		}
+	}
+	// A bare IPv6 literal, colons and all.
+	if net.ParseIP(authority) != nil {
+		return authority, "", nil
+	}
+	i := strings.LastIndex(authority, ":")
+	if i < 0 {
+		return authority, "", nil
+	}
+	if !validPort(authority[i+1:]) {
+		return "", "", fmt.Errorf("host must be a hostname or IP address only: %q is neither", original)
+	}
+	return authority[:i], authority[i+1:], nil
+}
+
+// validPort reports whether s is a decimal port number in range.
+func validPort(s string) bool {
+	if s == "" || len(s) > 5 {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	n, err := strconv.Atoi(s)
+	return err == nil && n > 0 && n <= 65535
+}
+
+// checkHost rejects a reg-name that cannot survive being placed in a URL
+// authority.
+func checkHost(host, original string) error {
+	if strings.HasPrefix(host, "[") {
+		return nil // already validated as a bracketed IPv6 literal
+	}
+	if net.ParseIP(host) != nil {
+		return nil // an IP literal, colons and all
+	}
+	if host == "" || strings.Trim(host, ".") == "" || strings.ContainsAny(host, invalidHostChars) {
+		return fmt.Errorf("host must be a hostname or IP address only: %q is neither", original)
+	}
+	return nil
+}
+
+// describeExtra names the trailing component in the words an operator sees in
+// their own address bar.
+func describeExtra(extra string) string {
+	switch extra[0] {
+	case '#':
+		return "a fragment"
+	case '?':
+		return "a query string"
+	default:
+		return "a path"
+	}
+}

--- a/internal/downloader/clienthost/clienthost_test.go
+++ b/internal/downloader/clienthost/clienthost_test.go
@@ -1,0 +1,156 @@
+package clienthost
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNormalize_Accepted covers everything a working install may already hold
+// in the Host field. Every one of these must survive untouched (or, for the
+// two unambiguous normalisations, survive with only the noise removed) —
+// rejecting any of them would break a connection that works today.
+func TestNormalize_Accepted(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare hostname", "qbittorrent", "qbittorrent"},
+		{"docker service name", "qbittorrent_vpn", "qbittorrent_vpn"},
+		{"fqdn", "qbit.home.arpa", "qbit.home.arpa"},
+		{"fqdn with root dot", "qbit.home.arpa.", "qbit.home.arpa."},
+		{"ipv4", "192.168.1.50", "192.168.1.50"},
+		{"ipv6 bracketed", "[::1]", "[::1]"},
+		{"ipv6 bare loopback", "::1", "::1"},
+		{"ipv6 bare global", "fd00::1", "fd00::1"},
+		{"http scheme stripped", "http://192.168.1.50", "192.168.1.50"},
+		{"https scheme stripped", "https://qbit.home.arpa", "qbit.home.arpa"},
+		{"scheme case insensitive", "HTTP://192.168.1.50", "192.168.1.50"},
+		{"trailing slash dropped", "192.168.1.50/", "192.168.1.50"},
+		{"scheme and trailing slash", "http://192.168.1.50/", "192.168.1.50"},
+		{"surrounding whitespace", "  192.168.1.50  ", "192.168.1.50"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Normalize(tc.in)
+			if err != nil {
+				t.Fatalf("Normalize(%q) returned error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("Normalize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalize_Rejected covers the values that cannot work. Each case checks
+// the message names what is wrong and, where there is one, the value to move
+// into the Port field — a rejection that does not say which box to edit is
+// only marginally better than the decode error it replaces.
+func TestNormalize_Rejected(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		in       string
+		contains []string
+	}{
+		{
+			// The exact string from #2203, copied out of a browser address bar.
+			name:     "address bar paste",
+			in:       "10.1.2.3:8080/#/",
+			contains: []string{"a port and a path", `"10.1.2.3"`, "8080 as the port"},
+		},
+		{
+			name:     "embedded port",
+			in:       "192.168.1.50:8080",
+			contains: []string{"a port", `"192.168.1.50"`, "8080 as the port"},
+		},
+		{
+			name:     "scheme and embedded port",
+			in:       "http://192.168.1.50:9091",
+			contains: []string{"a port", "9091 as the port"},
+		},
+		{
+			name:     "path",
+			in:       "192.168.1.50/qbittorrent",
+			contains: []string{"a path", `"192.168.1.50"`},
+		},
+		{
+			name:     "fragment",
+			in:       "192.168.1.50#/downloads",
+			contains: []string{"a fragment"},
+		},
+		{
+			name:     "query string",
+			in:       "192.168.1.50?v=2",
+			contains: []string{"a query string"},
+		},
+		{
+			name:     "bracketed ipv6 with port",
+			in:       "[fd00::1]:8080",
+			contains: []string{"a port", `"[fd00::1]"`, "8080 as the port"},
+		},
+		{
+			name:     "unsupported scheme",
+			in:       "ftp://192.168.1.50",
+			contains: []string{"not a URL"},
+		},
+		{
+			name:     "credentials",
+			in:       "admin:hunter2@192.168.1.50",
+			contains: []string{"Username and Password"},
+		},
+		{
+			name:     "space in hostname",
+			in:       "my qbit box",
+			contains: []string{"hostname or IP address only"},
+		},
+		{
+			name:     "empty",
+			in:       "   ",
+			contains: []string{"host is required"},
+		},
+		{
+			name:     "colon without a valid port",
+			in:       "192.168.1.50:notaport",
+			contains: []string{"hostname or IP address only"},
+		},
+		{
+			name:     "port out of range",
+			in:       "192.168.1.50:99999",
+			contains: []string{"hostname or IP address only"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Normalize(tc.in)
+			if err == nil {
+				t.Fatalf("Normalize(%q) = %q, want an error", tc.in, got)
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Normalize(%q) error = %q, want it to contain %q", tc.in, err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestAuthority checks that both spellings of an IPv6 literal render to the
+// one form a URL accepts, and that nothing else grows brackets.
+func TestAuthority(t *testing.T) {
+	for _, tc := range []struct {
+		host string
+		port int
+		want string
+	}{
+		{"qbittorrent", 8080, "qbittorrent:8080"},
+		{"192.168.1.50", 9091, "192.168.1.50:9091"},
+		{"::1", 8080, "[::1]:8080"},
+		{"[::1]", 8080, "[::1]:8080"},
+		{"fd00::1", 8112, "[fd00::1]:8112"},
+		{"[fd00::1]", 8112, "[fd00::1]:8112"},
+		{" 192.168.1.50 ", 8080, "192.168.1.50:8080"},
+	} {
+		if got := Authority(tc.host, tc.port); got != tc.want {
+			t.Errorf("Authority(%q, %d) = %q, want %q", tc.host, tc.port, got, tc.want)
+		}
+	}
+}

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 	"github.com/vavallee/bindery/internal/httpsec"
@@ -72,7 +73,7 @@ func New(host string, port int, password, urlBase string, useSSL bool) *Client {
 	}
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:        fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		baseURL:        fmt.Sprintf("%s://%s%s", scheme, clienthost.Authority(host, port), urlbase.Normalize(urlBase)),
 		password:       password,
 		http:           &http.Client{Timeout: 15 * time.Second, Jar: jar},
 		fetchTransport: httpsec.GuardedTransport(httpsec.DownloadFetchPolicy()),

--- a/internal/downloader/health.go
+++ b/internal/downloader/health.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/jobs"
 	"github.com/vavallee/bindery/internal/models"
@@ -178,6 +179,13 @@ func RefreshDownloadClientHealthAsync(parent context.Context, g *jobs.Group, sto
 func CheckDownloadClientHealth(ctx context.Context, client *models.DownloadClient, downloadDir, audiobookDownloadDir, globalRemap string) models.DownloadClientHealth {
 	if client == nil {
 		return models.DownloadClientHealth{Status: HealthUnknown, Message: "No download client to check"}
+	}
+	// A Host that carries a port or a path cannot work for any client type,
+	// but it still reaches a web server, so every probe below would report a
+	// healthy connection to the wrong endpoint. Clients saved before the
+	// validation added for #2203 are the ones that reach here.
+	if _, err := clienthost.Normalize(client.Host); err != nil {
+		return models.DownloadClientHealth{Status: HealthError, Message: err.Error()}
 	}
 	if client.Type == "qbittorrent" {
 		return checkQbittorrentCategoryPath(ctx, client, downloadDir, audiobookDownloadDir)

--- a/internal/downloader/health_test.go
+++ b/internal/downloader/health_test.go
@@ -373,3 +373,30 @@ func TestHealthStore_Set_NilNotifierDoesNotPanic(t *testing.T) {
 	s := NewHealthStore()
 	s.Set(1, models.DownloadClientHealth{Status: HealthError, Message: "broken"})
 }
+
+// TestCheckDownloadClientHealth_MalformedHost covers a client saved before the
+// Host validation added for #2203. Every probe below the check would connect
+// to something (the malformed URL still reaches a web server), so without
+// this the client list keeps showing a healthy dot for a client that can
+// never import anything.
+func TestCheckDownloadClientHealth_MalformedHost(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		host string
+	}{
+		{"port and path", "10.1.2.3:8080/#/"},
+		{"embedded port", "10.1.2.3:9091"},
+		{"path", "10.1.2.3/qbittorrent"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &models.DownloadClient{Name: "qBit", Type: "qbittorrent", Host: tc.host, Port: 8080, Enabled: true}
+			health := CheckDownloadClientHealth(context.Background(), client, t.TempDir(), "", "")
+			if health.Status != HealthError {
+				t.Fatalf("status = %q, want %q (message %q)", health.Status, HealthError, health.Message)
+			}
+			if !strings.Contains(health.Message, "hostname or IP address") {
+				t.Errorf("message %q does not explain the Host field", health.Message)
+			}
+		})
+	}
+}

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/nzbfetch"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
@@ -51,7 +52,7 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 		scheme = "https"
 	}
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d%s/jsonrpc", scheme, host, port, urlbase.Normalize(urlBase)),
+		baseURL:  fmt.Sprintf("%s://%s%s/jsonrpc", scheme, clienthost.Authority(host, port), urlbase.Normalize(urlBase)),
 		username: username,
 		password: password,
 		http:     &http.Client{Timeout: 15 * time.Second},

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 	"github.com/vavallee/bindery/internal/httpsec"
@@ -89,7 +90,7 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:        fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		baseURL:        fmt.Sprintf("%s://%s%s", scheme, clienthost.Authority(host, port), urlbase.Normalize(urlBase)),
 		username:       username,
 		password:       password,
 		http:           &http.Client{Timeout: 15 * time.Second, Jar: jar},
@@ -154,13 +155,18 @@ func (c *Client) Login(ctx context.Context) error {
 // responded but rejected us) get a targeted hint; transport failures (the
 // server didn't respond at all) get a hint based on the error class.
 func (c *Client) Test(ctx context.Context) error {
-	if _, err := c.get(ctx, "/api/v2/app/version"); err != nil {
+	body, err := c.get(ctx, "/api/v2/app/version")
+	if err != nil {
 		var authErr *AuthError
 		if errors.As(err, &authErr) {
 			// Server responded — this is an auth/config issue, not unreachable.
 			return fmt.Errorf("connected to qBittorrent at %s but %w", c.baseURL, err)
 		}
 		return fmt.Errorf("could not reach qBittorrent at %s — %w%s", c.baseURL, err, nethint.ForErr(err))
+	}
+	// Something answered, but not necessarily the API. See checkVersionBody.
+	if err := checkVersionBody(body); err != nil {
+		return fmt.Errorf("connected to %s but %w", c.baseURL, err)
 	}
 	return nil
 }
@@ -593,8 +599,8 @@ func (c *Client) GetTorrents(ctx context.Context, category string) ([]Torrent, e
 	}
 
 	var torrents []Torrent
-	if err := json.Unmarshal(data, &torrents); err != nil {
-		return nil, fmt.Errorf("decode torrents: %w", err)
+	if err := decodeJSON("torrents", data, &torrents); err != nil {
+		return nil, err
 	}
 	// Windows-qBit reports paths with backslashes; downstream Linux path code
 	// (filepath.Walk, PathRemap.Apply, pathIsAtOrUnder) can't process them.
@@ -614,8 +620,8 @@ func (c *Client) GetCategories(ctx context.Context) (map[string]Category, error)
 		return nil, err
 	}
 	var categories map[string]Category
-	if err := json.Unmarshal(data, &categories); err != nil {
-		return nil, fmt.Errorf("decode categories: %w", err)
+	if err := decodeJSON("categories", data, &categories); err != nil {
+		return nil, err
 	}
 	for name, category := range categories {
 		if category.Name == "" {
@@ -654,8 +660,8 @@ func (c *Client) Files(ctx context.Context, hash string) ([]File, error) {
 		return nil, err
 	}
 	var files []rpcFile
-	if err := json.Unmarshal(data, &files); err != nil {
-		return nil, fmt.Errorf("decode torrent files: %w", err)
+	if err := decodeJSON("torrent files", data, &files); err != nil {
+		return nil, err
 	}
 	out := make([]File, 0, len(files))
 	for _, f := range files {

--- a/internal/downloader/qbittorrent/decode.go
+++ b/internal/downloader/qbittorrent/decode.go
@@ -1,0 +1,109 @@
+package qbittorrent
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// snippetLimit caps how much of an unrecognised body is quoted back.
+const snippetLimit = 80
+
+// decodeJSON unmarshals a WebUI response into out, replacing the parser's own
+// error with a description of what actually arrived when the body was never
+// JSON to begin with.
+//
+// Same treatment #2128 gave Hardcover's error pages and #2105 gave NZB
+// fetches: a body the parser cannot even start on is a routing problem, not a
+// schema problem, and "invalid character '<' looking for beginning of value"
+// names neither. The case that prompted this (#2203) was a Host field holding
+// "1.2.3.4:8080/#/", whose fragment swallowed the API path so every call came
+// back with the WebUI's own HTML index page.
+//
+// A body that parsed as JSON but did not fit the expected shape keeps the
+// parser's message, which is the useful one there.
+func decodeJSON(what string, data []byte, out any) error {
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decode %s: %s", what, describeDecodeFailure(data, err))
+	}
+	return nil
+}
+
+// describeDecodeFailure explains a failed decode in terms of the body rather
+// than the byte offset the parser stopped at.
+func describeDecodeFailure(data []byte, err error) string {
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		// Valid JSON, wrong shape. The parser's message names the field.
+		return err.Error()
+	}
+	trimmed := bytes.TrimSpace(data)
+	switch {
+	case len(trimmed) == 0:
+		return "qBittorrent returned an empty response body"
+	case isMarkup(trimmed):
+		return markupHint()
+	default:
+		return fmt.Sprintf("qBittorrent returned a non-JSON response starting %s", snippet(trimmed))
+	}
+}
+
+// markupHint is the message for a body that is a web page. It names the two
+// settings that route a request away from the API, because those are what the
+// operator can change.
+func markupHint() string {
+	return "qBittorrent returned an HTML page instead of JSON, which is what its WebUI serves for any URL outside the API. " +
+		"Check that the download client's Host is a bare hostname or IP with no port and no path in it, " +
+		"and that URL Base matches the path your reverse proxy serves qBittorrent on"
+}
+
+// isMarkup reports whether the body opens an HTML or XML document. The
+// leading angle bracket is the whole test: it is the byte the JSON parser
+// tripped on, and no JSON document starts with one.
+func isMarkup(trimmed []byte) bool {
+	return trimmed[0] == '<'
+}
+
+// snippet renders the head of an unrecognised body as a single quoted line,
+// with runs of whitespace and control characters collapsed so a log line
+// stays one line.
+func snippet(trimmed []byte) string {
+	var b strings.Builder
+	space := false
+	for _, r := range string(trimmed) {
+		if b.Len() >= snippetLimit {
+			break
+		}
+		if unicode.IsSpace(r) || !unicode.IsPrint(r) {
+			space = true
+			continue
+		}
+		if space && b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		space = false
+		b.WriteRune(r)
+	}
+	return fmt.Sprintf("%q", b.String())
+}
+
+// checkVersionBody reports whether the /api/v2/app/version response really
+// came from the API. It is the one probe the Test button makes, and the
+// endpoint answers in plain text, so nothing downstream would otherwise
+// notice that an HTML page came back with HTTP 200 instead — which is exactly
+// how the misconfigured Host in #2203 tested green and then failed on every
+// poll.
+func checkVersionBody(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	switch {
+	case len(trimmed) == 0:
+		return errors.New("it returned an empty response for the API version rather than a version string")
+	case isMarkup(trimmed):
+		return errors.New(markupHint())
+	default:
+		return nil
+	}
+}

--- a/internal/downloader/qbittorrent/decode_test.go
+++ b/internal/downloader/qbittorrent/decode_test.go
@@ -1,0 +1,154 @@
+package qbittorrent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// webuiIndex is what qBittorrent's WebUI serves for any URL outside its API,
+// which is what a Host field carrying a path or a fragment routes every
+// request to (#2203).
+const webuiIndex = `<!DOCTYPE html>
+<html lang="en">
+<head><title>qBittorrent Web UI</title></head>
+<body><div id="desktop"></div></body>
+</html>`
+
+// serveWebUIIndex is a stub that logs in successfully and then answers every
+// API path with the WebUI's own index page, HTTP 200 and all.
+func serveWebUIIndex() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			_, _ = w.Write([]byte("Ok."))
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(webuiIndex))
+	}))
+}
+
+// assertLegible checks that an error explains what came back instead of
+// quoting the parser's byte-level complaint, and that it does not paste the
+// page itself into the message.
+func assertLegible(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "invalid character '<'") {
+		t.Errorf("error still surfaces the raw parser message: %q", msg)
+	}
+	if strings.Contains(msg, "<html") || strings.Contains(msg, "<!DOCTYPE") {
+		t.Errorf("error pastes the HTML body into the message: %q", msg)
+	}
+	for _, want := range []string{"HTML page", "Host", "URL Base"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// TestGetTorrents_HTMLResponse is the poll-time symptom from #2203: the
+// scanner logged "decode torrents: invalid character '<' looking for
+// beginning of value" every 15 seconds and named nothing an operator could
+// act on.
+func TestGetTorrents_HTMLResponse(t *testing.T) {
+	srv := serveWebUIIndex()
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	_, err := c.GetTorrents(context.Background(), "books")
+	assertLegible(t, err)
+	if !strings.HasPrefix(err.Error(), "decode torrents: ") {
+		t.Errorf("lost the operation prefix: %q", err)
+	}
+}
+
+// TestGetCategories_HTMLResponse is the health-check symptom from the same
+// report: "qBittorrent category path check failed: decode categories: invalid
+// character '<' ...".
+func TestGetCategories_HTMLResponse(t *testing.T) {
+	srv := serveWebUIIndex()
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	_, err := c.GetCategories(context.Background())
+	assertLegible(t, err)
+	if !strings.HasPrefix(err.Error(), "decode categories: ") {
+		t.Errorf("lost the operation prefix: %q", err)
+	}
+}
+
+func TestFiles_HTMLResponse(t *testing.T) {
+	srv := serveWebUIIndex()
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	_, err := c.Files(context.Background(), "deadbeef")
+	assertLegible(t, err)
+}
+
+// TestTest_HTMLResponse is the half of #2203 the reporter found hardest to
+// believe: the Test button said the connection was verified while every poll
+// failed. /api/v2/app/version answers in plain text, so an HTML page came
+// back with HTTP 200 and nothing looked at it.
+func TestTest_HTMLResponse(t *testing.T) {
+	srv := serveWebUIIndex()
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	assertLegible(t, c.Test(context.Background()))
+}
+
+func TestTest_EmptyVersionResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			_, _ = w.Write([]byte("Ok."))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected Test to fail on an empty version response")
+	}
+	if !strings.Contains(err.Error(), "empty response") {
+		t.Errorf("error = %q, want it to mention an empty response", err)
+	}
+}
+
+// TestDescribeDecodeFailure_ShapeMismatchKeepsParserMessage guards the other
+// side of the rule: a body that really is JSON but does not fit the struct is
+// a schema problem, and the parser's message is the informative one there.
+func TestDescribeDecodeFailure_ShapeMismatchKeepsParserMessage(t *testing.T) {
+	var torrents []Torrent
+	err := decodeJSON("torrents", []byte(`{"error":"nope"}`), &torrents)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Errorf("error = %q, want the parser's type message", err)
+	}
+}
+
+// TestDescribeDecodeFailure_PlainTextSnippet checks the fallback for a
+// non-JSON, non-HTML body: a short quoted snippet, collapsed onto one line.
+func TestDescribeDecodeFailure_PlainTextSnippet(t *testing.T) {
+	var categories map[string]Category
+	err := decodeJSON("categories", []byte("Forbidden\n\nyour IP is banned"), &categories)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "\n") {
+		t.Errorf("snippet was not collapsed onto one line: %q", msg)
+	}
+	if !strings.Contains(msg, "Forbidden your IP is banned") {
+		t.Errorf("error = %q, want the body's opening text", err)
+	}
+}

--- a/internal/downloader/rtorrent/client.go
+++ b/internal/downloader/rtorrent/client.go
@@ -30,14 +30,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/downloader/infohash"
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
@@ -163,7 +162,7 @@ func buildRPCURL(scheme, host string, port int, urlBase string) (*url.URL, error
 	}
 	return &url.URL{
 		Scheme: scheme,
-		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+		Host:   clienthost.Authority(host, port),
 		Path:   path,
 	}, nil
 }

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/nzbfetch"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
@@ -40,7 +41,7 @@ func New(host string, port int, apiKey, urlBase string, useSSL bool) *Client {
 		scheme = "https"
 	}
 	return &Client{
-		baseURL: fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		baseURL: fmt.Sprintf("%s://%s%s", scheme, clienthost.Authority(host, port), urlbase.Normalize(urlBase)),
 		apiKey:  apiKey,
 		http:    &http.Client{Timeout: 15 * time.Second},
 		// fetchHTTP pulls indexer-controlled NZB URLs, so guard the dial: it

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -9,15 +9,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 	"github.com/vavallee/bindery/internal/httpsec"
@@ -484,7 +483,7 @@ func buildRPCURL(scheme, host string, port int, urlBase string) (*url.URL, error
 
 	return &url.URL{
 		Scheme: scheme,
-		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+		Host:   clienthost.Authority(host, port),
 		Path:   urlbase.Normalize(urlBase) + "/transmission/rpc",
 	}, nil
 }

--- a/internal/migrate/readarr.go
+++ b/internal/migrate/readarr.go
@@ -12,6 +12,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/downloader/clienthost"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -267,6 +268,15 @@ func importReadarrDownloadClients(ctx context.Context, src *sql.DB, repo *db.Dow
 			res.fail(name, "missing host")
 			continue
 		}
+		// Readarr stores whatever was typed into its own Host field, so an
+		// unusable value migrates across as-is and then fails at poll time
+		// rather than at import time (#2203). Fail the row instead, with the
+		// same message the Settings form gives.
+		host, err := clienthost.Normalize(s.Host)
+		if err != nil {
+			res.fail(name, err.Error())
+			continue
+		}
 
 		t, ok := downloadClientTypeFor(impl)
 		if !ok {
@@ -282,7 +292,7 @@ func importReadarrDownloadClients(ctx context.Context, src *sql.DB, repo *db.Dow
 		c := &models.DownloadClient{
 			Name:     name,
 			Type:     t,
-			Host:     s.Host,
+			Host:     host,
 			Port:     s.Port,
 			APIKey:   s.APIKey,
 			Username: s.Username,

--- a/internal/migrate/readarr_test.go
+++ b/internal/migrate/readarr_test.go
@@ -489,3 +489,51 @@ func TestImportReadarr_CatalogueFetchIsBoundedAndSurvivesCancellation(t *testing
 		t.Fatalf("max in-flight = %d, want in (0, %d]", max, catalogueFetchConcurrency)
 	}
 }
+
+// TestImportReadarrDownloadClients_MalformedHost covers the migration half of
+// #2203. Readarr stores whatever was typed into its own Host field, so a
+// value that cannot work crosses over intact and then fails at poll time
+// under a Bindery banner. Failing the row names the client and the problem
+// while the operator is still looking at the migration report.
+func TestImportReadarrDownloadClients_MalformedHost(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "readarr.db")
+	src, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	if _, err := src.Exec(`CREATE TABLE DownloadClients (Id INTEGER PRIMARY KEY, Name TEXT, Implementation TEXT, Settings TEXT, Enable INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	_, err = src.Exec(`INSERT INTO DownloadClients (Name, Implementation, Settings, Enable) VALUES
+		('Good', 'QBittorrent', ?, 1),
+		('Pasted', 'QBittorrent', ?, 1)`,
+		`{"host":"qbt.local","port":8080,"username":"u","password":"p"}`,
+		`{"host":"10.1.2.3:8080/#/","port":8080,"username":"u","password":"p"}`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	repo := db.NewDownloadClientRepo(database)
+
+	var res Result
+	if err := importReadarrDownloadClients(context.Background(), src, repo, &res); err != nil {
+		t.Fatalf("importReadarrDownloadClients: %v", err)
+	}
+	if res.Added != 1 || res.Errors != 1 {
+		t.Fatalf("Added=%d Errors=%d, want 1 and 1", res.Added, res.Errors)
+	}
+	clients, err := repo.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(clients) != 1 || clients[0].Name != "Good" {
+		t.Fatalf("imported clients = %+v, want only Good", clients)
+	}
+}


### PR DESCRIPTION
## Summary

A download client Host copied out of a browser address bar was stored verbatim, so `1.2.3.4:8080/#/` became `http://1.2.3.4:8080/#/:8080/`. The fragment swallowed the API path, every request landed on the client's WebUI index page (HTTP 200, HTML body), **Test** reported the connection verified, and the poller failed every 15 seconds with `invalid character '<' looking for beginning of value`. This validates the Host field everywhere it is accepted and makes a non JSON response from qBittorrent say what actually arrived. Thanks to @ThatDeltaGuy for reporting it and for self diagnosing the cause, which is what made the second half of this fix obvious.

Closes #2203.

## Reject or normalise

**Reject**, with two exceptions.

The form has a visibly populated **Port** box next to Host, pre filled per client type. Lifting a port out of the Host field means silently overriding a value the operator can see and did not touch, and when the two disagree there is no reading of intent that is not a guess. An error saying which box to move the number to costs one edit and leaves nothing ambiguous, so the message does the parsing work for them:

```
host must be a hostname or IP address only, with no port and no path:
"1.2.3.4:8080/#/" includes a port and a path. Use "1.2.3.4" as the host and 8080 as the port
```

The two things still normalised are the ones that carry no information: a leading `http://` or `https://` (the form already asks operators to omit it, and it was already stripped before this PR) and a single trailing slash. Neither changes where a request goes.

| Host | Result |
|---|---|
| `qbittorrent`, `qbit_vpn`, `10.1.2.3`, `qbit.home.arpa` | accepted unchanged |
| `http://10.1.2.3`, `10.1.2.3/` | accepted, cleaned |
| `10.1.2.3:8080` | rejected, names 8080 as the port to move |
| `10.1.2.3:8080/#/` | rejected, names the port and the path |
| `10.1.2.3/qbittorrent` | rejected, points at URL Base |
| `admin:pw@10.1.2.3` | rejected, points at Username and Password |

## IPv6

`::1` cannot be split on the last colon, so the parser checks `net.ParseIP` before looking for a port, and accepts both `::1` and `[::1]` as written rather than picking a canonical form. Storing one form would have rewritten existing rows for no gain, because both spellings were already in the field.

Both were also already half broken, in opposite directions. qBittorrent, SABnzbd, NZBGet and Deluge build their base URL with `fmt.Sprintf("%s://%s:%d")`, which needs the brackets; Transmission and rTorrent use `net.JoinHostPort`, which adds a second pair to a host that already has them. `clienthost.Authority` unbrackets and rejoins, so all six now render `[::1]:8080` from either input. That is a small scope addition, but validation that accepts `[::1]` while two client types still cannot use it would not have been a fix.

## Where the check runs

Save time validation alone leaves an already broken client broken and silent, so every entry point runs it:

| Path | Behaviour |
|---|---|
| `POST /downloadclient` | 400, nothing saved |
| `PUT /downloadclient/{id}` | 400, stored Host untouched |
| `POST /downloadclient/test` (inline Test on the form) | 400 before any connection attempt |
| `POST /downloadclient/{id}/test` (Test on a saved client) | 400 naming the fields to fix |
| Health probe | `error` status with the same message, so the client list dot goes red |
| Readarr migration import | row fails with the message instead of importing an unusable client |

## Legible decode errors

`decodeJSON` wraps the three qBittorrent decode sites (torrents, categories, torrent files) following `classifyHTTPError` from #2128 and `ValidateNZB` from #2105: describe the body, never paste it. An HTML body is reported as an HTML page from the WebUI plus the two settings that route a request away from the API; an empty body and a plain text body get their own wording, the latter with a capped one line snippet. A body that is valid JSON of the wrong shape keeps the parser's message, which is the useful one there.

`Test` also checks the `/api/v2/app/version` body, which is plain text and so was never parsed. That is the half of the report the reporter found least believable: nothing looked at what came back, so an HTML page with HTTP 200 tested green.

Before and after on the reporter's setup:

```
decode categories: invalid character '<' looking for beginning of value
```
```
decode categories: qBittorrent returned an HTML page instead of JSON, which is what its WebUI
serves for any URL outside the API. Check that the download client's Host is a bare hostname or
IP with no port and no path in it, and that URL Base matches the path your reverse proxy serves
qBittorrent on
```

## Verification against `main`

Every new test that encodes new behaviour was run with the source change stashed and the tests kept.

`internal/api` on `main` behaviour:

```
--- FAIL: TestDownloadClientCreate_RejectsMalformedHost/address_bar_paste
    expected 400, got 201: {"host":"10.1.2.3:8080/#/", ...}
--- FAIL: TestDownloadClientUpdate_RejectsMalformedHost
--- FAIL: TestDownloadClientTest_RejectsSavedBadHost
    response {"error":"could not reach qBittorrent at http://10.1.2.3:8080/#/:8080 ..."}
--- FAIL: TestDownloadClientTestConfig_RejectsMalformedHost
--- FAIL: TestDownloadClientCreate_AcceptsPlainHosts/trailing_slash
--- FAIL: TestDownloadClientURL_IPv6
    downloadClientURL("::1") = "http://::1:8080/", want "http://[::1]:8080/"
```

`internal/downloader/qbittorrent` on `main` behaviour:

```
--- FAIL: TestGetTorrents_HTMLResponse
    error still surfaces the raw parser message: "decode torrents: invalid character '<' looking for beginning of value"
--- FAIL: TestGetCategories_HTMLResponse
    error still surfaces the raw parser message: "decode categories: invalid character '<' looking for beginning of value"
--- FAIL: TestFiles_HTMLResponse
--- FAIL: TestTest_HTMLResponse
    expected an error
--- FAIL: TestTest_EmptyVersionResponse
    expected Test to fail on an empty version response
```

`TestTest_HTMLResponse` failing with "expected an error" is the Test button reporting success on a client that cannot work, reproduced. With the change in place all of the above pass and the full `./internal/...` suite is green.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (`docs/DEPLOYMENT.md` gained "What goes in a download client's Host field", `docs/Troubleshooting-Wiki.md` gained the symptom entry, godoc on the new exported symbols)
- [x] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `go test -count=1 ./cmd/... ./internal/...`
- [x] `golangci-lint run ./internal/downloader/... ./internal/api/... ./internal/migrate/...`
- [x] `gofmt -l`, `go vet ./...`, `go build ./...`
- [ ] `cd web && npm run build` (no `web/` changes in this PR; the Host help text already reads "Hostname or IP only")
