### PR TITLE
feat(author): add safe catalogue reconciliation (#2208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Clean-room Go rewrite, modern React UI, MIT-licensed, actively developed.
 - Series support with position tracking, edition tracking (format / ISBN / publisher / page count), Calendar view of upcoming releases, and multiple library roots.
 - Library scan with four-tier matching: ASIN → title + author → series name + position → fuzzy title. Honours librarian sort-suffix form (`Title, The`) and series-annotated filenames (`[Mistborn, Book 1]`).
 - Author aliases (`RR Haywood` / `R.R. Haywood` / `R R Haywood` merge into one canonical row), and metadata re-bind to correct a wrong match without delete-and-re-add.
+- Explicit author-catalogue reconciliation with a selectable preview: remove chosen stale metadata-only Wanted rows after changing provider or metadata profile while always protecting imported books and every row with a tracked file.
 
 **Search & downloads**
 - Newznab + Torznab indexers queried in parallel, deduplicated, then composite-ranked by format quality, edition tags (RETAIL / UNABRIDGED / ABRIDGED), year match, grab count, size, and ISBN exact-match bonus.

--- a/changelog.d/2208-author-catalogue-reconciliation.md
+++ b/changelog.d/2208-author-catalogue-reconciliation.md
@@ -1,0 +1,2 @@
+### Added
+- **Safe author catalogue reconciliation** (#2208) — preview, select, and explicitly remove stale metadata-only Wanted rows after a provider or metadata-profile change while protecting imported and file-bearing books.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -890,6 +890,8 @@ func main() {
 		r.Put("/author/{id}/genres", authorHandler.ApplyGenres)
 		r.Delete("/author/{id}", authorHandler.Delete)
 		r.Post("/author/{id}/refresh", authorHandler.Refresh)
+		r.Get("/author/{id}/catalogue-reconciliation", authorHandler.PreviewCatalogueReconciliation)
+		r.Post("/author/{id}/catalogue-reconciliation", authorHandler.ApplyCatalogueReconciliation)
 		r.Get("/author/{id}/relink-upstream/candidates", authorHandler.RelinkCandidates)
 		r.Post("/author/{id}/relink-upstream", authorHandler.RelinkUpstream)
 		r.Get("/author/{id}/series", authorHandler.ListSeries)

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,6 +39,10 @@ GET    /api/v1/author/{id}                        author detail
 PUT    /api/v1/author/{id}                        update monitored / metadata profile
 DELETE /api/v1/author/{id}                        remove (with optional file delete)
 POST   /api/v1/author/{id}/refresh                re-pull works from OpenLibrary
+GET    /api/v1/author/{id}/catalogue-reconciliation
+                                                    preview stale metadata-only Wanted rows
+POST   /api/v1/author/{id}/catalogue-reconciliation
+                                                    recheck and remove selected preview rows
 GET    /api/v1/author/{id}/relink-upstream/candidates
                                                     search metadata candidates for manual relink
 POST   /api/v1/author/{id}/relink-upstream        re-bind to a different foreign ID
@@ -86,6 +90,22 @@ instead of silent:
 ```
 
 The field is absent when the providers match or no primary is configured.
+
+Catalogue reconciliation is deliberately separate from refresh. The GET route
+queries the current primary provider without using its cached author catalogue
+and returns `candidates`, a reason-count summary, protection counts, and
+`providerComplete`. A partial provider result never treats absence as a reason
+to remove a row. The POST route accepts the IDs from the preview:
+
+```json
+{ "bookIds": [12, 19] }
+```
+
+The server recomputes the preview and deletes only IDs that are still
+candidates and still match the database-level guard: same author, status
+`wanted`, not excluded, no legacy file-path columns, and no `book_files` rows.
+It returns an `applied` summary with `requested`, `deleted`, and `skipped`.
+Neither route removes files from disk.
 
 `POST /api/v1/author/{id}/relink-upstream` may be called without a body for
 automatic upstream matching. Manual relink can send:

--- a/docs/User-Guide-Wiki.md
+++ b/docs/User-Guide-Wiki.md
@@ -361,6 +361,19 @@ no books at all is populated, which is how bulk **Refresh metadata** repairs
 an import that landed an author but no catalogue.) When a refresh declines to
 add works, the author page says how many and why.
 
+Changing a provider or tightening a metadata profile does not silently delete
+old catalogue rows during refresh. To apply the new catalogue rules to an
+author's existing rows, open the author, choose **More → Reconcile catalogue…**,
+and review the preview. Every candidate starts selected; clear any row you do
+not want to remove before applying. Apply removes only selected metadata-only
+rows whose status is still Wanted. Imported books, excluded books, books in
+another active status, and any row with `filePath`, `ebookFilePath`,
+`audiobookFilePath`, or a tracked `book_files` entry are protected. No files
+are deleted. Apply fetches the provider again and rechecks the database
+safeguards, so a row that gained a file or changed status after preview is
+skipped. If the provider returns a partial catalogue, missing works are kept
+rather than guessed stale.
+
 ## What Bindery deliberately does not do
 
 Knowing the edges saves time:

--- a/docs/User-Guide-Wiki.md
+++ b/docs/User-Guide-Wiki.md
@@ -372,7 +372,10 @@ another active status, and any row with `filePath`, `ebookFilePath`,
 are deleted. Apply fetches the provider again and rechecks the database
 safeguards, so a row that gained a file or changed status after preview is
 skipped. If the provider returns a partial catalogue, missing works are kept
-rather than guessed stale.
+rather than guessed stale. OpenLibrary's `searchAuthorWorks` lookup currently
+requests at most 200 works (`limit=200`), so authors with more than 200 works
+remain marked partial: the warning may stay visible, and reconciliation will
+not remove their `not_in_current_catalogue` rows.
 
 ## What Bindery deliberately does not do
 

--- a/internal/api/catalogue_reconciliation.go
+++ b/internal/api/catalogue_reconciliation.go
@@ -1,0 +1,452 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/concurrency"
+	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+const (
+	reconcileReasonProviderChanged = "provider_changed"
+	reconcileReasonNotInCatalogue  = "not_in_current_catalogue"
+	reconcileReasonLanguage        = "language_not_allowed"
+	reconcileReasonPartBook        = "part_book"
+	reconcileReasonMissingDate     = "missing_release_date"
+	reconcileReasonPopularity      = "below_minimum_popularity"
+	reconcileReasonPages           = "below_minimum_pages"
+	reconcileReasonISBN            = "missing_isbn"
+	reconcileReasonCatalogueFilter = "catalogue_filter"
+)
+
+// CatalogueReconciliationCandidate is a local, metadata-only Wanted row that
+// the current primary-provider catalogue and metadata profile no longer
+// accept. It contains no file operation: reconciliation deletes database rows
+// only, and only after an explicit apply request.
+type CatalogueReconciliationCandidate struct {
+	BookID           int64  `json:"bookId"`
+	Title            string `json:"title"`
+	MetadataProvider string `json:"metadataProvider"`
+	Reason           string `json:"reason"`
+}
+
+type CatalogueReconciliationSummary struct {
+	Total             int            `json:"total"`
+	Candidates        int            `json:"candidates"`
+	Kept              int            `json:"kept"`
+	Protected         int            `json:"protected"`
+	ProtectedFiles    int            `json:"protectedFiles"`
+	ProtectedImported int            `json:"protectedImported"`
+	ProtectedStatus   int            `json:"protectedStatus"`
+	ProtectedExcluded int            `json:"protectedExcluded"`
+	Indeterminate     int            `json:"indeterminate"`
+	Reasons           map[string]int `json:"reasons"`
+}
+
+type CatalogueReconciliationApplySummary struct {
+	Requested int   `json:"requested"`
+	Deleted   int64 `json:"deleted"`
+	Skipped   int64 `json:"skipped"`
+}
+
+// CatalogueReconciliation is both the preview payload and, after apply, the
+// deletion report. ProviderComplete is false when an upstream provider served
+// only a partial author catalogue; in that case absence is never used as a
+// deletion reason.
+type CatalogueReconciliation struct {
+	AuthorID         int64                                `json:"authorId"`
+	AuthorName       string                               `json:"authorName"`
+	Provider         string                               `json:"provider"`
+	ProviderComplete bool                                 `json:"providerComplete"`
+	ProfileName      string                               `json:"profileName"`
+	Warning          string                               `json:"warning,omitempty"`
+	Candidates       []CatalogueReconciliationCandidate   `json:"candidates"`
+	Summary          CatalogueReconciliationSummary       `json:"summary"`
+	Applied          *CatalogueReconciliationApplySummary `json:"applied,omitempty"`
+}
+
+type applyCatalogueReconciliationRequest struct {
+	BookIDs []int64 `json:"bookIds"`
+}
+
+// PreviewCatalogueReconciliation handles
+// GET /api/v1/author/{id}/catalogue-reconciliation. It is read-only: the
+// provider is queried afresh and every candidate is reported with a reason.
+func (h *AuthorHandler) PreviewCatalogueReconciliation(w http.ResponseWriter, r *http.Request) {
+	author, ok := h.ownedAuthorFromRequest(w, r)
+	if !ok {
+		return
+	}
+	preview, err := h.buildCatalogueReconciliation(r.Context(), author)
+	if err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, preview)
+}
+
+// ApplyCatalogueReconciliation handles
+// POST /api/v1/author/{id}/catalogue-reconciliation. It recomputes the preview
+// and intersects it with the requested IDs before issuing one guarded DELETE;
+// the client never gets to turn an arbitrary book ID into a deletion.
+func (h *AuthorHandler) ApplyCatalogueReconciliation(w http.ResponseWriter, r *http.Request) {
+	author, ok := h.ownedAuthorFromRequest(w, r)
+	if !ok {
+		return
+	}
+	var req applyCatalogueReconciliationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if len(req.BookIDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bookIds is required"})
+		return
+	}
+
+	preview, err := h.buildCatalogueReconciliation(r.Context(), author)
+	if err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+	current := make(map[int64]struct{}, len(preview.Candidates))
+	for _, candidate := range preview.Candidates {
+		current[candidate.BookID] = struct{}{}
+	}
+	requested := make(map[int64]struct{}, len(req.BookIDs))
+	eligible := make([]int64, 0, len(req.BookIDs))
+	for _, id := range req.BookIDs {
+		if id <= 0 {
+			continue
+		}
+		if _, duplicate := requested[id]; duplicate {
+			continue
+		}
+		requested[id] = struct{}{}
+		if _, stillCandidate := current[id]; stillCandidate {
+			eligible = append(eligible, id)
+		}
+	}
+	deleted, err := h.books.DeleteMetadataOnlyWantedByIDs(r.Context(), author.ID, eligible)
+	if err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+	preview.Applied = &CatalogueReconciliationApplySummary{
+		Requested: len(requested),
+		Deleted:   deleted,
+		Skipped:   int64(len(requested)) - deleted,
+	}
+	writeJSON(w, http.StatusOK, preview)
+}
+
+func (h *AuthorHandler) ownedAuthorFromRequest(w http.ResponseWriter, r *http.Request) (*models.Author, bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return nil, false
+	}
+	author, err := h.authors.GetByID(r.Context(), id)
+	if err != nil {
+		writeServerError(w, r, err)
+		return nil, false
+	}
+	if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return nil, false
+	}
+	return author, true
+}
+
+type reconciliationProfile struct {
+	name            string
+	allowedLangs    []string
+	unknownFail     bool
+	skipPartBooks   bool
+	skipMissingDate bool
+	minPopularity   int
+	minPages        int
+	skipMissingISBN bool
+}
+
+func (h *AuthorHandler) reconciliationProfile(ctx context.Context, author *models.Author) (reconciliationProfile, error) {
+	if h.profiles == nil {
+		return reconciliationProfile{}, errors.New("metadata profiles are not configured")
+	}
+	id := models.DefaultMetadataProfileID
+	if author.MetadataProfileID != nil {
+		id = *author.MetadataProfileID
+	}
+	profile, err := h.profiles.GetByID(ctx, id)
+	if err != nil {
+		return reconciliationProfile{}, fmt.Errorf("load metadata profile: %w", err)
+	}
+	if profile == nil {
+		return reconciliationProfile{}, fmt.Errorf("metadata profile %d not found", id)
+	}
+	return reconciliationProfile{
+		name:            profile.Name,
+		allowedLangs:    models.ParseAllowedLanguages(profile.AllowedLanguages),
+		unknownFail:     profile.UnknownLanguageBehavior == models.UnknownLanguageFail,
+		skipPartBooks:   profile.SkipPartBooks,
+		skipMissingDate: profile.SkipMissingDate,
+		minPopularity:   profile.MinPopularity,
+		minPages:        profile.MinPages,
+		skipMissingISBN: profile.SkipMissingISBN,
+	}, nil
+}
+
+type editionEvidence struct {
+	editions []models.Edition
+	known    bool
+}
+
+func (h *AuthorHandler) buildCatalogueReconciliation(ctx context.Context, author *models.Author) (CatalogueReconciliation, error) {
+	if h.meta == nil {
+		return CatalogueReconciliation{}, errors.New("metadata aggregator is not configured")
+	}
+	profile, err := h.reconciliationProfile(ctx, author)
+	if err != nil {
+		return CatalogueReconciliation{}, err
+	}
+	snapshot, err := h.meta.GetAuthorWorksSnapshotForAuthor(ctx, *author)
+	if err != nil {
+		return CatalogueReconciliation{}, fmt.Errorf("fetch current author catalogue: %w", err)
+	}
+	works := snapshot.Books
+	if len(profile.allowedLangs) > 0 {
+		// Best effort. A still-unknown language is always protected below, even
+		// when the normal ingestion policy says unknown=fail: reconciliation
+		// cannot distinguish missing metadata from a partial lookup failure.
+		h.meta.FillMissingAuthorWorkLanguages(ctx, works)
+	}
+
+	editions := make(map[string]editionEvidence)
+	if profile.minPages > 0 || profile.skipMissingISBN {
+		var mu sync.Mutex
+		concurrency.RunBounded(ctx, works, authorAutoSearchConcurrency, func(ctx context.Context, work models.Book) {
+			if strings.TrimSpace(work.ForeignID) == "" {
+				return
+			}
+			provider := bookProvider(&work)
+			if provider == "dnb" {
+				return
+			}
+			found, err := h.meta.GetEditionsFromProvider(ctx, provider, work.ForeignID)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				editions[work.ForeignID] = editionEvidence{}
+				return
+			}
+			editions[work.ForeignID] = editionEvidence{editions: found, known: true}
+		})
+	}
+
+	acceptedIDs := make(map[string]struct{}, len(works))
+	indeterminateIDs := make(map[string]struct{})
+	rejectedIDs := make(map[string]string, len(works))
+	acceptedTitles := indexer.NewTitleIndex[struct{}]()
+	indeterminateTitles := indexer.NewTitleIndex[struct{}]()
+	rejectedTitles := make(map[string]string)
+	normalizedAuthor := strings.ToLower(strings.TrimSpace(author.Name))
+	for _, work := range works {
+		reason, indeterminate := reconciliationRejectReason(work, normalizedAuthor, profile, editions[work.ForeignID])
+		if reason == "" {
+			acceptedIDs[work.ForeignID] = struct{}{}
+			acceptedTitles.Add(work.Title, struct{}{})
+			if indeterminate {
+				indeterminateIDs[work.ForeignID] = struct{}{}
+				indeterminateTitles.Add(work.Title, struct{}{})
+			}
+			continue
+		}
+		rejectedIDs[work.ForeignID] = reason
+		if key := indexer.CanonicalDedupKey(work.Title); key != "" {
+			rejectedTitles[key] = reason
+		}
+	}
+
+	localBooks, err := h.books.ListByAuthorIncludingExcluded(ctx, author.ID)
+	if err != nil {
+		return CatalogueReconciliation{}, fmt.Errorf("list local author catalogue: %w", err)
+	}
+	result := CatalogueReconciliation{
+		AuthorID:         author.ID,
+		AuthorName:       author.Name,
+		Provider:         snapshot.Provider,
+		ProviderComplete: snapshot.Complete,
+		ProfileName:      profile.name,
+		Candidates:       []CatalogueReconciliationCandidate{},
+		Summary: CatalogueReconciliationSummary{
+			Total:   len(localBooks),
+			Reasons: map[string]int{},
+		},
+	}
+	if !snapshot.Complete {
+		result.Warning = "The provider returned a partial catalogue. Missing works are protected; only explicit profile rejections can be removed."
+	}
+
+	for i := range localBooks {
+		book := &localBooks[i]
+		if !auth.CheckOwnership(ctx, book.OwnerUserID) {
+			result.Summary.Protected++
+			result.Summary.ProtectedStatus++
+			continue
+		}
+		if book.FilePath != "" || book.EbookFilePath != "" || book.AudiobookFilePath != "" {
+			result.Summary.Protected++
+			result.Summary.ProtectedFiles++
+			continue
+		}
+		if book.Status == models.BookStatusImported {
+			result.Summary.Protected++
+			result.Summary.ProtectedImported++
+			continue
+		}
+		if book.Status != models.BookStatusWanted {
+			result.Summary.Protected++
+			result.Summary.ProtectedStatus++
+			continue
+		}
+		if book.Excluded {
+			result.Summary.Protected++
+			result.Summary.ProtectedExcluded++
+			continue
+		}
+
+		identifiers, err := h.books.ListBookIdentifiers(ctx, book.ID)
+		if err != nil {
+			return CatalogueReconciliation{}, fmt.Errorf("list identifiers for book %d: %w", book.ID, err)
+		}
+		ids := make([]string, 0, len(identifiers)+1)
+		ids = append(ids, book.ForeignID)
+		for _, identifier := range identifiers {
+			ids = append(ids, identifier.ForeignID)
+		}
+		if anyReconciliationIDAccepted(ids, acceptedIDs) {
+			result.Summary.Kept++
+			if anyReconciliationIDAccepted(ids, indeterminateIDs) {
+				result.Summary.Indeterminate++
+			}
+			continue
+		}
+		if _, accepted := acceptedTitles.Lookup(book.Title); accepted {
+			result.Summary.Kept++
+			if _, indeterminate := indeterminateTitles.Lookup(book.Title); indeterminate {
+				result.Summary.Indeterminate++
+			}
+			continue
+		}
+
+		reason := reconciliationReasonForIDs(ids, rejectedIDs)
+		if reason == "" {
+			if titleReason, rejected := rejectedTitles[indexer.CanonicalDedupKey(book.Title)]; rejected {
+				reason = titleReason
+			}
+		}
+		if reason == "" {
+			if !snapshot.Complete {
+				result.Summary.Kept++
+				result.Summary.Indeterminate++
+				continue
+			}
+			if bookProvider(book) != snapshot.Provider {
+				reason = reconcileReasonProviderChanged
+			} else {
+				reason = reconcileReasonNotInCatalogue
+			}
+		}
+
+		result.Candidates = append(result.Candidates, CatalogueReconciliationCandidate{
+			BookID:           book.ID,
+			Title:            book.Title,
+			MetadataProvider: bookProvider(book),
+			Reason:           reason,
+		})
+		result.Summary.Reasons[reason]++
+	}
+
+	sort.Slice(result.Candidates, func(i, j int) bool {
+		return strings.ToLower(result.Candidates[i].Title) < strings.ToLower(result.Candidates[j].Title)
+	})
+	result.Summary.Candidates = len(result.Candidates)
+	return result, nil
+}
+
+func reconciliationRejectReason(work models.Book, normalizedAuthor string, profile reconciliationProfile, evidence editionEvidence) (string, bool) {
+	normalizedTitle := strings.ToLower(strings.TrimSpace(work.Title))
+	if normalizedTitle == "" || normalizedTitle == normalizedAuthor || work.IsCompilation || metadata.IsUnambiguousBundleTitle(work.Title) {
+		return reconcileReasonCatalogueFilter, false
+	}
+	if len(profile.allowedLangs) > 0 {
+		if strings.TrimSpace(work.Language) == "" {
+			return "", profile.unknownFail
+		}
+		if !models.IsLanguageAllowed(work.Language, profile.allowedLangs, profile.unknownFail) {
+			return reconcileReasonLanguage, false
+		}
+	}
+	if profile.skipPartBooks && isPartBookTitle(work.Title) {
+		return reconcileReasonPartBook, false
+	}
+	if profile.skipMissingDate && work.ReleaseDate == nil {
+		return reconcileReasonMissingDate, false
+	}
+	hasRatingSignal := work.RatingsCount > 0 || work.AverageRating > 0
+	if profile.minPopularity > 0 && hasRatingSignal && work.RatingsCount < profile.minPopularity &&
+		(work.ReleaseDate == nil || !work.ReleaseDate.After(time.Now())) {
+		return reconcileReasonPopularity, false
+	}
+	if profile.minPages > 0 || profile.skipMissingISBN {
+		if !evidence.known {
+			return "", true
+		}
+		if profile.skipMissingISBN && !anyEditionHasISBN(evidence.editions) {
+			return reconcileReasonISBN, false
+		}
+		if profile.minPages > 0 && !passesMinPagesFilter(evidence.editions, profile.minPages) {
+			return reconcileReasonPages, false
+		}
+	}
+	return "", false
+}
+
+func anyReconciliationIDAccepted(ids []string, accepted map[string]struct{}) bool {
+	for _, id := range ids {
+		if _, ok := accepted[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func reconciliationReasonForIDs(ids []string, rejected map[string]string) string {
+	for _, id := range ids {
+		if reason := rejected[id]; reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
+func bookProvider(book *models.Book) string {
+	if provider := strings.ToLower(strings.TrimSpace(book.MetadataProvider)); provider != "" {
+		return provider
+	}
+	return models.BookProviderFromForeignID(book.ForeignID)
+}

--- a/internal/api/catalogue_reconciliation.go
+++ b/internal/api/catalogue_reconciliation.go
@@ -267,15 +267,21 @@ func (h *AuthorHandler) buildCatalogueReconciliation(ctx context.Context, author
 	for _, work := range works {
 		reason, indeterminate := reconciliationRejectReason(work, normalizedAuthor, profile, editions[work.ForeignID])
 		if reason == "" {
-			acceptedIDs[work.ForeignID] = struct{}{}
+			if strings.TrimSpace(work.ForeignID) != "" {
+				acceptedIDs[work.ForeignID] = struct{}{}
+			}
 			acceptedTitles.Add(work.Title, struct{}{})
 			if indeterminate {
-				indeterminateIDs[work.ForeignID] = struct{}{}
+				if strings.TrimSpace(work.ForeignID) != "" {
+					indeterminateIDs[work.ForeignID] = struct{}{}
+				}
 				indeterminateTitles.Add(work.Title, struct{}{})
 			}
 			continue
 		}
-		rejectedIDs[work.ForeignID] = reason
+		if strings.TrimSpace(work.ForeignID) != "" {
+			rejectedIDs[work.ForeignID] = reason
+		}
 		if key := indexer.CanonicalDedupKey(work.Title); key != "" {
 			rejectedTitles[key] = reason
 		}
@@ -284,6 +290,10 @@ func (h *AuthorHandler) buildCatalogueReconciliation(ctx context.Context, author
 	localBooks, err := h.books.ListByAuthorIncludingExcluded(ctx, author.ID)
 	if err != nil {
 		return CatalogueReconciliation{}, fmt.Errorf("list local author catalogue: %w", err)
+	}
+	identifiersByBookID, err := h.books.ListBookIdentifiersByAuthor(ctx, author.ID)
+	if err != nil {
+		return CatalogueReconciliation{}, fmt.Errorf("list identifiers for author %d: %w", author.ID, err)
 	}
 	result := CatalogueReconciliation{
 		AuthorID:         author.ID,
@@ -329,14 +339,15 @@ func (h *AuthorHandler) buildCatalogueReconciliation(ctx context.Context, author
 			continue
 		}
 
-		identifiers, err := h.books.ListBookIdentifiers(ctx, book.ID)
-		if err != nil {
-			return CatalogueReconciliation{}, fmt.Errorf("list identifiers for book %d: %w", book.ID, err)
-		}
+		identifiers := identifiersByBookID[book.ID]
 		ids := make([]string, 0, len(identifiers)+1)
-		ids = append(ids, book.ForeignID)
+		if strings.TrimSpace(book.ForeignID) != "" {
+			ids = append(ids, book.ForeignID)
+		}
 		for _, identifier := range identifiers {
-			ids = append(ids, identifier.ForeignID)
+			if strings.TrimSpace(identifier.ForeignID) != "" {
+				ids = append(ids, identifier.ForeignID)
+			}
 		}
 		if anyReconciliationIDAccepted(ids, acceptedIDs) {
 			result.Summary.Kept++

--- a/internal/api/catalogue_reconciliation_test.go
+++ b/internal/api/catalogue_reconciliation_test.go
@@ -275,6 +275,54 @@ func TestPreviewCatalogueReconciliation_PartialProviderNeverUsesAbsence(t *testi
 	}
 }
 
+func TestPreviewCatalogueReconciliation_RejectedEmptyIDDoesNotMatchLocalBook(t *testing.T) {
+	provider := &partialSnapshotProvider{
+		stubMetaProvider: stubMetaProvider{name: "hardcover", works: []models.Book{
+			{ForeignID: "", Title: "Rejected Provider Work", Language: "spa", MetadataProvider: "hardcover"},
+		}},
+		complete: false,
+	}
+	f := newReconciliationFixture(t, provider)
+	local := f.createBook(t, "", "Unrelated Local Book", "hardcover", models.BookStatusWanted)
+
+	got, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Candidates) != 0 {
+		t.Fatalf("candidates = %+v, want empty-id local book protected by partial snapshot", got.Candidates)
+	}
+	if got.Summary.Kept != 1 || got.Summary.Indeterminate != 1 {
+		t.Fatalf("summary = %+v, want unrelated local book kept as indeterminate", got.Summary)
+	}
+	if book, err := f.books.GetByID(context.Background(), local.ID); err != nil || book == nil {
+		t.Fatalf("local book missing after preview: book=%+v err=%v", book, err)
+	}
+}
+
+func TestPreviewCatalogueReconciliation_AcceptedEmptyIDDoesNotKeepLocalBook(t *testing.T) {
+	provider := &partialSnapshotProvider{
+		stubMetaProvider: stubMetaProvider{name: "hardcover", works: []models.Book{
+			{ForeignID: "", Title: "Accepted Provider Work", Language: "eng", MetadataProvider: "hardcover"},
+		}},
+		complete: true,
+	}
+	f := newReconciliationFixture(t, provider)
+	local := f.createBook(t, "", "Unrelated Local Book", "hardcover", models.BookStatusWanted)
+
+	got, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Candidates) != 1 || got.Candidates[0].BookID != local.ID ||
+		got.Candidates[0].Reason != reconcileReasonNotInCatalogue {
+		t.Fatalf("candidates = %+v, want unrelated local book missing from current catalogue", got.Candidates)
+	}
+	if got.Summary.Kept != 0 {
+		t.Fatalf("kept = %d, want 0", got.Summary.Kept)
+	}
+}
+
 func TestPreviewCatalogueReconciliation_InvalidID(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h := &AuthorHandler{}
@@ -380,12 +428,12 @@ func TestCatalogueReconciliation_ReportsDependencyAndStorageErrors(t *testing.T)
 
 	t.Run("identifier query failure", func(t *testing.T) {
 		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
-		book := f.createBook(t, "hc:gone", "Gone", "hardcover", models.BookStatusWanted)
+		f.createBook(t, "hc:gone", "Gone", "hardcover", models.BookStatusWanted)
 		if _, err := f.database.ExecContext(context.Background(), "DROP TABLE book_identifiers"); err != nil {
 			t.Fatal(err)
 		}
 		_, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
-		if err == nil || !strings.Contains(err.Error(), "list identifiers for book "+strconv.FormatInt(book.ID, 10)) {
+		if err == nil || !strings.Contains(err.Error(), "list identifiers for author "+strconv.FormatInt(f.author.ID, 10)) {
 			t.Fatalf("error = %v, want identifier context", err)
 		}
 	})

--- a/internal/api/catalogue_reconciliation_test.go
+++ b/internal/api/catalogue_reconciliation_test.go
@@ -1,0 +1,646 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+type partialSnapshotProvider struct {
+	stubMetaProvider
+	complete bool
+}
+
+type failingSnapshotProvider struct {
+	stubMetaProvider
+	err error
+}
+
+func (p *failingSnapshotProvider) GetAuthorWorksSnapshot(_ context.Context, _ string) ([]models.Book, bool, error) {
+	return nil, false, p.err
+}
+
+type editionResultsProvider struct {
+	partialSnapshotProvider
+	editions map[string][]models.Edition
+	errors   map[string]error
+}
+
+func (p *editionResultsProvider) GetEditions(_ context.Context, foreignID string) ([]models.Edition, error) {
+	if err := p.errors[foreignID]; err != nil {
+		return nil, err
+	}
+	return p.editions[foreignID], nil
+}
+
+func (p *partialSnapshotProvider) GetAuthorWorksSnapshot(_ context.Context, _ string) ([]models.Book, bool, error) {
+	return p.works, p.complete, nil
+}
+
+type reconciliationFixture struct {
+	handler  *AuthorHandler
+	author   *models.Author
+	books    *db.BookRepo
+	profiles *db.MetadataProfileRepo
+	database *sql.DB
+}
+
+func newReconciliationFixture(t *testing.T, provider metadata.Provider) reconciliationFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	profiles := db.NewMetadataProfileRepo(database)
+	profile, err := profiles.GetByID(ctx, models.DefaultMetadataProfileID)
+	if err != nil || profile == nil {
+		t.Fatalf("load default metadata profile: profile=%+v err=%v", profile, err)
+	}
+	profile.AllowedLanguages = "eng"
+	profile.UnknownLanguageBehavior = models.UnknownLanguageFail
+	if err := profiles.Update(ctx, profile); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID: "hc:test-author", Name: "Test Author", SortName: "Author, Test",
+		MetadataProvider: "hardcover", Monitored: true,
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	return reconciliationFixture{
+		handler:  NewAuthorHandler(authors, nil, books, nil, metadata.NewAggregator(provider), nil, profiles, nil),
+		author:   author,
+		books:    books,
+		profiles: profiles,
+		database: database,
+	}
+}
+
+func (f reconciliationFixture) createBook(t *testing.T, foreignID, title, provider, status string) *models.Book {
+	t.Helper()
+	book := &models.Book{
+		ForeignID: foreignID, AuthorID: f.author.ID, Title: title, SortTitle: title,
+		MetadataProvider: provider, Monitored: true, Status: status, MediaType: models.MediaTypeEbook,
+	}
+	if err := f.books.Create(context.Background(), book); err != nil {
+		t.Fatal(err)
+	}
+	return book
+}
+
+func reconciliationRequest(method, target string, authorID int64, body []byte) *http.Request {
+	req := httptest.NewRequest(method, target, bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(authorID, 10))
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestPreviewCatalogueReconciliation_ReportsOnlySafeCandidates(t *testing.T) {
+	provider := &stubMetaProvider{name: "hardcover", works: []models.Book{
+		{ForeignID: "hc:keep", Title: "Keep", Language: "eng", MetadataProvider: "hardcover"},
+		{ForeignID: "hc:spanish", Title: "Spanish", Language: "spa", MetadataProvider: "hardcover"},
+		{ForeignID: "hc:unknown", Title: "Unknown", Language: "", MetadataProvider: "hardcover"},
+	}}
+	f := newReconciliationFixture(t, provider)
+	keep := f.createBook(t, "hc:keep", "Keep", "hardcover", models.BookStatusWanted)
+	spanish := f.createBook(t, "hc:spanish", "Spanish", "hardcover", models.BookStatusWanted)
+	staleProvider := f.createBook(t, "OL-stale", "Old OpenLibrary Work", "openlibrary", models.BookStatusWanted)
+	missing := f.createBook(t, "hc:missing", "Removed Upstream", "hardcover", models.BookStatusWanted)
+	unknown := f.createBook(t, "hc:unknown", "Unknown", "hardcover", models.BookStatusWanted)
+	imported := f.createBook(t, "hc:owned", "Owned", "hardcover", models.BookStatusImported)
+	withFile := f.createBook(t, "hc:partial-owned", "Partially Owned", "hardcover", models.BookStatusWanted)
+	withFile.MediaType = models.MediaTypeBoth
+	if err := f.books.Update(context.Background(), withFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.books.AddBookFile(context.Background(), withFile.ID, models.MediaTypeEbook, "/library/owned.epub"); err != nil {
+		t.Fatal(err)
+	}
+	excluded := f.createBook(t, "hc:excluded", "Excluded", "hardcover", models.BookStatusWanted)
+	if err := f.books.SetExcluded(context.Background(), excluded.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	f.handler.PreviewCatalogueReconciliation(rec, reconciliationRequest(http.MethodGet, "/api/v1/author/1/catalogue-reconciliation", f.author.ID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var got CatalogueReconciliation
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.ProviderComplete || got.Provider != "hardcover" {
+		t.Errorf("provider status = %q complete=%v", got.Provider, got.ProviderComplete)
+	}
+	wantReasons := map[int64]string{
+		spanish.ID:       reconcileReasonLanguage,
+		staleProvider.ID: reconcileReasonProviderChanged,
+		missing.ID:       reconcileReasonNotInCatalogue,
+	}
+	if len(got.Candidates) != len(wantReasons) {
+		t.Fatalf("candidates = %+v, want %d", got.Candidates, len(wantReasons))
+	}
+	for _, candidate := range got.Candidates {
+		if want := wantReasons[candidate.BookID]; want != candidate.Reason {
+			t.Errorf("candidate %d reason = %q, want %q", candidate.BookID, candidate.Reason, want)
+		}
+	}
+	if got.Summary.ProtectedFiles != 1 || got.Summary.ProtectedImported != 1 || got.Summary.ProtectedExcluded != 1 {
+		t.Errorf("protection summary = %+v", got.Summary)
+	}
+	if got.Summary.Indeterminate != 1 {
+		t.Errorf("indeterminate = %d, want 1 for unknown language", got.Summary.Indeterminate)
+	}
+	if got.Summary.Kept != 2 {
+		t.Errorf("kept = %d, want 2 (%q and %q)", got.Summary.Kept, keep.Title, unknown.Title)
+	}
+	_ = imported
+}
+
+func TestApplyCatalogueReconciliation_RecomputesAndProtectsNewFiles(t *testing.T) {
+	provider := &stubMetaProvider{name: "hardcover", works: []models.Book{
+		{ForeignID: "hc:keep", Title: "Keep", Language: "eng", MetadataProvider: "hardcover"},
+	}}
+	f := newReconciliationFixture(t, provider)
+	deleteMe := f.createBook(t, "hc:gone", "Gone", "hardcover", models.BookStatusWanted)
+	becameOwned := f.createBook(t, "hc:owned-after-preview", "Owned after preview", "hardcover", models.BookStatusWanted)
+	becameOwned.MediaType = models.MediaTypeBoth
+	if err := f.books.Update(context.Background(), becameOwned); err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
+	if err != nil || len(preview.Candidates) != 2 {
+		t.Fatalf("preview candidates=%+v err=%v", preview.Candidates, err)
+	}
+	if err := f.books.AddBookFile(context.Background(), becameOwned.ID, models.MediaTypeEbook, "/library/new.epub"); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(applyCatalogueReconciliationRequest{BookIDs: []int64{deleteMe.ID, becameOwned.ID}})
+	rec := httptest.NewRecorder()
+	f.handler.ApplyCatalogueReconciliation(rec, reconciliationRequest(http.MethodPost, "/api/v1/author/1/catalogue-reconciliation", f.author.ID, body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var got CatalogueReconciliation
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Applied == nil || got.Applied.Deleted != 1 || got.Applied.Skipped != 1 {
+		t.Fatalf("apply summary = %+v", got.Applied)
+	}
+	if book, _ := f.books.GetByID(context.Background(), deleteMe.ID); book != nil {
+		t.Errorf("eligible metadata-only row survived: %+v", book)
+	}
+	if book, _ := f.books.GetByID(context.Background(), becameOwned.ID); book == nil {
+		t.Error("file-bearing row was deleted after preview")
+	}
+}
+
+func TestApplyCatalogueReconciliation_UsesOnlyUniqueCurrentCandidates(t *testing.T) {
+	provider := &stubMetaProvider{name: "hardcover"}
+	f := newReconciliationFixture(t, provider)
+	deleteMe := f.createBook(t, "hc:gone", "Gone", "hardcover", models.BookStatusWanted)
+	body, err := json.Marshal(applyCatalogueReconciliationRequest{
+		BookIDs: []int64{0, -1, deleteMe.ID, deleteMe.ID, deleteMe.ID + 999},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	f.handler.ApplyCatalogueReconciliation(rec, reconciliationRequest(
+		http.MethodPost,
+		"/api/v1/author/1/catalogue-reconciliation",
+		f.author.ID,
+		body,
+	))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var got CatalogueReconciliation
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Applied == nil || got.Applied.Requested != 2 || got.Applied.Deleted != 1 || got.Applied.Skipped != 1 {
+		t.Fatalf("apply summary = %+v, want requested=2 deleted=1 skipped=1", got.Applied)
+	}
+}
+
+func TestPreviewCatalogueReconciliation_PartialProviderNeverUsesAbsence(t *testing.T) {
+	provider := &partialSnapshotProvider{
+		stubMetaProvider: stubMetaProvider{name: "hardcover", works: []models.Book{
+			{ForeignID: "hc:spanish", Title: "Spanish", Language: "spa", MetadataProvider: "hardcover"},
+		}},
+		complete: false,
+	}
+	f := newReconciliationFixture(t, provider)
+	missing := f.createBook(t, "hc:not-returned", "Not returned", "hardcover", models.BookStatusWanted)
+	spanish := f.createBook(t, "hc:spanish", "Spanish", "hardcover", models.BookStatusWanted)
+
+	got, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProviderComplete || got.Warning == "" {
+		t.Fatalf("partial snapshot not reported: %+v", got)
+	}
+	if len(got.Candidates) != 1 || got.Candidates[0].BookID != spanish.ID {
+		t.Fatalf("partial candidates = %+v, want only explicit language rejection", got.Candidates)
+	}
+	if got.Summary.Indeterminate != 1 {
+		t.Fatalf("indeterminate = %d, want the missing local row", got.Summary.Indeterminate)
+	}
+	if book, _ := f.books.GetByID(context.Background(), missing.ID); book == nil {
+		t.Fatal("preview mutated the database")
+	}
+}
+
+func TestPreviewCatalogueReconciliation_InvalidID(t *testing.T) {
+	rec := httptest.NewRecorder()
+	h := &AuthorHandler{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/author/nope/catalogue-reconciliation", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "nope")
+	h.PreviewCatalogueReconciliation(rec, req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestApplyCatalogueReconciliation_RejectsInvalidRequests(t *testing.T) {
+	provider := &stubMetaProvider{name: "hardcover"}
+	f := newReconciliationFixture(t, provider)
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{name: "invalid json", body: []byte(`{`)},
+		{name: "missing book ids", body: []byte(`{}`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			f.handler.ApplyCatalogueReconciliation(rec, reconciliationRequest(
+				http.MethodPost,
+				"/api/v1/author/1/catalogue-reconciliation",
+				f.author.ID,
+				tt.body,
+			))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	rec := httptest.NewRecorder()
+	f.handler.ApplyCatalogueReconciliation(rec, reconciliationRequest(
+		http.MethodPost, "/api/v1/author/0/catalogue-reconciliation", 0, []byte(`{"bookIds":[1]}`),
+	))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid author status = %d, want 400", rec.Code)
+	}
+}
+
+func TestCatalogueReconciliation_ReportsDependencyAndStorageErrors(t *testing.T) {
+	t.Run("preview without metadata aggregator", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		f.handler.meta = nil
+		rec := httptest.NewRecorder()
+		f.handler.PreviewCatalogueReconciliation(rec, reconciliationRequest(
+			http.MethodGet, "/api/v1/author/1/catalogue-reconciliation", f.author.ID, nil,
+		))
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("apply without metadata aggregator", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		f.handler.meta = nil
+		rec := httptest.NewRecorder()
+		f.handler.ApplyCatalogueReconciliation(rec, reconciliationRequest(
+			http.MethodPost, "/api/v1/author/1/catalogue-reconciliation", f.author.ID, []byte(`{"bookIds":[1]}`),
+		))
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("profile configuration failure", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		f.handler.profiles = nil
+		_, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
+		if err == nil || !strings.Contains(err.Error(), "metadata profiles") {
+			t.Fatalf("error = %v, want metadata profile configuration error", err)
+		}
+	})
+
+	t.Run("provider failure", func(t *testing.T) {
+		providerErr := errors.New("provider unavailable")
+		f := newReconciliationFixture(t, &failingSnapshotProvider{
+			stubMetaProvider: stubMetaProvider{name: "hardcover"},
+			err:              providerErr,
+		})
+		_, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
+		if !errors.Is(err, providerErr) {
+			t.Fatalf("error = %v, want wrapped provider error", err)
+		}
+	})
+
+	t.Run("local catalogue query failure", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		if _, err := f.database.ExecContext(context.Background(), "DROP TABLE books"); err != nil {
+			t.Fatal(err)
+		}
+		_, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
+		if err == nil || !strings.Contains(err.Error(), "list local author catalogue") {
+			t.Fatalf("error = %v, want local catalogue context", err)
+		}
+	})
+
+	t.Run("identifier query failure", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		book := f.createBook(t, "hc:gone", "Gone", "hardcover", models.BookStatusWanted)
+		if _, err := f.database.ExecContext(context.Background(), "DROP TABLE book_identifiers"); err != nil {
+			t.Fatal(err)
+		}
+		_, err := f.handler.buildCatalogueReconciliation(context.Background(), f.author)
+		if err == nil || !strings.Contains(err.Error(), "list identifiers for book "+strconv.FormatInt(book.ID, 10)) {
+			t.Fatalf("error = %v, want identifier context", err)
+		}
+	})
+
+	t.Run("guarded delete failure", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		candidate := f.createBook(t, "hc:gone", "Gone", "hardcover", models.BookStatusWanted)
+		if _, err := f.database.ExecContext(context.Background(), `
+			CREATE TRIGGER fail_reconciliation_delete
+			BEFORE DELETE ON books
+			BEGIN
+				SELECT RAISE(ABORT, 'blocked delete');
+			END`); err != nil {
+			t.Fatal(err)
+		}
+		body, err := json.Marshal(applyCatalogueReconciliationRequest{BookIDs: []int64{candidate.ID}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		f.handler.ApplyCatalogueReconciliation(rec, reconciliationRequest(
+			http.MethodPost, "/api/v1/author/1/catalogue-reconciliation", f.author.ID, body,
+		))
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500: %s", rec.Code, rec.Body.String())
+		}
+		if book, err := f.books.GetByID(context.Background(), candidate.ID); err != nil || book == nil {
+			t.Fatalf("candidate missing after failed delete: book=%+v err=%v", book, err)
+		}
+	})
+}
+
+func TestOwnedAuthorFromRequest_RejectsMissingUnownedAndUnavailableAuthors(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		rec := httptest.NewRecorder()
+		f.handler.PreviewCatalogueReconciliation(rec, reconciliationRequest(
+			http.MethodGet, "/api/v1/author/999/catalogue-reconciliation", f.author.ID+999, nil,
+		))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("owned by another user", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		owner, err := db.NewUserRepo(f.database).Create(context.Background(), "author-owner", "password-hash")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.database.ExecContext(context.Background(), "UPDATE authors SET owner_user_id = ? WHERE id = ?", owner.ID, f.author.ID); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(auth.EnforceTenancyEnv, "true")
+		req := reconciliationRequest(http.MethodGet, "/api/v1/author/1/catalogue-reconciliation", f.author.ID, nil)
+		ctx := auth.WithUserRole(auth.WithUserID(req.Context(), 7), "user")
+		rec := httptest.NewRecorder()
+		f.handler.PreviewCatalogueReconciliation(rec, req.WithContext(ctx))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("repository unavailable", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		if err := f.database.Close(); err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		f.handler.PreviewCatalogueReconciliation(rec, reconciliationRequest(
+			http.MethodGet, "/api/v1/author/1/catalogue-reconciliation", f.author.ID, nil,
+		))
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rec.Code)
+		}
+	})
+}
+
+func TestReconciliationProfile_ReportsConfigurationErrors(t *testing.T) {
+	if _, err := (&AuthorHandler{}).reconciliationProfile(context.Background(), &models.Author{}); err == nil {
+		t.Fatal("missing profile repository returned nil error")
+	}
+
+	t.Run("profile not found", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		missingID := int64(999)
+		author := *f.author
+		author.MetadataProfileID = &missingID
+		if _, err := f.handler.reconciliationProfile(context.Background(), &author); err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("error = %v, want not found", err)
+		}
+	})
+
+	t.Run("profile query failure", func(t *testing.T) {
+		f := newReconciliationFixture(t, &stubMetaProvider{name: "hardcover"})
+		if _, err := f.database.ExecContext(context.Background(), "DROP TABLE metadata_profiles"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.handler.reconciliationProfile(context.Background(), f.author); err == nil || !strings.Contains(err.Error(), "load metadata profile") {
+			t.Fatalf("error = %v, want load context", err)
+		}
+	})
+}
+
+func TestBuildCatalogueReconciliation_UsesConservativeEditionAndIdentityEvidence(t *testing.T) {
+	pages100 := 100
+	pages300 := 300
+	editionErr := errors.New("edition lookup failed")
+	provider := &editionResultsProvider{
+		partialSnapshotProvider: partialSnapshotProvider{
+			stubMetaProvider: stubMetaProvider{name: "hardcover", works: []models.Book{
+				{ForeignID: "", Title: "No ID", Language: "eng", MetadataProvider: "hardcover"},
+				{ForeignID: "dnb:123", Title: "DNB Work", Language: "eng", MetadataProvider: "dnb"},
+				{ForeignID: "hc:short", Title: "Short Work", Language: "eng", MetadataProvider: "hardcover"},
+				{ForeignID: "hc:error", Title: "Edition Error", Language: "eng", MetadataProvider: "hardcover"},
+				{ForeignID: "hc:accepted", Title: "Accepted Work", Language: "eng", MetadataProvider: "hardcover"},
+				{ForeignID: "hc:spanish", Title: "Matched Spanish", Language: "spa", MetadataProvider: "hardcover"},
+			}},
+			complete: true,
+		},
+		editions: map[string][]models.Edition{
+			"hc:short":    {{NumPages: &pages100}},
+			"hc:accepted": {{NumPages: &pages300}},
+		},
+		errors: map[string]error{"hc:error": editionErr},
+	}
+	f := newReconciliationFixture(t, provider)
+	profile, err := f.profiles.GetByID(context.Background(), models.DefaultMetadataProfileID)
+	if err != nil || profile == nil {
+		t.Fatalf("load profile: profile=%+v err=%v", profile, err)
+	}
+	profile.MinPages = 200
+	if err := f.profiles.Update(context.Background(), profile); err != nil {
+		t.Fatal(err)
+	}
+
+	noID := f.createBook(t, "local:no-id", "No ID", "hardcover", models.BookStatusWanted)
+	dnb := f.createBook(t, "dnb:123", "DNB Work", "dnb", models.BookStatusWanted)
+	short := f.createBook(t, "hc:short", "Short Work", "hardcover", models.BookStatusWanted)
+	editionUnknown := f.createBook(t, "hc:error", "Edition Error", "hardcover", models.BookStatusWanted)
+	alias := f.createBook(t, "OL-alias", "Different Local Title", "openlibrary", models.BookStatusWanted)
+	if err := f.books.UpsertBookIdentifier(context.Background(), alias.ID, "hc:accepted"); err != nil {
+		t.Fatal(err)
+	}
+	titleMatch := f.createBook(t, "OL-title", "Accepted Work", "openlibrary", models.BookStatusWanted)
+	rejectedTitle := f.createBook(t, "OL-spanish", "Matched Spanish", "openlibrary", models.BookStatusWanted)
+	fallbackProvider := f.createBook(t, "OL-stale", "Stale Work", "", models.BookStatusWanted)
+	downloading := f.createBook(t, "hc:downloading", "Downloading", "hardcover", models.BookStatusDownloading)
+	otherOwner, err := db.NewUserRepo(f.database).Create(context.Background(), "other-owner", "password-hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonOwner := &models.Book{
+		ForeignID: "hc:other-owner", AuthorID: f.author.ID, Title: "Other Owner", SortTitle: "Other Owner",
+		MetadataProvider: "hardcover", Monitored: true, Status: models.BookStatusWanted,
+		MediaType: models.MediaTypeEbook, OwnerUserID: otherOwner.ID,
+	}
+	if err := f.books.Create(context.Background(), nonOwner); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(auth.EnforceTenancyEnv, "true")
+	ctx := auth.WithUserRole(auth.WithUserID(context.Background(), 7), "user")
+	got, err := f.handler.buildCatalogueReconciliation(ctx, f.author)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCandidates := map[int64]string{
+		short.ID:            reconcileReasonPages,
+		rejectedTitle.ID:    reconcileReasonLanguage,
+		fallbackProvider.ID: reconcileReasonProviderChanged,
+	}
+	if len(got.Candidates) != len(wantCandidates) {
+		t.Fatalf("candidates = %+v, want %d", got.Candidates, len(wantCandidates))
+	}
+	for _, candidate := range got.Candidates {
+		if want := wantCandidates[candidate.BookID]; candidate.Reason != want {
+			t.Errorf("candidate %d reason = %q, want %q", candidate.BookID, candidate.Reason, want)
+		}
+	}
+	if got.Summary.Indeterminate < 3 {
+		t.Errorf("indeterminate = %d, want no-ID, DNB, and edition-error rows protected", got.Summary.Indeterminate)
+	}
+	if got.Summary.ProtectedStatus < 2 {
+		t.Errorf("protected status = %d, want downloading and other-owner rows", got.Summary.ProtectedStatus)
+	}
+	for _, protected := range []*models.Book{noID, dnb, editionUnknown, alias, titleMatch, downloading, nonOwner} {
+		if book, err := f.books.GetByID(context.Background(), protected.ID); err != nil || book == nil {
+			t.Errorf("protected book %q missing: book=%+v err=%v", protected.Title, book, err)
+		}
+	}
+}
+
+func TestReconciliationRejectReason_ProfileReasonsAndIndeterminateEvidence(t *testing.T) {
+	pages100 := 100
+	pages250 := 250
+	tests := []struct {
+		name          string
+		work          models.Book
+		profile       reconciliationProfile
+		evidence      editionEvidence
+		wantReason    string
+		indeterminate bool
+	}{
+		{name: "accepted", work: models.Book{Title: "Dune"}},
+		{name: "empty title", work: models.Book{}, wantReason: reconcileReasonCatalogueFilter},
+		{name: "author self reference", work: models.Book{Title: "Test Author"}, wantReason: reconcileReasonCatalogueFilter},
+		{name: "provider compilation", work: models.Book{Title: "Stories", IsCompilation: true}, wantReason: reconcileReasonCatalogueFilter},
+		{name: "unambiguous bundle", work: models.Book{Title: "Dune Box Set"}, wantReason: reconcileReasonCatalogueFilter},
+		{
+			name: "known language rejected", work: models.Book{Title: "Libro", Language: "spa"},
+			profile: reconciliationProfile{allowedLangs: []string{"eng"}}, wantReason: reconcileReasonLanguage,
+		},
+		{
+			name: "unknown language kept", work: models.Book{Title: "Unknown"},
+			profile: reconciliationProfile{allowedLangs: []string{"eng"}, unknownFail: true}, indeterminate: true,
+		},
+		{
+			name: "part book", work: models.Book{Title: "The New Turing Omnibus"},
+			profile: reconciliationProfile{skipPartBooks: true}, wantReason: reconcileReasonPartBook,
+		},
+		{
+			name: "missing date", work: models.Book{Title: "Undated"},
+			profile: reconciliationProfile{skipMissingDate: true}, wantReason: reconcileReasonMissingDate,
+		},
+		{
+			name: "below popularity", work: models.Book{Title: "Unpopular", RatingsCount: 1, AverageRating: 2},
+			profile: reconciliationProfile{minPopularity: 10}, wantReason: reconcileReasonPopularity,
+		},
+		{
+			name: "edition lookup unavailable", work: models.Book{Title: "Unresolved"},
+			profile: reconciliationProfile{minPages: 200}, indeterminate: true,
+		},
+		{
+			name: "missing isbn", work: models.Book{Title: "No ISBN"},
+			profile: reconciliationProfile{skipMissingISBN: true}, evidence: editionEvidence{known: true}, wantReason: reconcileReasonISBN,
+		},
+		{
+			name: "below page floor", work: models.Book{Title: "Short"},
+			profile:    reconciliationProfile{minPages: 200},
+			evidence:   editionEvidence{known: true, editions: []models.Edition{{NumPages: &pages100}}},
+			wantReason: reconcileReasonPages,
+		},
+		{
+			name: "page floor accepted", work: models.Book{Title: "Long"},
+			profile:  reconciliationProfile{minPages: 200},
+			evidence: editionEvidence{known: true, editions: []models.Edition{{NumPages: &pages250}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, indeterminate := reconciliationRejectReason(tt.work, "test author", tt.profile, tt.evidence)
+			if reason != tt.wantReason || indeterminate != tt.indeterminate {
+				t.Fatalf("reason=%q indeterminate=%v, want %q/%v", reason, indeterminate, tt.wantReason, tt.indeterminate)
+			}
+		})
+	}
+}

--- a/internal/db/book_identifiers.go
+++ b/internal/db/book_identifiers.go
@@ -103,6 +103,36 @@ func (r *BookRepo) ListBookIdentifiers(ctx context.Context, bookID int64) ([]mod
 	return out, rows.Err()
 }
 
+// ListBookIdentifiersByAuthor returns every provider id attached to the
+// author's books, grouped by book id. The author-scoped query keeps callers
+// from issuing one identifier lookup per book without growing an unbounded
+// IN clause for prolific authors.
+func (r *BookRepo) ListBookIdentifiersByAuthor(ctx context.Context, authorID int64) (map[int64][]models.BookIdentifier, error) {
+	rows, err := r.exec.QueryContext(ctx, `
+		SELECT bi.book_id, bi.provider, bi.foreign_id, bi.created_at, bi.updated_at
+		FROM book_identifiers bi
+		JOIN books b ON b.id = bi.book_id
+		WHERE b.author_id = ?
+		ORDER BY bi.book_id, bi.provider, bi.foreign_id`, authorID)
+	if err != nil {
+		return nil, fmt.Errorf("list book identifiers for author %d: %w", authorID, err)
+	}
+	defer rows.Close()
+	out := make(map[int64][]models.BookIdentifier)
+	for rows.Next() {
+		var identifier models.BookIdentifier
+		if err := rows.Scan(&identifier.BookID, &identifier.Provider, &identifier.ForeignID,
+			&identifier.CreatedAt, &identifier.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan book identifier for author %d: %w", authorID, err)
+		}
+		out[identifier.BookID] = append(out[identifier.BookID], identifier)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read book identifiers for author %d: %w", authorID, err)
+	}
+	return out, nil
+}
+
 // UpsertBookIdentifier attaches foreignID to bookID.
 //
 // Returns a *BookIdentifierConflictError when the id already belongs to a

--- a/internal/db/book_identifiers_test.go
+++ b/internal/db/book_identifiers_test.go
@@ -189,6 +189,58 @@ func TestBookIdentifiers_ReattachingToTheSameBookIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestBookIdentifiers_ListByAuthorGroupsIdentifiersInOneQuery(t *testing.T) {
+	books, author := bookIdentityFixture(t)
+	ctx := context.Background()
+
+	first := newBook("hc:volume-1", "Volume 1", author.ID)
+	second := newBook("hc:volume-2", "Volume 2", author.ID)
+	for _, book := range []*models.Book{first, second} {
+		if err := books.Create(ctx, book); err != nil {
+			t.Fatalf("create %q: %v", book.Title, err)
+		}
+	}
+	if err := books.UpsertBookIdentifier(ctx, first.ID, "OL1W"); err != nil {
+		t.Fatalf("attach first alias: %v", err)
+	}
+	if err := books.UpsertBookIdentifier(ctx, second.ID, "OL2W"); err != nil {
+		t.Fatalf("attach second alias: %v", err)
+	}
+
+	otherAuthor := &models.Author{ForeignID: "OL2A", Name: "Other Author", SortName: "Author, Other"}
+	if err := NewAuthorRepo(books.db).Create(ctx, otherAuthor); err != nil {
+		t.Fatalf("create other author: %v", err)
+	}
+	otherBook := newBook("hc:other", "Other Book", otherAuthor.ID)
+	if err := books.Create(ctx, otherBook); err != nil {
+		t.Fatalf("create other book: %v", err)
+	}
+
+	got, err := books.ListBookIdentifiersByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatalf("list identifiers by author: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("identifier groups = %+v, want two books", got)
+	}
+	for _, book := range []*models.Book{first, second} {
+		if len(got[book.ID]) != 2 {
+			t.Errorf("identifiers for %q = %+v, want primary plus alias", book.Title, got[book.ID])
+		}
+	}
+	if _, ok := got[otherBook.ID]; ok {
+		t.Errorf("other author's identifiers leaked into result: %+v", got[otherBook.ID])
+	}
+
+	empty, err := books.ListBookIdentifiersByAuthor(ctx, author.ID+999)
+	if err != nil {
+		t.Fatalf("list missing author identifiers: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("missing author identifiers = %+v, want empty map", empty)
+	}
+}
+
 // TestBookIdentifiers_DeletingABookClearsItsIdentifiers: the FK cascade is what
 // stops a dead id permanently blocking the same book being re-added, which is
 // the failure migration 068 had to repair for authors.

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -1121,6 +1121,48 @@ func (r *BookRepo) Delete(ctx context.Context, id int64) error {
 	return err
 }
 
+// DeleteMetadataOnlyWantedByIDs removes the requested books only while they
+// are still safe catalogue-only Wanted rows for authorID. The predicates are
+// intentionally repeated at deletion time so an import or scanner that adds a
+// file after a reconciliation preview wins the race and protects the row.
+func (r *BookRepo) DeleteMetadataOnlyWantedByIDs(ctx context.Context, authorID int64, ids []int64) (int64, error) {
+	if authorID <= 0 || len(ids) == 0 {
+		return 0, nil
+	}
+	placeholders := make([]string, 0, len(ids))
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, authorID)
+	for _, id := range ids {
+		if id <= 0 {
+			continue
+		}
+		placeholders = append(placeholders, "?")
+		args = append(args, id)
+	}
+	if len(placeholders) == 0 {
+		return 0, nil
+	}
+	result, err := r.exec.ExecContext(ctx, `
+		DELETE FROM books
+		WHERE author_id = ?
+		  AND id IN (`+strings.Join(placeholders, ",")+`)
+		  AND status = ?
+		  AND excluded = 0
+		  AND COALESCE(file_path, '') = ''
+		  AND COALESCE(ebook_file_path, '') = ''
+		  AND COALESCE(audiobook_file_path, '') = ''
+		  AND NOT EXISTS (SELECT 1 FROM book_files bf WHERE bf.book_id = books.id)`,
+		append(args, models.BookStatusWanted)...)
+	if err != nil {
+		return 0, fmt.Errorf("delete metadata-only wanted books: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count deleted metadata-only wanted books: %w", err)
+	}
+	return deleted, nil
+}
+
 func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Book, error) {
 	var rows *sql.Rows
 	var err error

--- a/internal/db/books_reconciliation_test.go
+++ b/internal/db/books_reconciliation_test.go
@@ -1,0 +1,168 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestDeleteMetadataOnlyWantedByIDs_RechecksEverySafetyGuard(t *testing.T) {
+	database, author, plain := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	create := func(foreignID, title, status string) *models.Book {
+		t.Helper()
+		book := &models.Book{
+			ForeignID: foreignID, AuthorID: author.ID, Title: title, SortTitle: title,
+			Monitored: true, Status: status, MediaType: models.MediaTypeEbook,
+		}
+		if err := repo.Create(ctx, book); err != nil {
+			t.Fatalf("create %s: %v", title, err)
+		}
+		return book
+	}
+
+	imported := create("OL-imported", "Imported", models.BookStatusImported)
+	legacyFile := create("OL-legacy-file", "Legacy file", models.BookStatusWanted)
+	legacyFile.FilePath = "/library/legacy.epub"
+	if err := repo.Update(ctx, legacyFile); err != nil {
+		t.Fatal(err)
+	}
+	legacyEbook := create("OL-legacy-ebook", "Legacy ebook", models.BookStatusWanted)
+	legacyEbook.EbookFilePath = "/library/legacy-ebook.epub"
+	if err := repo.Update(ctx, legacyEbook); err != nil {
+		t.Fatal(err)
+	}
+	legacyAudiobook := create("OL-legacy-audiobook", "Legacy audiobook", models.BookStatusWanted)
+	legacyAudiobook.AudiobookFilePath = "/library/legacy-audiobook.m4b"
+	if err := repo.Update(ctx, legacyAudiobook); err != nil {
+		t.Fatal(err)
+	}
+	trackedFile := create("OL-tracked-file", "Tracked file", models.BookStatusWanted)
+	if err := repo.AddBookFile(ctx, trackedFile.ID, models.MediaTypeEbook, "/library/tracked.epub"); err != nil {
+		t.Fatal(err)
+	}
+	excluded := create("OL-excluded", "Excluded", models.BookStatusWanted)
+	if err := repo.SetExcluded(ctx, excluded.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	downloading := create("OL-downloading", "Downloading", models.BookStatusDownloading)
+
+	ids := []int64{
+		plain.ID, imported.ID, legacyFile.ID, legacyEbook.ID, legacyAudiobook.ID,
+		trackedFile.ID, excluded.ID, downloading.ID,
+	}
+	deleted, err := repo.DeleteMetadataOnlyWantedByIDs(ctx, author.ID, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	if got, err := repo.GetByID(ctx, plain.ID); err != nil || got != nil {
+		t.Fatalf("plain metadata-only Wanted row survived: book=%+v err=%v", got, err)
+	}
+	for _, protected := range []*models.Book{
+		imported, legacyFile, legacyEbook, legacyAudiobook, trackedFile, excluded, downloading,
+	} {
+		if got, err := repo.GetByID(ctx, protected.ID); err != nil || got == nil {
+			t.Errorf("protected book %q was deleted: book=%+v err=%v", protected.Title, got, err)
+		}
+	}
+}
+
+func TestDeleteMetadataOnlyWantedByIDs_IsAuthorScoped(t *testing.T) {
+	database, author, book := openTestDB(t)
+	repo := NewBookRepo(database)
+	deleted, err := repo.DeleteMetadataOnlyWantedByIDs(context.Background(), author.ID+999, []int64{book.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted = %d, want 0", deleted)
+	}
+	if got, err := repo.GetByID(context.Background(), book.ID); err != nil || got == nil {
+		t.Fatalf("cross-author delete removed book: book=%+v err=%v", got, err)
+	}
+}
+
+func TestDeleteMetadataOnlyWantedByIDs_IgnoresInvalidInputs(t *testing.T) {
+	database, author, _ := openTestDB(t)
+	repo := NewBookRepo(database)
+	for _, tt := range []struct {
+		name     string
+		authorID int64
+		ids      []int64
+	}{
+		{name: "invalid author", ids: []int64{1}},
+		{name: "empty ids", authorID: author.ID},
+		{name: "only invalid ids", authorID: author.ID, ids: []int64{0, -1}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			deleted, err := repo.DeleteMetadataOnlyWantedByIDs(context.Background(), tt.authorID, tt.ids)
+			if err != nil || deleted != 0 {
+				t.Fatalf("deleted=%d err=%v, want 0/nil", deleted, err)
+			}
+		})
+	}
+}
+
+func TestDeleteMetadataOnlyWantedByIDs_ReportsDatabaseErrors(t *testing.T) {
+	database, author, _ := openTestDB(t)
+	execErr := errors.New("exec failed")
+	rowsErr := errors.New("rows affected failed")
+	for _, tt := range []struct {
+		name string
+		exec dbExecutor
+		want error
+	}{
+		{
+			name: "delete",
+			exec: reconciliationExecutor{err: execErr},
+			want: execErr,
+		},
+		{
+			name: "rows affected",
+			exec: reconciliationExecutor{result: reconciliationResult{rowsErr: rowsErr}},
+			want: rowsErr,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewBookRepo(database)
+			repo.exec = tt.exec
+			deleted, err := repo.DeleteMetadataOnlyWantedByIDs(context.Background(), author.ID, []int64{-1, 1})
+			if deleted != 0 || !errors.Is(err, tt.want) {
+				t.Fatalf("deleted=%d err=%v, want wrapped %v", deleted, err, tt.want)
+			}
+		})
+	}
+}
+
+type reconciliationExecutor struct {
+	result sql.Result
+	err    error
+}
+
+func (e reconciliationExecutor) ExecContext(context.Context, string, ...any) (sql.Result, error) {
+	return e.result, e.err
+}
+
+func (reconciliationExecutor) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	panic("unexpected query")
+}
+
+func (reconciliationExecutor) QueryRowContext(context.Context, string, ...any) *sql.Row {
+	panic("unexpected query row")
+}
+
+type reconciliationResult struct {
+	rowsErr error
+}
+
+func (reconciliationResult) LastInsertId() (int64, error) { return 0, nil }
+
+func (r reconciliationResult) RowsAffected() (int64, error) { return 0, r.rowsErr }

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"sort"
@@ -15,6 +16,70 @@ import (
 
 type worksProvider interface {
 	GetAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error)
+}
+
+// authorWorksSnapshotProvider is the optional, stronger form of
+// worksProvider used by destructive catalogue reconciliation. Providers with
+// multiple best-effort upstream calls can report that the returned slice is
+// partial even when at least one call succeeded.
+type authorWorksSnapshotProvider interface {
+	GetAuthorWorksSnapshot(ctx context.Context, authorForeignID string) ([]models.Book, bool, error)
+}
+
+// AuthorWorksSnapshot is a fresh primary-provider catalogue read. Complete is
+// false when the provider returned usable but partial data; callers must not
+// infer that a missing work was removed upstream in that case.
+type AuthorWorksSnapshot struct {
+	Books    []models.Book
+	Provider string
+	Complete bool
+}
+
+// GetPrimaryAuthorWorksSnapshot bypasses the metadata cache and queries only
+// the provider identified by authorForeignID. It exists for explicit catalogue
+// reconciliation: stale cached data or a failed supplemental enricher is not a
+// safe basis for deleting local rows.
+func (a *Aggregator) GetPrimaryAuthorWorksSnapshot(ctx context.Context, authorForeignID string) (AuthorWorksSnapshot, error) {
+	provider := a.providerForForeignID(authorForeignID)
+	if provider == nil {
+		return AuthorWorksSnapshot{}, errors.New("metadata provider is not available for this author")
+	}
+	name := normalizedProviderName(provider.Name())
+	if sp, ok := provider.(authorWorksSnapshotProvider); ok {
+		books, complete, err := sp.GetAuthorWorksSnapshot(ctx, authorForeignID)
+		if err != nil {
+			return AuthorWorksSnapshot{}, err
+		}
+		return AuthorWorksSnapshot{Books: books, Provider: name, Complete: complete}, nil
+	}
+	wp, ok := provider.(worksProvider)
+	if !ok {
+		return AuthorWorksSnapshot{}, fmt.Errorf("metadata provider %s cannot enumerate author works", name)
+	}
+	books, err := wp.GetAuthorWorks(ctx, authorForeignID)
+	if err != nil {
+		return AuthorWorksSnapshot{}, err
+	}
+	// DNB currently caps an author lookup at 50 records. The data is useful for
+	// exact profile matches, but absence from it is never authoritative.
+	complete := name != "dnb"
+	return AuthorWorksSnapshot{Books: books, Provider: name, Complete: complete}, nil
+}
+
+// GetAuthorWorksSnapshotForAuthor returns the same effective primary-plus-
+// supplement catalogue used by a normal author refresh, but without using the
+// author-works cache. A configured supplement failure makes the snapshot
+// partial; a supplement that is not configured is disabled and therefore does
+// not make the active catalogue indeterminate.
+func (a *Aggregator) GetAuthorWorksSnapshotForAuthor(ctx context.Context, author models.Author) (AuthorWorksSnapshot, error) {
+	snapshot, err := a.GetPrimaryAuthorWorksSnapshot(ctx, author.ForeignID)
+	if err != nil {
+		return AuthorWorksSnapshot{}, err
+	}
+	books, supplementsComplete, _ := a.mergeAuthorWorksSupplements(ctx, snapshot.Books, author)
+	snapshot.Books = books
+	snapshot.Complete = snapshot.Complete && supplementsComplete
+	return snapshot, nil
 }
 
 // workLanguageFiller is the optional capability a provider implements when it
@@ -120,17 +185,29 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 		return nil, err
 	}
 
+	books, _, cacheable := a.mergeAuthorWorksSupplements(ctx, books, author)
+
+	a.enrichMissingAuthorWorkCovers(ctx, books)
+	if cacheable {
+		a.cache.set(key, cloneBooks(books))
+	}
+	return books, nil
+}
+
+func (a *Aggregator) mergeAuthorWorksSupplements(ctx context.Context, books []models.Book, author models.Author) ([]models.Book, bool, bool) {
 	authorName := strings.TrimSpace(author.Name)
-	supplementsComplete := true
+	complete := true
+	cacheable := true
 	compilationTitles := map[string]struct{}{}
 	if authorName != "" {
 		for _, provider := range a.authorWorksByNameProviders() {
 			supplemental, err := a.authorWorksSupplement(ctx, provider, author, authorName)
 			if err != nil {
-				supplementsComplete = false
+				cacheable = false
 				if errors.Is(err, ErrProviderNotConfigured) {
 					continue
 				}
+				complete = false
 				slog.Warn("author works supplement failed", "provider", provider.Name(), "author", authorName, "error", err)
 				continue
 			}
@@ -161,12 +238,7 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 	books = pruneAuthorWorkRedundantTitles(books)
 	books = pruneAuthorWorkSubjectOutliers(books)
 	books = pruneAuthorWorkSelfReference(books, author)
-
-	a.enrichMissingAuthorWorkCovers(ctx, books)
-	if supplementsComplete {
-		a.cache.set(key, cloneBooks(books))
-	}
-	return books, nil
+	return books, complete, cacheable
 }
 
 func (a *Aggregator) rawPrimaryAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {

--- a/internal/metadata/aggregator_author_works_test.go
+++ b/internal/metadata/aggregator_author_works_test.go
@@ -539,6 +539,49 @@ func TestAggregator_GetAuthorWorksForAuthor_ContinuesWhenSupplementFails(t *test
 	}
 }
 
+func TestAggregator_GetAuthorWorksSnapshotForAuthor_IncludesSupplementsAndReportsFailures(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Dune", MetadataProvider: "openlibrary"},
+		}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider: mockProvider{name: "hardcover"},
+		authorWorksByName: []models.Book{
+			{ForeignID: "hc:children-of-dune", Title: "Children of Dune", MetadataProvider: "hardcover"},
+		},
+	}
+	agg := newTestAggregator(primary, hardcover)
+	author := models.Author{ForeignID: "OL123A", Name: "Frank Herbert"}
+
+	snapshot, err := agg.GetAuthorWorksSnapshotForAuthor(context.Background(), author)
+	if err != nil {
+		t.Fatalf("GetAuthorWorksSnapshotForAuthor: %v", err)
+	}
+	if !snapshot.Complete || len(snapshot.Books) != 2 || snapshot.Books[1].ForeignID != "hc:children-of-dune" {
+		t.Fatalf("complete merged snapshot = %+v", snapshot)
+	}
+
+	hardcover.authorWorksByName = nil
+	hardcover.authorWorksByNameErr = errors.New("hardcover unavailable")
+	snapshot, err = agg.GetAuthorWorksSnapshotForAuthor(context.Background(), author)
+	if err != nil {
+		t.Fatalf("GetAuthorWorksSnapshotForAuthor after failure: %v", err)
+	}
+	if snapshot.Complete {
+		t.Fatalf("configured supplement failure was reported complete: %+v", snapshot)
+	}
+
+	hardcover.authorWorksByNameErr = ErrProviderNotConfigured
+	snapshot, err = agg.GetAuthorWorksSnapshotForAuthor(context.Background(), author)
+	if err != nil {
+		t.Fatalf("GetAuthorWorksSnapshotForAuthor while disabled: %v", err)
+	}
+	if !snapshot.Complete {
+		t.Fatalf("disabled supplement made the active catalogue partial: %+v", snapshot)
+	}
+}
+
 func TestAggregator_GetAuthorWorksForAuthor_DoesNotCacheUnconfiguredSupplement(t *testing.T) {
 	primary := &mockWorksProvider{
 		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -299,22 +299,33 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 // Both upstream calls are best-effort: as long as one returns, we proceed —
 // the other's failure is logged.
 func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {
+	books, _, err := c.GetAuthorWorksSnapshot(ctx, authorForeignID)
+	return books, err
+}
+
+// GetAuthorWorksSnapshot is the reconciliation-aware form of GetAuthorWorks.
+// OpenLibrary's works and search endpoints are intentionally best-effort for a
+// normal refresh, but a successful half-result must not be treated as proof
+// that absent local books are stale.
+func (c *Client) GetAuthorWorksSnapshot(ctx context.Context, authorForeignID string) ([]models.Book, bool, error) {
 	var (
-		primary    []authorWorkEntry
-		primaryErr error
-		enrichment []models.Book
-		enrichErr  error
-		wg         sync.WaitGroup
+		primary         []authorWorkEntry
+		primaryComplete bool
+		primaryErr      error
+		enrichment      []models.Book
+		enrichComplete  bool
+		enrichErr       error
+		wg              sync.WaitGroup
 	)
 
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		primary, primaryErr = c.authorWorksBackfill(ctx, authorForeignID)
+		primary, primaryComplete, primaryErr = c.authorWorksBackfill(ctx, authorForeignID)
 	}()
 	go func() {
 		defer wg.Done()
-		enrichment, enrichErr = c.searchAuthorWorks(ctx, authorForeignID)
+		enrichment, enrichComplete, enrichErr = c.searchAuthorWorks(ctx, authorForeignID)
 	}()
 	wg.Wait()
 
@@ -325,7 +336,7 @@ func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]
 		slog.Debug("openlibrary: author search enrichment failed", "author", authorForeignID, "error", enrichErr)
 	}
 	if primaryErr != nil && enrichErr != nil {
-		return nil, fmt.Errorf("get author works %s: primary=%w enrichment=%w", authorForeignID, primaryErr, enrichErr)
+		return nil, false, fmt.Errorf("get author works %s: primary=%w enrichment=%w", authorForeignID, primaryErr, enrichErr)
 	}
 
 	// Build enrichment index: workID → search result for fast lookup.
@@ -413,7 +424,7 @@ func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]
 		books = append(books, e)
 	}
 
-	return books, nil
+	return books, primaryErr == nil && enrichErr == nil && primaryComplete && enrichComplete, nil
 }
 
 // searchAuthorWorks queries the OL search endpoint for all works by the given
@@ -425,11 +436,13 @@ func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]
 // Uses /search.json (FastAPI-backed JSON API). /search without .json is the
 // HTML web-UI path still served by Solr, which returns HTTP 500
 // "DEPRECATED ENDPOINT ACCESSED" for API consumers (issue #462).
-func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {
+func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, bool, error) {
+	const resultLimit = 200
 	u := fmt.Sprintf("%s/search.json?author_key=%s&fields=key,title,language,edition_count,first_publish_year,cover_i,isbn,subject,ratings_count,ratings_average,author_key&limit=200",
 		baseURL, authorForeignID)
 	var resp struct {
-		Docs []struct {
+		NumFound int `json:"numFound"`
+		Docs     []struct {
 			Key              string   `json:"key"`
 			Title            string   `json:"title"`
 			Language         []string `json:"language"`
@@ -444,7 +457,7 @@ func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) 
 		} `json:"docs"`
 	}
 	if err := c.getJSON(ctx, u, &resp); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	books := make([]models.Book, 0, len(resp.Docs))
 	for _, doc := range resp.Docs {
@@ -475,7 +488,8 @@ func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) 
 		}
 		books = append(books, b)
 	}
-	return books, nil
+	complete := len(resp.Docs) < resultLimit || (resp.NumFound > 0 && len(resp.Docs) >= resp.NumFound)
+	return books, complete, nil
 }
 
 // authorWorksBackfill fetches the author's works list from OpenLibrary's
@@ -489,15 +503,16 @@ func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) 
 // hard cap of 100 books on prolific authors). We now page through until the
 // catalogue is exhausted, bounded by authorWorksMaxFetch to keep pathological
 // or maliciously large responses from running away.
-func (c *Client) authorWorksBackfill(ctx context.Context, authorForeignID string) ([]authorWorkEntry, error) {
+func (c *Client) authorWorksBackfill(ctx context.Context, authorForeignID string) ([]authorWorkEntry, bool, error) {
 	var entries []authorWorkEntry
+	complete := false
 	for offset := 0; offset < authorWorksMaxFetch; offset += authorWorksPageSize {
 		u := fmt.Sprintf("%s/authors/%s/works.json?limit=%d&offset=%d",
 			baseURL, authorForeignID, authorWorksPageSize, offset)
 		var resp authorWorksResponse
 		if err := c.getJSON(ctx, u, &resp); err != nil {
 			if offset == 0 {
-				return nil, err
+				return nil, false, err
 			}
 			// A later page failing shouldn't discard the works already
 			// collected — return what we have and let enrichment fill gaps.
@@ -509,16 +524,26 @@ func (c *Client) authorWorksBackfill(ctx context.Context, authorForeignID string
 		// Stop on a short page (end of list) or once we've collected the
 		// advertised total. Size is omitted (0) by older/partial responses,
 		// in which case the short-page check is the authoritative terminator.
-		if len(resp.Entries) < authorWorksPageSize ||
-			(resp.Size > 0 && len(entries) >= resp.Size) {
+		if resp.Size > 0 {
+			if len(entries) >= resp.Size {
+				complete = true
+				break
+			}
+			if len(resp.Entries) < authorWorksPageSize {
+				// The provider advertised more works than it returned. Keep the
+				// usable page, but do not make absence authoritative.
+				break
+			}
+		} else if len(resp.Entries) < authorWorksPageSize {
+			complete = true
 			break
 		}
 	}
-	if len(entries) >= authorWorksMaxFetch {
+	if !complete && len(entries) >= authorWorksMaxFetch {
 		slog.Warn("openlibrary: author works hit pagination cap; catalogue may be truncated",
 			"author", authorForeignID, "cap", authorWorksMaxFetch)
 	}
-	return entries, nil
+	return entries, complete, nil
 }
 
 // pickPreferredLanguage returns "eng" if present in the list, otherwise the

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -986,6 +986,38 @@ func TestGetAuthorWorks_HTTP_PaginatesPastFirstPage(t *testing.T) {
 	}
 }
 
+func TestGetAuthorWorksSnapshot_HTTP_ReportsInterruptedPaginationAsPartial(t *testing.T) {
+	worksHandler := func(r *http.Request) string {
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		if offset > 0 {
+			return `{broken`
+		}
+		entries := make([]authorWorkEntry, 0, authorWorksPageSize)
+		for i := 0; i < authorWorksPageSize; i++ {
+			entries = append(entries, authorWorkEntry{
+				Key:   "/works/OL" + strconv.Itoa(i) + "W",
+				Title: "Book " + strconv.Itoa(i),
+			})
+		}
+		return jsonStr(authorWorksResponse{Size: authorWorksPageSize + 1, Entries: entries})
+	}
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/authors/OL123A/works.json": worksHandler,
+		"/search.json":               jsonStr(searchRespForAuthor{}),
+	})
+
+	books, complete, err := c.GetAuthorWorksSnapshot(context.Background(), "OL123A")
+	if err != nil {
+		t.Fatalf("GetAuthorWorksSnapshot: %v", err)
+	}
+	if complete {
+		t.Fatal("interrupted pagination was reported as complete")
+	}
+	if len(books) != authorWorksPageSize {
+		t.Fatalf("expected usable first page of %d books, got %d", authorWorksPageSize, len(books))
+	}
+}
+
 // Works present only in the search index (when /authors/{id}/works is empty)
 // are still returned as a fallback — the search enrichment source stands on
 // its own when the works endpoint returns nothing.

--- a/web/src/api/authors.ts
+++ b/web/src/api/authors.ts
@@ -116,6 +116,49 @@ export interface MergeAuthorsResult {
   TargetUpdated: boolean
 }
 
+export type CatalogueReconciliationReason =
+  | 'provider_changed'
+  | 'not_in_current_catalogue'
+  | 'language_not_allowed'
+  | 'part_book'
+  | 'missing_release_date'
+  | 'below_minimum_popularity'
+  | 'below_minimum_pages'
+  | 'missing_isbn'
+  | 'catalogue_filter'
+
+export interface CatalogueReconciliationCandidate {
+  bookId: number
+  title: string
+  metadataProvider: string
+  reason: CatalogueReconciliationReason
+}
+
+export interface CatalogueReconciliationSummary {
+  total: number
+  candidates: number
+  kept: number
+  protected: number
+  protectedFiles: number
+  protectedImported: number
+  protectedStatus: number
+  protectedExcluded: number
+  indeterminate: number
+  reasons: Partial<Record<CatalogueReconciliationReason, number>>
+}
+
+export interface CatalogueReconciliation {
+  authorId: number
+  authorName: string
+  provider: string
+  providerComplete: boolean
+  profileName: string
+  warning?: string
+  candidates: CatalogueReconciliationCandidate[]
+  summary: CatalogueReconciliationSummary
+  applied?: { requested: number; deleted: number; skipped: number }
+}
+
 export type MediaType = 'ebook' | 'audiobook' | 'both'
 export type AuthorMonitorMode = 'all' | 'future' | 'latest' | 'none' | 'series'
 export type MonitorNewItems = 'all' | 'none'
@@ -191,6 +234,13 @@ export const authorsApi = {
   deleteAuthor: (id: number, deleteFiles = false) =>
     request<void>(`/author/${id}${deleteFiles ? '?deleteFiles=true' : ''}`, { method: 'DELETE' }),
   refreshAuthor: (id: number) => request<void>(`/author/${id}/refresh`, { method: 'POST' }),
+  previewAuthorCatalogueReconciliation: (id: number) =>
+    request<CatalogueReconciliation>(`/author/${id}/catalogue-reconciliation`),
+  applyAuthorCatalogueReconciliation: (id: number, bookIds: number[]) =>
+    request<CatalogueReconciliation>(`/author/${id}/catalogue-reconciliation`, {
+      method: 'POST',
+      body: JSON.stringify({ bookIds }),
+    }),
   searchAuthorLinkCandidates: (id: number, term: string) =>
     request<Author[]>(`/author/${id}/relink-upstream/candidates?term=${encodeURIComponent(term)}`),
   relinkAuthorUpstream: (id: number, candidate?: RelinkAuthorCandidate) =>

--- a/web/src/components/CatalogueReconciliationModal.test.tsx
+++ b/web/src/components/CatalogueReconciliationModal.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api, CatalogueReconciliation } from '../api/client'
+import CatalogueReconciliationModal from './CatalogueReconciliationModal'
+
+vi.mock('react-i18next', () => {
+  const t = (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback
+      const template = String(fallback?.defaultValue ?? key)
+      return Object.entries(fallback ?? {}).reduce(
+        (text, [name, value]) => name === 'defaultValue' ? text : text.replaceAll(`{{${name}}}`, String(value)),
+        template,
+      )
+  }
+  return { useTranslation: () => ({ t }) }
+})
+
+vi.mock('../api/client', () => ({
+  api: {
+    previewAuthorCatalogueReconciliation: vi.fn(),
+    applyAuthorCatalogueReconciliation: vi.fn(),
+  },
+}))
+
+const preview: CatalogueReconciliation = {
+  authorId: 7,
+  authorName: 'Test Author',
+  provider: 'hardcover',
+  providerComplete: true,
+  profileName: 'English only',
+  candidates: [
+    { bookId: 11, title: 'Libro', metadataProvider: 'hardcover', reason: 'language_not_allowed' },
+    { bookId: 12, title: 'Old Work', metadataProvider: 'openlibrary', reason: 'provider_changed' },
+  ],
+  summary: {
+    total: 8,
+    candidates: 2,
+    kept: 3,
+    protected: 3,
+    protectedFiles: 2,
+    protectedImported: 1,
+    protectedStatus: 0,
+    protectedExcluded: 0,
+    indeterminate: 1,
+    reasons: { language_not_allowed: 1, provider_changed: 1 },
+  },
+}
+
+describe('CatalogueReconciliationModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.previewAuthorCatalogueReconciliation).mockResolvedValue(preview)
+  })
+
+  it('previews candidates and explains protected rows before apply', async () => {
+    render(<CatalogueReconciliationModal authorId={7} authorName="Test Author" onClose={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText('Libro')).toBeInTheDocument())
+    expect(api.previewAuthorCatalogueReconciliation).toHaveBeenCalledWith(7)
+    expect(screen.getByText('Old Work')).toBeInTheDocument()
+    expect(screen.getByText('Provider: hardcover · Profile: English only')).toBeInTheDocument()
+    expect(screen.getByText(/2 file-bearing, 1 imported, 0 other-status, and 0 excluded/)).toBeInTheDocument()
+    expect(screen.getByText('1 row(s) were kept because provider or profile evidence was incomplete.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove 2 stale row(s)' })).toBeInTheDocument()
+  })
+
+  it('applies exactly the previewed IDs and reports server-side rechecks', async () => {
+    const onApplied = vi.fn()
+    vi.mocked(api.applyAuthorCatalogueReconciliation).mockResolvedValue({
+      ...preview,
+      applied: { requested: 2, deleted: 1, skipped: 1 },
+    })
+    render(<CatalogueReconciliationModal authorId={7} authorName="Test Author" onClose={() => {}} onApplied={onApplied} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove 2 stale row(s)' }))
+
+    await waitFor(() => {
+      expect(api.applyAuthorCatalogueReconciliation).toHaveBeenCalledWith(7, [11, 12])
+      expect(onApplied).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByText('Removed 1 row(s). 1 were skipped because they were no longer eligible.')).toBeInTheDocument()
+    expect(onApplied).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies only the rows selected by the user', async () => {
+    vi.mocked(api.applyAuthorCatalogueReconciliation).mockResolvedValue({
+      ...preview,
+      applied: { requested: 1, deleted: 1, skipped: 0 },
+    })
+    render(<CatalogueReconciliationModal authorId={7} authorName="Test Author" onClose={() => {}} />)
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Select Old Work' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove 1 stale row(s)' }))
+
+    await waitFor(() => {
+      expect(api.applyAuthorCatalogueReconciliation).toHaveBeenCalledWith(7, [11])
+    })
+  })
+
+  it('disables apply when every candidate is deselected', async () => {
+    render(<CatalogueReconciliationModal authorId={7} authorName="Test Author" onClose={() => {}} />)
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Select Libro' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Old Work' }))
+
+    expect(screen.getByRole('button', { name: 'Remove 0 stale row(s)' })).toBeDisabled()
+  })
+
+  it('does not offer apply when the preview is clean', async () => {
+    vi.mocked(api.previewAuthorCatalogueReconciliation).mockResolvedValue({
+      ...preview,
+      candidates: [],
+      summary: { ...preview.summary, candidates: 0 },
+    })
+    render(<CatalogueReconciliationModal authorId={7} authorName="Test Author" onClose={() => {}} />)
+
+    expect(await screen.findByText('No metadata-only Wanted rows need reconciliation.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Remove .* stale/ })).toBeDisabled()
+  })
+})

--- a/web/src/components/CatalogueReconciliationModal.tsx
+++ b/web/src/components/CatalogueReconciliationModal.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api, CatalogueReconciliation, CatalogueReconciliationReason } from '../api/client'
+import { btn, btnSize } from './buttons'
+
+interface Props {
+  authorId: number
+  authorName: string
+  onClose: () => void
+  onApplied?: () => void
+}
+
+const reasonDefaults: Record<CatalogueReconciliationReason, string> = {
+  provider_changed: 'From the previous metadata provider',
+  not_in_current_catalogue: 'No longer in the current provider catalogue',
+  language_not_allowed: 'Rejected by the language filter',
+  part_book: 'Rejected as a box set or part-book',
+  missing_release_date: 'Rejected because the release date is missing',
+  below_minimum_popularity: 'Below the minimum popularity',
+  below_minimum_pages: 'Below the minimum page count',
+  missing_isbn: 'No edition has an ISBN',
+  catalogue_filter: 'Rejected by the catalogue filter',
+}
+
+export default function CatalogueReconciliationModal({ authorId, authorName, onClose, onApplied }: Props) {
+  const { t } = useTranslation()
+  const [result, setResult] = useState<CatalogueReconciliation | null>(null)
+  const [selectedBookIds, setSelectedBookIds] = useState<Set<number>>(new Set())
+  const [loading, setLoading] = useState(true)
+  const [applying, setApplying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    api.previewAuthorCatalogueReconciliation(authorId)
+      .then(preview => {
+        if (!cancelled) {
+          setResult(preview)
+          setSelectedBookIds(new Set(preview.candidates.map(candidate => candidate.bookId)))
+        }
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof Error ? err.message : t('catalogueReconciliation.previewFailed', 'Preview failed'))
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [authorId, t])
+
+  const apply = async () => {
+    if (!result) return
+    const selectedIds = result.candidates
+      .filter(candidate => selectedBookIds.has(candidate.bookId))
+      .map(candidate => candidate.bookId)
+    if (selectedIds.length === 0) return
+    setApplying(true)
+    setError(null)
+    try {
+      const applied = await api.applyAuthorCatalogueReconciliation(
+        authorId,
+        selectedIds,
+      )
+      setResult(applied)
+      if ((applied.applied?.deleted ?? 0) > 0) onApplied?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('catalogueReconciliation.applyFailed', 'Reconciliation failed'))
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const candidates = result?.candidates ?? []
+  const applied = result?.applied
+  const selectedCount = candidates.reduce(
+    (count, candidate) => count + (selectedBookIds.has(candidate.bookId) ? 1 : 0),
+    0,
+  )
+
+  const toggleCandidate = (bookId: number) => {
+    setSelectedBookIds(current => {
+      const next = new Set(current)
+      if (next.has(bookId)) next.delete(bookId)
+      else next.add(bookId)
+      return next
+    })
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-700 rounded-lg shadow-xl p-6 w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col"
+        onClick={event => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="catalogue-reconciliation-title"
+      >
+        <h2 id="catalogue-reconciliation-title" className="text-base font-semibold text-slate-900 dark:text-white">
+          {t('catalogueReconciliation.title', 'Reconcile catalogue')}
+        </h2>
+        <p className="mt-1 text-xs text-slate-500 dark:text-zinc-400">
+          {t('catalogueReconciliation.description', {
+            author: authorName,
+            defaultValue: 'Compare {{author}}’s metadata-only Wanted rows with the current provider and metadata profile.',
+          })}
+        </p>
+
+        {loading ? (
+          <p className="mt-4 text-sm text-slate-500 dark:text-zinc-400">
+            {t('catalogueReconciliation.loading', 'Checking the current provider catalogue…')}
+          </p>
+        ) : error && !result ? (
+          <p className="mt-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+        ) : result ? (
+          <>
+            <div className="mt-4 grid grid-cols-3 gap-px overflow-hidden rounded-lg border border-slate-200 bg-slate-200 dark:border-zinc-800 dark:bg-zinc-800">
+              <SummaryCell label={t('catalogueReconciliation.remove', 'Safe to remove')} value={result.summary.candidates} tone="danger" />
+              <SummaryCell label={t('catalogueReconciliation.protected', 'Protected')} value={result.summary.protected} />
+              <SummaryCell label={t('catalogueReconciliation.kept', 'Still accepted')} value={result.summary.kept} />
+            </div>
+
+            <p className="mt-3 text-xs text-slate-600 dark:text-zinc-400">
+              {t('catalogueReconciliation.context', {
+                provider: result.provider,
+                profile: result.profileName,
+                defaultValue: 'Provider: {{provider}} · Profile: {{profile}}',
+              })}
+            </p>
+            <p className="mt-3 text-xs text-slate-600 dark:text-zinc-400">
+              {t('catalogueReconciliation.safeguards', {
+                files: result.summary.protectedFiles,
+                imported: result.summary.protectedImported,
+                status: result.summary.protectedStatus,
+                excluded: result.summary.protectedExcluded,
+                defaultValue: 'Files are never deleted. Protected: {{files}} file-bearing, {{imported}} imported, {{status}} other-status, and {{excluded}} excluded row(s). Apply rechecks every safeguard.',
+              })}
+            </p>
+
+            {result.summary.indeterminate > 0 && (
+              <p className="mt-2 text-xs text-slate-600 dark:text-zinc-400">
+                {t('catalogueReconciliation.indeterminate', {
+                  count: result.summary.indeterminate,
+                  defaultValue: '{{count}} row(s) were kept because provider or profile evidence was incomplete.',
+                })}
+              </p>
+            )}
+
+            {result.warning && (
+              <div className="mt-3 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
+                {t('catalogueReconciliation.partialWarning', result.warning)}
+              </div>
+            )}
+
+            {applied ? (
+              <div className="mt-4 rounded border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">
+                {t('catalogueReconciliation.applied', {
+                  deleted: applied.deleted,
+                  skipped: applied.skipped,
+                  defaultValue: 'Removed {{deleted}} row(s). {{skipped}} were skipped because they were no longer eligible.',
+                })}
+              </div>
+            ) : candidates.length === 0 ? (
+              <p className="mt-4 text-sm text-slate-600 dark:text-zinc-400">
+                {t('catalogueReconciliation.clean', 'No metadata-only Wanted rows need reconciliation.')}
+              </p>
+            ) : (
+              <div className="mt-4 min-h-0 flex-1 overflow-y-auto rounded border border-slate-200 dark:border-zinc-800">
+                <ul className="divide-y divide-slate-200 dark:divide-zinc-800">
+                  {candidates.map(candidate => (
+                    <li key={candidate.bookId} className="px-3 py-2 text-xs">
+                      <label className="flex cursor-pointer items-start gap-3">
+                        <input
+                          type="checkbox"
+                          checked={selectedBookIds.has(candidate.bookId)}
+                          onChange={() => toggleCandidate(candidate.bookId)}
+                          disabled={applying}
+                          aria-label={t('catalogueReconciliation.selectCandidate', {
+                            title: candidate.title,
+                            defaultValue: 'Select {{title}}',
+                          })}
+                          className="mt-0.5 h-4 w-4 rounded border-slate-300 text-red-600 focus:ring-red-500 dark:border-zinc-600 dark:bg-zinc-800"
+                        />
+                        <span>
+                          <span className="block font-medium text-slate-800 dark:text-zinc-200">{candidate.title}</span>
+                          <span className="mt-0.5 flex flex-wrap gap-x-2 text-slate-500 dark:text-zinc-500">
+                            <span>{t(`catalogueReconciliation.reasons.${candidate.reason}`, reasonDefaults[candidate.reason])}</span>
+                            <span aria-hidden="true">·</span>
+                            <span>{candidate.metadataProvider}</span>
+                          </span>
+                        </span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </>
+        ) : null}
+
+        {error && result && <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+        <div className="mt-4 flex justify-end gap-2 border-t border-slate-200 pt-4 dark:border-zinc-800">
+          <button type="button" onClick={onClose} className={`${btn.secondary} ${btnSize.md}`}>
+            {applied ? t('common.close', 'Close') : t('common.cancel', 'Cancel')}
+          </button>
+          {!applied && result && (
+            <button
+              type="button"
+              onClick={apply}
+              disabled={applying || selectedCount === 0}
+              className={`${btn.dangerSolid} ${btnSize.md}`}
+            >
+              {applying
+                ? t('catalogueReconciliation.applying', 'Rechecking and removing…')
+                : t('catalogueReconciliation.apply', {
+                    count: selectedCount,
+                    defaultValue: 'Remove {{count}} stale row(s)',
+                  })}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SummaryCell({ label, value, tone }: { label: string; value: number; tone?: 'danger' }) {
+  return (
+    <div className="bg-white px-3 py-2 dark:bg-zinc-900">
+      <div className="text-[11px] text-slate-500 dark:text-zinc-500">{label}</div>
+      <div className={`text-lg font-semibold tabular-nums ${tone === 'danger' ? 'text-red-700 dark:text-red-300' : 'text-slate-900 dark:text-white'}`}>
+        {value}
+      </div>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -274,6 +274,8 @@
       "renameFilesHint": "Move this author’s files to match the current naming template",
       "merge": "Merge…",
       "mergeHint": "Merge another author into this one",
+      "reconcileCatalogue": "Reconcile catalogue…",
+      "reconcileCatalogueHint": "Preview stale metadata-only Wanted rows before removing them",
       "delete": "Delete"
     },
     "filters": {
@@ -291,6 +293,36 @@
       "status_imported": "Imported",
       "status_skipped": "Skipped",
       "status_excluded": "Excluded"
+    }
+  },
+  "catalogueReconciliation": {
+    "title": "Reconcile catalogue",
+    "description": "Compare {{author}}’s metadata-only Wanted rows with the current provider and metadata profile.",
+    "loading": "Checking the current provider catalogue…",
+    "previewFailed": "Preview failed",
+    "applyFailed": "Reconciliation failed",
+    "remove": "Safe to remove",
+    "protected": "Protected",
+    "kept": "Still accepted",
+    "context": "Provider: {{provider}} · Profile: {{profile}}",
+    "safeguards": "Files are never deleted. Protected: {{files}} file-bearing, {{imported}} imported, {{status}} other-status, and {{excluded}} excluded row(s). Apply rechecks every safeguard.",
+    "indeterminate": "{{count}} row(s) were kept because provider or profile evidence was incomplete.",
+    "partialWarning": "The provider returned a partial catalogue. Missing works are protected; only explicit profile rejections can be removed.",
+    "applied": "Removed {{deleted}} row(s). {{skipped}} were skipped because they were no longer eligible.",
+    "clean": "No metadata-only Wanted rows need reconciliation.",
+    "selectCandidate": "Select {{title}}",
+    "applying": "Rechecking and removing…",
+    "apply": "Remove {{count}} stale row(s)",
+    "reasons": {
+      "provider_changed": "From the previous metadata provider",
+      "not_in_current_catalogue": "No longer in the current provider catalogue",
+      "language_not_allowed": "Rejected by the language filter",
+      "part_book": "Rejected as a box set or part-book",
+      "missing_release_date": "Rejected because the release date is missing",
+      "below_minimum_popularity": "Below the minimum popularity",
+      "below_minimum_pages": "Below the minimum page count",
+      "missing_isbn": "No edition has an ISBN",
+      "catalogue_filter": "Rejected by the catalogue filter"
     }
   },
   "books": {

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -19,6 +19,7 @@ import CoverPlaceholder from '../components/CoverPlaceholder'
 import MoreMenu from '../components/MoreMenu'
 import Section from '../components/Section'
 import AuthorSyncNotice from '../components/AuthorSyncNotice'
+import CatalogueReconciliationModal from '../components/CatalogueReconciliationModal'
 
 type MediaFilter = '' | 'ebook' | 'audiobook'
 // 'excluded' folds in what used to be a separate "Show excluded" checkbox. It
@@ -80,6 +81,7 @@ export default function AuthorDetailPage() {
   const [showEdit, setShowEdit] = useState(false)
   const [showRename, setShowRename] = useState(false)
   const [showMetadataLink, setShowMetadataLink] = useState(false)
+  const [showCatalogueReconciliation, setShowCatalogueReconciliation] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // Bulk multi-select state (#791). Selection is keyed by book.id and
@@ -791,6 +793,11 @@ export default function AuthorDetailPage() {
                   ? [{ label: metadataLinkLabel, onSelect: () => setShowMetadataLink(true) }]
                   : []),
                 {
+                  label: t('authorDetail.actions.reconcileCatalogue', 'Reconcile catalogue…'),
+                  title: t('authorDetail.actions.reconcileCatalogueHint', 'Preview stale metadata-only Wanted rows before removing them'),
+                  onSelect: () => setShowCatalogueReconciliation(true),
+                },
+                {
                   label: t('authorDetail.actions.delete', 'Delete'),
                   danger: true,
                   onSelect: handleDelete,
@@ -854,6 +861,15 @@ export default function AuthorDetailPage() {
               .then(([a, bs]) => { setAuthor(a); setBooks(bs) })
               .catch(console.error)
           }}
+        />
+      )}
+
+      {showCatalogueReconciliation && (
+        <CatalogueReconciliationModal
+          authorId={author.id}
+          authorName={author.authorName}
+          onClose={() => setShowCatalogueReconciliation(false)}
+          onApplied={reloadBooks}
         />
       )}
 


### PR DESCRIPTION
## Summary

- add an explicit **More → Reconcile catalogue…** preview/apply flow for one author; normal metadata refresh remains non-destructive
- compare local rows with a fresh effective catalogue (primary provider plus configured supplements) and the current metadata profile, reporting candidates, protection counts, indeterminate rows, and per-book reasons
- let users deselect individual preview rows and submit only the chosen IDs; every candidate starts selected
- treat partial primary or supplemental results conservatively: absence is never deletion evidence after a provider failure, and unresolved language/edition evidence is kept
- recompute the preview on apply, intersect it with the requested IDs, and repeat every safeguard in one guarded database delete
- preserve imported/owned books and any row with `filePath`, `ebookFilePath`, `audiobookFilePath`, or a `book_files` record; no filesystem deletion is involved
- document the UI/API behavior and add a changelog fragment

The branch is rebased onto current `main`, including the merged Hardcover language fix from #2246. Reconciliation remains a separate explicit operation and does not make refresh destructive. Refs #2208; the separate series-fill behavior described there is intentionally outside this PR.

## Suggested review order

1. `internal/db/books.go` and `internal/api/catalogue_reconciliation.go` — deletion boundary and apply-time safeguards
2. `internal/metadata/aggregator_author_works.go` and OpenLibrary completeness reporting — conservative catalogue evidence
3. `internal/api/catalogue_reconciliation_test.go` and `internal/db/books_reconciliation_test.go` — destructive/error-path coverage
4. `web/src/components/CatalogueReconciliationModal.tsx` — explicit preview and per-row selection
5. route wiring, API docs, user guide, and changelog fragment

## Checklist

- [x] Commits signed off with `git commit -s` — see [Sign your work](../CONTRIBUTING.md#sign-your-work-dco)
- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (not applicable: no deployment/config change)
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`) — see [changelog.d/README.md](../changelog.d/README.md)
- [x] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `go test -timeout=30m ./cmd/... ./internal/...`
- [x] reconciliation API race tests, `-count=10`
- [x] guarded DB deletion race tests, `-count=10`
- [x] focused coverage: 100% statements for every function in `catalogue_reconciliation.go` and for `DeleteMetadataOnlyWantedByIDs`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] pinned `govulncheck ./...` (no called vulnerabilities)
- [x] frontend typecheck, lint, production build, and full test suite (67 files / 657 tests)
- [x] real-binary HTTP smoke suite (`go test -count=1 -timeout=60s ./tests/smoke/...`)

The full backend run used `TMPDIR=/private/tmp` on macOS so the existing rTorrent deletion safety test sees a direct path instead of the `/var` → `/private/var` system symlink.
