### PR TITLE
fix(downloader): send shareLimitAction so qBittorrent accepts seed limits (#2205)

### DIFF
--- a/changelog.d/2205-qbittorrent-share-limit-action.md
+++ b/changelog.d/2205-qbittorrent-share-limit-action.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Per-indexer seed ratios reach qBittorrent again** (#2205). qBittorrent 5.2 made `shareLimitAction` a required parameter of the share limits endpoint, so every attempt to apply an indexer's seed ratio was rejected with HTTP 400 and the torrent silently kept the client's global limit. Bindery now sends the parameter with its default value, which preserves the previous behaviour of applying the client's configured action when the limit is reached. Older qBittorrent versions ignore the extra field, so nothing changes there.

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -179,6 +179,22 @@ func (c *Client) Test(ctx context.Context) error {
 // touches the ratio rule. Callers resolve the value from the indexer's
 // SeedRatio override (#883); a nil override skips this call entirely so the
 // torrent keeps the client's global rule.
+//
+// qBittorrent 5.2.0 made shareLimitAction a required parameter of this
+// endpoint; without it the whole call is rejected with HTTP 400 and the
+// torrent silently keeps the global limit (#2205). The value is the
+// enumerator NAME, parsed server side by QMetaEnum::keyToValue. The enum
+// (src/base/bittorrent/sharelimits.h) is Default = -1, Stop = 0, Remove = 1,
+// EnableSuperSeeding = 2, RemoveWithContent = 3; "Default" means "apply the
+// client's configured default action when the limit is reached", which is
+// what the old five-field call effectively did, so behaviour is unchanged.
+// shareLimitsMode (Default = -1, MatchAny = 0, MatchAll = 1) is not yet
+// required by any release but is by qBittorrent master; sending
+// "Default" now avoids repeating this bug when that ships. Releases that do
+// not know a field ignore it: requireParams (webui/api/apicontroller.cpp)
+// only checks that the listed keys are present, never that extras are
+// absent, so both fields are safe to send unconditionally to 5.1.x and
+// older.
 func (c *Client) SetShareLimits(ctx context.Context, hash string, ratioLimit float64) error {
 	if err := c.ensureLoggedIn(ctx); err != nil {
 		return err
@@ -188,6 +204,8 @@ func (c *Client) SetShareLimits(ctx context.Context, hash string, ratioLimit flo
 		"ratioLimit":               {strconv.FormatFloat(ratioLimit, 'f', -1, 64)},
 		"seedingTimeLimit":         {"-2"},
 		"inactiveSeedingTimeLimit": {"-2"},
+		"shareLimitAction":         {"Default"},
+		"shareLimitsMode":          {"Default"},
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		c.baseURL+"/api/v2/torrents/setShareLimits",

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -2074,9 +2074,32 @@ func TestClient_Files_WindowsBackslashesNormalized(t *testing.T) {
 	}
 }
 
+// requireShareLimitParams mimics qBittorrent 5.2's requireParams for
+// /api/v2/torrents/setShareLimits (webui/api/torrentscontroller.cpp): the
+// listed keys must be present or the whole request 400s. This is exactly the
+// failure #2205 hit in production while the old stub accepted anything, so
+// the stub now enforces it. Extra keys are ignored, matching the real
+// server.
+func requireShareLimitParams(w http.ResponseWriter, r *http.Request) bool {
+	var missing []string
+	for _, p := range []string{"hashes", "ratioLimit", "seedingTimeLimit", "inactiveSeedingTimeLimit", "shareLimitAction"} {
+		if !r.PostForm.Has(p) {
+			missing = append(missing, p)
+		}
+	}
+	if len(missing) > 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprintf(w, "Missing required parameters: %s", strings.Join(missing, ", "))
+		return false
+	}
+	return true
+}
+
 // TestSetShareLimits_Positive asserts a positive override posts the ratioLimit
 // verbatim to /api/v2/torrents/setShareLimits, with seedingTime fields left at
-// -2 (use global) so only the ratio rule is touched.
+// -2 (use global) so only the ratio rule is touched, and shareLimitAction set
+// to Default (apply the client's configured action) as qBittorrent 5.2+
+// requires.
 func TestSetShareLimits_Positive(t *testing.T) {
 	var gotForm url.Values
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2085,6 +2108,9 @@ func TestSetShareLimits_Positive(t *testing.T) {
 			_, _ = w.Write([]byte("Ok."))
 		case "/api/v2/torrents/setShareLimits":
 			_ = r.ParseForm()
+			if !requireShareLimitParams(w, r) {
+				return
+			}
 			gotForm = r.PostForm
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -2107,6 +2133,9 @@ func TestSetShareLimits_Positive(t *testing.T) {
 	if got := gotForm.Get("seedingTimeLimit"); got != "-2" {
 		t.Errorf("seedingTimeLimit = %q, want -2 (use global)", got)
 	}
+	if got := gotForm.Get("shareLimitAction"); got != "Default" {
+		t.Errorf("shareLimitAction = %q, want Default", got)
+	}
 }
 
 // TestSetShareLimits_Unlimited asserts the -1 sentinel passes straight through;
@@ -2119,6 +2148,9 @@ func TestSetShareLimits_Unlimited(t *testing.T) {
 			_, _ = w.Write([]byte("Ok."))
 		case "/api/v2/torrents/setShareLimits":
 			_ = r.ParseForm()
+			if !requireShareLimitParams(w, r) {
+				return
+			}
 			gotRatio = r.PostForm.Get("ratioLimit")
 			w.WriteHeader(http.StatusOK)
 		default:


### PR DESCRIPTION
## Summary

Per-indexer seed ratios never reached qBittorrent 5.2+. The `setShareLimits` call posted only `hashes`, `ratioLimit`, `seedingTimeLimit` and `inactiveSeedingTimeLimit`, and qBittorrent 5.2.0 made `shareLimitAction` a required parameter, so the whole request was rejected with `HTTP 400: Missing required parameters: shareLimitAction` and the torrent silently kept the client's global limit. The only trace was a WARN in trace logs, which ThatDeltaGuy dug out along with screenshots pinpointing the missing parameter. Thanks for the excellent report. Closes #2205.

## Implementation notes

The client now sends `shareLimitAction=Default` and `shareLimitsMode=Default` alongside the existing fields.

**Why `Default`.** qBittorrent parses the value with `Utils::String::toEnum`, which maps the enumerator name via `QMetaEnum::keyToValue`, so the wire value is the name, not a number. The enum in `src/base/bittorrent/sharelimits.h` (release-5.2.0):

| Name | Value | Meaning |
|------|-------|---------|
| `Default` | -1 | apply the client's configured default action when the limit is reached |
| `Stop` | 0 | stop the torrent |
| `Remove` | 1 | remove the torrent |
| `EnableSuperSeeding` | 2 | switch to super seeding |
| `RemoveWithContent` | 3 | remove the torrent and its data |

`Default` is what the old five-field call effectively did, so behaviour on limit reach is unchanged. It is also the fallback qBittorrent itself uses for an unparseable value.

**Why also `shareLimitsMode`.** qBittorrent master already lists it in `requireParams` for this endpoint (`Default` = -1, `MatchAny` = 0, `MatchAll` = 1, same name-based parsing with a `Default` fallback). Sending `Default` now costs nothing on current releases and avoids repeating this exact bug when the next qBittorrent release ships.

**Backward compatibility evidence.** `APIController::requireParams` (`src/webui/api/apicontroller.cpp`, verified at release-5.1.2) only checks that each listed key is present in the params map. Nothing anywhere rejects unknown extra keys, so 5.1.x and older ignore both new fields. Verified per version tag:

| qBittorrent | Required params for `setShareLimits` |
|-------------|--------------------------------------|
| release-5.1.2 | hashes, ratioLimit, seedingTimeLimit, inactiveSeedingTimeLimit |
| release-5.2.0 through release-5.2.3 | the above plus shareLimitAction |
| master (unreleased) | the above plus shareLimitsMode |

**Test gap.** The stub previously accepted any form body, which is why this shipped green. It now enforces the same required-parameter check as qBittorrent 5.2 and answers the exact production 400 when a field is missing; with the client change stashed, both `TestSetShareLimits_Positive` and `TestSetShareLimits_Unlimited` fail with `setShareLimits HTTP 400: Missing required parameters: shareLimitAction`.

## Scope

#2206 (making the two hardcoded `-2` seeding-time values configurable) is an enhancement and stays open; this patch deliberately adds no settings or columns.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (no docs mention the setShareLimits parameters; the one seed-ratio doc line is about rTorrent)
- [x] Wiki pages updated if user-facing behaviour changed (none needed)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/... ./internal/...`
- [x] `gofmt -l` clean on touched files
- [x] `go test ./internal/downloader/...`
- [x] `go test ./internal/...`
- [ ] `cd web && npm run build` (no web changes)
