### PR TITLE
fix(api): restore the strings import in the download client handlers

### DIFF
--- a/changelog.d/2218-restore-strings-import.md
+++ b/changelog.d/2218-restore-strings-import.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Build break on main from two credential PRs landing together** — #2211 dropped the `strings` import from the download client handlers when host parsing moved into `clienthost`, while #2216 added a `strings.TrimSpace` call in the same file. Each passed CI against its own base and the merged result did not compile.

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"


### PR DESCRIPTION
## Summary

`main` does not compile. `internal/api/download_clients.go` calls `strings.TrimSpace` with no `strings` import, so `go build ./...` fails with `undefined: strings`.

This is a semantic conflict between two PRs that were both green on their own base and merged within a few minutes of each other:

| PR | What it did to this file |
|----|--------------------------|
| #2211 | Moved host parsing into `internal/downloader/clienthost`, which removed the last `strings` use in the file, so the import went with it. |
| #2216 | Added the redirect fence in `hydrateTestConfigCredentials`, which compares `strings.TrimSpace(stored.URLBase)` against the submitted one. |

Git merged both cleanly because they touch different lines. Neither branch's CI could have caught it: the breakage only exists in the combination, and neither PR was required to be up to date with `main` before merging.

The fix is the one-line import. No behaviour change.

## Why it was not caught

Branch protection requires `lint`, `validate (Go)` and `Security Summary`, but does not require branches to be current with `main` before merge. Two PRs touching one file can therefore both be green and still produce a broken merge. Worth considering whether to require up-to-date branches, though that serialises merges and costs a CI round trip each time.

## Checklist

- [x] Tests added or updated (not applicable, restores an import; the existing suite covers the call site)
- [x] Doc-update gate cleared (no documented behaviour changes)
- [x] Wiki pages updated if user-facing behaviour changed (not applicable)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/... ./internal/...`
- [x] `go test ./internal/... ./cmd/...` (full suite, no failures)
