### PR TITLE
fix(web): offer every recognised release format in the quality profile editor (#1700)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Clean-room Go rewrite, modern React UI, MIT-licensed, actively developed.
 - Smart matching — four-tier query fallback (`t=book` → `surname+title` → `author+title` → title), word-boundary keyword matching, contiguous-phrase requirement for multi-word titles, dual-author-anchor for ambiguous short titles, subtitle-aware (`Title: Subtitle`).
 - SABnzbd, NZBGet, qBittorrent, Transmission, Deluge, rTorrent/ruTorrent — with **Use SSL** and **URL Base** for reverse-proxy subpaths.
 - Auto-grab sweep every 12h, immediate search on add or `wanted` flip, plus interactive per-book search and "Search all wanted" per author. Global kill-switch pauses auto-grab without losing your monitored list.
-- Quality profiles (EPUB / MOBI / AZW3 / PDF), language filter, regex-based custom formats, delay profiles, blocklist (consulted on every search; one-click add from History), and failure visibility in Queue and History.
+- Quality profiles covering every format release parsing recognises (EPUB, MOBI, AZW3, PDF, plus AZW, DJVU, CBR, CBZ, FB2, LIT, RTF, TXT and the audio containers M4B, M4A, FLAC, MP3, OGG), language filter, regex-based custom formats, delay profiles, blocklist (consulted on every search; one-click add from History), and failure visibility in Queue and History.
 
 **Import & organize**
 - Completed downloads matched by NZO ID and placed in the library with configurable naming. Modes: **Auto** (default — hardlink when possible, else copy; seeding-safe), **Move**, **Copy** (keep source for seeding), **Hardlink** (zero extra disk; same filesystem required), **External** (hand off to a sibling tool).

--- a/changelog.d/1700-quality-profile-format-vocabulary.md
+++ b/changelog.d/1700-quality-profile-format-vocabulary.md
@@ -1,0 +1,2 @@
+### Fixed
+- **The quality profile editor now offers every format release parsing recognises** (#1700). It listed only 8 of the 17 formats the search pipeline can label, so once v1.28.2 made the allow-list authoritative (#1693), AZW, DJVU, CBR, CBZ, FB2, LIT, RTF, TXT and OGG could never be allowed for an author with a configured profile. All nine are now available as "+ Add" chips in the editor; new profiles still start from the familiar PDF, MOBI, EPUB, AZW3 seed. A drift test keeps the editor's vocabulary locked to the parser's so they cannot diverge again.

--- a/internal/indexer/quality_editor_vocab_test.go
+++ b/internal/indexer/quality_editor_vocab_test.go
@@ -1,0 +1,107 @@
+package indexer
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// qualityTabPath points at the quality profile editor relative to this
+// package directory (go test always runs with the package dir as cwd).
+const qualityTabPath = "../../web/src/pages/settings/QualityTab.tsx"
+
+// extractTSXStringList pulls the string literals out of a
+// `const NAME = ['a', 'b', ...] as const` declaration in the editor source.
+// It fails the test loudly when the declaration cannot be found, so a rename
+// or refactor of the TSX constants breaks here instead of silently passing.
+func extractTSXStringList(t *testing.T, src, name string) []string {
+	t.Helper()
+	re := regexp.MustCompile(`const ` + name + `\s*=\s*\[([^\]]*)\]`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		t.Fatalf("could not find `const %s = [...]` in %s; if the constant was renamed or moved, update this drift guard to follow it", name, qualityTabPath)
+	}
+	var out []string
+	for _, q := range regexp.MustCompile(`'([^']+)'`).FindAllStringSubmatch(m[1], -1) {
+		out = append(out, q[1])
+	}
+	if len(out) == 0 {
+		t.Fatalf("`const %s` in %s parsed to an empty list; the editor would offer no formats", name, qualityTabPath)
+	}
+	return out
+}
+
+// TestQualityEditorFormatVocabulary is the drift guard for #1700: the quality
+// profile editor keeps a hand-written mirror of formatTokens, and when the
+// mirror fell behind (8 formats offered, 17 recognised) the missing nine
+// could never be allowed once #1693 made the allow-list authoritative.
+//
+// It asserts that EBOOK_FORMATS and AUDIOBOOK_FORMATS in QualityTab.tsx,
+// taken together, are exactly formatTokens, and that each token sits in the
+// list matching MediaTypeForFormat. Membership is compared as sets: the order
+// within each TSX list is a UI concern (worst → best) that this test does not
+// pin. Adding a token to formatTokens without giving it a checkbox, or adding
+// a checkbox for a token release parsing can never emit, fails here.
+func TestQualityEditorFormatVocabulary(t *testing.T) {
+	raw, err := os.ReadFile(qualityTabPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v (this guard needs the full repo checkout)", qualityTabPath, err)
+	}
+	src := string(raw)
+
+	ebook := extractTSXStringList(t, src, "EBOOK_FORMATS")
+	audio := extractTSXStringList(t, src, "AUDIOBOOK_FORMATS")
+
+	seen := map[string]string{}
+	for _, l := range []struct {
+		name    string
+		formats []string
+	}{{"EBOOK_FORMATS", ebook}, {"AUDIOBOOK_FORMATS", audio}} {
+		for _, f := range l.formats {
+			if prev, dup := seen[f]; dup {
+				t.Errorf("%q appears in both %s and %s in %s", f, prev, l.name, qualityTabPath)
+				continue
+			}
+			seen[f] = l.name
+		}
+	}
+
+	var wantEbook, wantAudio []string
+	for _, tok := range formatTokens {
+		switch MediaTypeForFormat(tok) {
+		case models.MediaTypeEbook:
+			wantEbook = append(wantEbook, tok)
+		case models.MediaTypeAudiobook:
+			wantAudio = append(wantAudio, tok)
+		default:
+			t.Errorf("formatTokens entry %q maps to no media type; TestMediaTypeForFormat should have caught this", tok)
+		}
+	}
+
+	assertSameSet := func(name string, got, want []string) {
+		t.Helper()
+		for _, w := range want {
+			if !slices.Contains(got, w) {
+				t.Errorf("release parsing emits %q but %s in %s has no entry for it, so it can never be allowed (#1700); add it to the editor list", w, name, qualityTabPath)
+			}
+		}
+		for _, g := range got {
+			if !slices.Contains(want, g) {
+				t.Errorf("%s in %s offers %q, which release parsing never emits (formatTokens in internal/indexer/release.go) or which belongs in the other list per MediaTypeForFormat", name, qualityTabPath, g)
+			}
+		}
+	}
+	assertSameSet("EBOOK_FORMATS", ebook, wantEbook)
+	assertSameSet("AUDIOBOOK_FORMATS", audio, wantAudio)
+
+	// The new-profile seed must be a subset of the ebook vocabulary; a typo
+	// there would create profile items no release can ever match.
+	for _, f := range extractTSXStringList(t, src, "DEFAULT_EBOOK_ITEMS") {
+		if !slices.Contains(wantEbook, f) {
+			t.Errorf("DEFAULT_EBOOK_ITEMS in %s seeds %q, which is not an ebook format release parsing can emit", qualityTabPath, f)
+		}
+	}
+}

--- a/web/src/pages/settings/QualityTab.test.tsx
+++ b/web/src/pages/settings/QualityTab.test.tsx
@@ -84,4 +84,36 @@ describe('QualityTab', () => {
     expect(screen.getByText('settings.quality.formPreference')).toBeInTheDocument()
     expect(screen.getByText('settings.quality.formCutoff')).toBeInTheDocument()
   })
+
+  it('offers every release format the parser recognises (#1700)', async () => {
+    mockList.mockResolvedValueOnce([])
+    render(<QualityTab />)
+    await waitFor(() => screen.getByText('settings.quality.newProfile'))
+    fireEvent.click(screen.getByText('settings.quality.newProfile'))
+    // A new profile still seeds only the four mainstream ebook containers
+    // (each also appears as a cutoff <option>, hence getAllByText).
+    for (const seeded of ['pdf', 'mobi', 'epub', 'azw3']) {
+      expect(screen.getAllByText(seeded).length).toBeGreaterThanOrEqual(1)
+    }
+    // Everything else ParseRelease can emit is one "+ Add" chip away. Before
+    // #1700 nine of these had no path into the allow-list at all.
+    const chips = [
+      'txt', 'rtf', 'lit', 'djvu', 'cbr', 'cbz', 'fb2', 'azw',
+      'ogg', 'mp3', 'm4a', 'm4b', 'flac',
+    ]
+    for (const f of chips) {
+      expect(screen.getByText(`+ ${f}`)).toBeInTheDocument()
+    }
+  })
+
+  it('adds ogg via its chip and badges it as an audiobook format', async () => {
+    mockList.mockResolvedValueOnce([])
+    render(<QualityTab />)
+    await waitFor(() => screen.getByText('settings.quality.newProfile'))
+    fireEvent.click(screen.getByText('settings.quality.newProfile'))
+    fireEvent.click(screen.getByText('+ ogg'))
+    expect(screen.queryByText('+ ogg')).not.toBeInTheDocument()
+    expect(screen.getByText('ogg')).toBeInTheDocument()
+    expect(screen.getByText('common.audiobook')).toBeInTheDocument()
+  })
 })

