### PR TITLE
chore(release): add the missing changelog fragments for #2102 and #1719

### DIFF
--- a/changelog.d/1719-manual-import-metadata-add.md
+++ b/changelog.d/1719-manual-import-metadata-add.md
@@ -1,0 +1,2 @@
+### Added
+- **Create a book from Manual Import's unmatched files** (#1719) — an unmatched file could only be pointed at a book already in the library, so a file for a book nobody had added yet dead ended on the page that found it. Unmatched rows now offer a metadata search that creates the book, and its author when new, then resolves the row against it.

--- a/changelog.d/2102-authors-display-name-sort.md
+++ b/changelog.d/2102-authors-display-name-sort.md
@@ -1,0 +1,2 @@
+### Added
+- **Sort the Authors list by display name** (#2102) — the list could only be ordered by sort name, so an author filed under a surname was hard to find by the name actually shown. First name A to Z and Z to A join the existing buttons, ordered by a new folded `name_sort_key` column so accented first names sort in place rather than after Z.

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"


### PR DESCRIPTION
## Summary

Two merged PRs landed without a `changelog.d/` fragment, so both would have been missing from the v1.33.0 notes with nothing to catch it at assembly time:

| PR | Issue | What shipped |
|----|-------|--------------|
| #2103 | #2102 | Display-name sort for the Authors list |
| #2159 | #1719 | Create a book from an unmatched Manual Import file |

This adds a fragment for each. No code changes.

Checked the rest of the batch while I was here. #2209, #2210, #2211, #2214, #2215, #2216, #2184, #2127 and #2134 all carry fragments. #2181 needs none: its half of #2166 already shipped in v1.32.2 and is in that section of `CHANGELOG.md`.

## Checklist

- [x] Tests added or updated (not applicable, documentation fragments only)
- [x] Doc-update gate cleared (this is the doc update)
- [x] Wiki pages updated if user-facing behaviour changed (not applicable)

## Test plan

- [x] Fragments start with a valid Keep a Changelog section heading (`### Added`)
- [x] `CHANGELOG.md` untouched, per the release-time-only rule
