### PR TITLE
fix(hardcover): carry author-work language from default editions (#2241)

### DIFF
--- a/changelog.d/2241-hardcover-author-language.md
+++ b/changelog.d/2241-hardcover-author-language.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Hardcover author language filtering** (#2241) — derive work language from default editions so strict unknown-language profiles retain matching books.

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -192,12 +192,10 @@ func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, 
 // returns no supplemental results.
 // authorWorksProjection is the field set every author-works query returns.
 //
-// NB: do NOT select `language` here. It is an *edition* field; the `books`
-// type has no `language`, so requesting it makes Hardcover reject the whole
-// query ("field 'language' not found in type: 'books'", validation-failed)
-// and the entire author-works supplement fails (#1036-adjacent report). A
-// book's language can only be derived by traversing to a default edition;
-// until that's added, supplemental books carry no language.
+// NB: do not select `language` directly here. It is an *edition* field; the
+// `books` type has no `language`, so requesting it makes Hardcover reject the
+// whole query ("field 'language' not found in type: 'books'",
+// validation-failed). Derive it through the default-edition relations instead.
 const authorWorksProjection = `
 		id
 		title
@@ -213,6 +211,8 @@ const authorWorksProjection = `
 		audio_seconds
 		default_audio_edition_id
 		default_ebook_edition_id
+		default_ebook_edition { language { language } }
+		default_audio_edition { language { language } }
 		book_series(order_by: { position: asc }) {
 			position
 			series { id name }

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -664,11 +664,16 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 				t.Fatalf("query did not request Hardcover field %q: %s", field, req.Query)
 			}
 		}
-		// Regression: `language` is an edition field, not a `books` field.
-		// Requesting it makes Hardcover reject the whole query
-		// (validation-failed) and the author-works supplement fails entirely.
-		if strings.Contains(req.Query, "language") {
-			t.Fatalf("author-works query must not request the invalid books.language field: %s", req.Query)
+		// #2241: language belongs to editions, not books. Selecting both
+		// default-edition relations keeps the query valid and prevents strict
+		// unknown-language profiles from dropping every Hardcover work.
+		for _, relation := range []string{
+			"default_ebook_edition { language { language } }",
+			"default_audio_edition { language { language } }",
+		} {
+			if !strings.Contains(req.Query, relation) {
+				t.Fatalf("author-works query does not request %q: %s", relation, req.Query)
+			}
 		}
 		gotVars = req.Variables
 		data := map[string]interface{}{
@@ -684,6 +689,9 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 					"rating":        4.5,
 					"users_count":   2000,
 					"audio_seconds": 7200,
+					"default_ebook_edition": map[string]interface{}{
+						"language": map[string]interface{}{"language": "English"},
+					},
 					"contributions": []map[string]interface{}{
 						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
 					},
@@ -697,6 +705,9 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 					"rating":        4.2,
 					"users_count":   100,
 					"compilation":   true,
+					"default_audio_edition": map[string]interface{}{
+						"language": map[string]interface{}{"language": "Spanish"},
+					},
 					"contributions": []map[string]interface{}{
 						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
 					},
@@ -738,16 +749,18 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 	if book.MediaType != "" {
 		t.Fatalf("MediaType = %q, want empty author import default", book.MediaType)
 	}
-	// #889 originally selected books.language to drive the allowed_languages
-	// filter, but that field doesn't exist on Hardcover's `books` type and made
-	// the whole query fail. With it removed, supplemental books carry no
-	// language until it's derived from a default edition (follow-up); the filter
-	// treats them as "unknown language: pass", which is the pre-#889 behaviour.
-	if book.Language != "" {
-		t.Errorf("author-works book Language = %q, want empty (not fetched at books level)", book.Language)
+	if book.Language != "eng" {
+		t.Errorf("author-works book Language = %q, want eng from default ebook edition", book.Language)
 	}
-	if books[1].Language != "" {
-		t.Errorf("author-works book[1] Language = %q, want empty", books[1].Language)
+	if books[1].Language != "spa" {
+		t.Errorf("author-works book[1] Language = %q, want spa from default audio edition", books[1].Language)
+	}
+	allowed := []string{"eng"}
+	if !models.IsLanguageAllowed(book.Language, allowed, true) {
+		t.Error("English author work was rejected by a strict unknown-language profile (#2241)")
+	}
+	if models.IsLanguageAllowed(books[1].Language, allowed, true) {
+		t.Error("Spanish author work passed an English-only strict profile")
 	}
 }
 


### PR DESCRIPTION
## Summary

Hardcover author-work queries now select language through the default ebook and audio edition relations, allowing the existing `hcBook`/`toBook()` path to populate `Book.Language`. This prevents strict unknown-language profiles from rejecting matching Hardcover works while continuing to reject known non-allowed languages.

Closes #2241.

## Why minimal

- Reuses the default-edition language fields and conversion logic already used by Hardcover list/shelf queries.
- Adds no database schema or model changes.
- Adds no per-book request or API fan-out.
- Does not change reconciliation or deletion behavior.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated
- [x] Doc-update gate cleared; this restores existing profile semantics without adding configuration or an API surface
- [x] Added a changelog fragment under `changelog.d/`

## Test plan

- [x] `go test -race ./internal/metadata/hardcover -count=1`
- [x] `go test ./internal/metadata/... -count=1`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m` (v2.11.4; 0 issues)

A repository-wide race run was also attempted locally. The changed Hardcover package passed, but the overall command did not complete cleanly on macOS: `internal/api` reached its 30-minute timeout and an existing downloader test hit the `/var` → `/private/var` temporary-directory symlink safety guard. Neither failure exercised this diff; the focused race test and all metadata tests pass.