--- a/web/src/pages/settings/QualityTab.tsx
+++ b/web/src/pages/settings/QualityTab.tsx
@@ -4,15 +4,27 @@ import { api, QualityProfile } from '../../api/client'
 import { inputCls, labelCls } from './formStyles'
 import { dangerLink } from '../../components/buttons'
 
-// EBOOK_FORMATS and AUDIOBOOK_FORMATS are the format keys the rest of the
-// backend (decision.QualityRank, QualityFromFilename) already understands.
-// Two short lists keeps the UI honest: nothing should be selectable that the
-// scanner cannot label on disk. Split ebook/audiobook so a profile editor can
-// be focused; the model itself has no ebook-vs-audiobook column, but a
-// profile that mixes both is allowed if someone really wants to.
-const EBOOK_FORMATS = ['pdf', 'mobi', 'epub', 'azw3'] as const
-const AUDIOBOOK_FORMATS = ['mp3', 'm4a', 'm4b', 'flac'] as const
+// EBOOK_FORMATS and AUDIOBOOK_FORMATS mirror formatTokens in
+// internal/indexer/release.go, split by indexer.MediaTypeForFormat. Every
+// token release parsing can emit must have a checkbox here: since #1693 the
+// allow-list is authoritative, so a format this editor cannot offer can never
+// be allowed for an author with a configured profile (#1700). Within each
+// list the order is worst → best, following models.QualityRank where a rank
+// exists. The drift guard TestQualityEditorFormatVocabulary
+// (internal/indexer/quality_editor_vocab_test.go) fails the Go suite if
+// either side of this mirror changes without the other.
+// The split matters only for editor focus and the audiobook badge; the model
+// itself has no ebook-vs-audiobook column, and a profile that mixes both is
+// allowed if someone really wants to.
+const EBOOK_FORMATS = ['txt', 'rtf', 'lit', 'djvu', 'cbr', 'cbz', 'fb2', 'pdf', 'azw', 'mobi', 'epub', 'azw3'] as const
+const AUDIOBOOK_FORMATS = ['ogg', 'mp3', 'm4a', 'm4b', 'flac'] as const
 const ALL_FORMATS = [...EBOOK_FORMATS, ...AUDIOBOOK_FORMATS] as const
+
+// Seed for a brand-new profile: the mainstream ebook containers only, worst →
+// best. The long tail (txt, comic archives, ogg, …) is offered through the
+// "+ Add" chips instead, so a fresh profile does not silently allow plain-text
+// dumps or formats the user never asked for.
+const DEFAULT_EBOOK_ITEMS = ['pdf', 'mobi', 'epub', 'azw3'] as const
 
 interface EditorItem {
   quality: string
@@ -22,7 +34,7 @@ interface EditorItem {
 function defaultItems(): EditorItem[] {
   // Worst → best for ebooks. The decision spec compares cutoff and current
   // by index, so order matters: later = better.
-  return EBOOK_FORMATS.map(q => ({ quality: q, allowed: true }))
+  return DEFAULT_EBOOK_ITEMS.map(q => ({ quality: q, allowed: true }))
 }
 
 function normalisedItems(items?: EditorItem[]): EditorItem[] {


### PR DESCRIPTION
## Summary

The quality profile editor mirrored only 8 of the 17 format tokens `ParseRelease` emits, and since #1693 made the allow-list authoritative the other nine (azw, djvu, cbr, cbz, fb2, lit, rtf, txt, ogg) could never be allowed for an author with a configured profile. `EBOOK_FORMATS` and `AUDIOBOOK_FORMATS` in `QualityTab.tsx` now cover all of `formatTokens`, split by `indexer.MediaTypeForFormat` (ogg lands in the audiobook list and gets the badge automatically). Closes #1700.

## Scope decisions

- **New profiles still seed from pdf, mobi, epub, azw3.** The long tail is offered through the existing "+ Add" chips instead of being pre-ticked, so a fresh profile does not silently allow plain text dumps or comic archives. `DEFAULT_EBOOK_ITEMS` carries the seed; the two vocabulary lists carry everything.
- **Drift guard: a Go test that reads the TSX** (`internal/indexer/quality_editor_vocab_test.go`, `TestQualityEditorFormatVocabulary`). It extracts the two constants with a regex and asserts they are exactly `formatTokens` partitioned by `MediaTypeForFormat`, failing with a pointed message if the declaration is renamed, a token is missing, or a token that parsing can never emit is offered. Chosen over a generated TS constant or a JSON fixture because it needs no codegen step and no committed artifact that can itself go stale, and because `go test ./cmd/... ./internal/...` runs on every PR with no path filter, so the guard fires no matter which side of the mirror a PR touches. Same shape as the `TestRenamerPreviewSampleDriftGuard` precedent in `internal/importer`. Verified by temporarily adding a fake token to `formatTokens`: the test fails naming the token, and passes again on revert.
- **Ordering** within each list stays worst to best (the decision spec compares by index), following `models.QualityRank` where a rank exists; the guard compares membership only, since order is a UI default the user can rearrange.
- **Ranks for the new formats are unchanged.** djvu, cbr, cbz, fb2, lit and ogg have no `QualityRank` entry, so they score as unknown in search ranking. That predates this PR and only affects scoring, not the allow-list; happy to follow up if they should get ranks.
- **First commit is a one line build fix for main**: the #2216 squash over #2184 left `internal/api/download_clients.go` calling `strings.TrimSpace` without importing `strings`, so `origin/main` does not compile and no PR based on it can pass CI. Included here so this PR is green; it rebases away cleanly if the same fix lands first.

No new i18n strings: format tokens render verbatim and the audiobook badge reuses `common.audiobook`. README's feature list now names the full vocabulary; the wiki pages do not enumerate formats, so no wiki change.

## Checklist

- [x] Commits signed off with `git commit -s` (see [Sign your work](../CONTRIBUTING.md#sign-your-work-dco))
- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (not applicable, no env or config change)
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`, see [changelog.d/README.md](../changelog.d/README.md))
- [ ] Wiki pages updated if user-facing behaviour changed (checked: no wiki page enumerates the format vocabulary; README updated instead)

## Test plan

- [x] `go build ./... && go vet ./cmd/... ./internal/...`
- [x] `go test ./internal/indexer/... ./internal/models/... ./internal/api/`
- [x] `golangci-lint run ./internal/indexer/... ./internal/api/...` (v2.11.4, 0 issues)
- [x] `cd web && npm ci && npm run lint && npm run typecheck && npm run build`
- [x] `cd web && npx vitest run` (64 files, 617 tests)
- [x] Drift guard failure demo: fake token added to `formatTokens` makes `TestQualityEditorFormatVocabulary` fail, reverted after
