### PR TITLE
fix(authors): surface the OpenLibrary fallback and unscope relink lookups (#2237, #2243)

### DIFF
--- a/changelog.d/2237-hardcover-add-fallback.md
+++ b/changelog.d/2237-hardcover-add-fallback.md
@@ -1,0 +1,3 @@
+### Fixed
+- **Provider fallback when adding an author is no longer silent** (#2237): with `metadata.primary_provider` set, adding an author whose record comes from another provider now says so. The add dialog flags the result, warns before the add that the catalogue will sync from the other provider, and the API response carries a `providerMismatch` object.
+- **Relink endpoints honour tenancy enforcement being off** (#2243): `relink-upstream` and its candidates endpoint no longer 404 for callers whose user id differs from the author's owner while `BINDERY_ENFORCE_TENANCY` is unset. They now scope their lookup like every other author endpoint, and cross-user access stays blocked when enforcement is on.

--- a/docs/API.md
+++ b/docs/API.md
@@ -71,6 +71,22 @@ It is held in memory, not stored, so it is absent after a restart until the
 author is synced again. `skippedLanguageSample` is capped at a few titles; the
 counts are exact.
 
+`POST /api/v1/author` responses include a `providerMismatch` object when the
+linked record routes its catalogue syncs to a provider other than the
+configured `metadata.primary_provider` (#2237), so a fallback pick is visible
+instead of silent:
+
+```json
+{
+  "providerMismatch": {
+    "primaryProvider": "hardcover",
+    "linkedProvider": "openlibrary"
+  }
+}
+```
+
+The field is absent when the providers match or no primary is configured.
+
 `POST /api/v1/author/{id}/relink-upstream` may be called without a body for
 automatic upstream matching. Manual relink can send:
 

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -565,6 +565,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 			// fields (Description, ImageURL, ...); cleaning afterwards would race
 			// the snapshot read against this write (see fetchAuthorBooksAsync).
 			cleanAuthorDescription(canonical)
+			h.stampProviderMismatch(canonical)
 			h.fetchAuthorBooksAsync(canonical, catalogueSyncOptions{autoSearch: req.SearchOnAdd, mediaType: mediaType})
 			writeJSON(w, http.StatusOK, canonical)
 			return
@@ -611,6 +612,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// ImageURL, ...). Cleaning after the spawn would race the snapshot read
 	// against this write (see fetchAuthorBooksAsync).
 	cleanAuthorDescription(author)
+	h.stampProviderMismatch(author)
 
 	// Fetch and store books for this author. Always populate the catalogue;
 	// pass searchOnAdd so FetchAuthorBooks knows whether to also queue grabs.
@@ -623,6 +625,28 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 func cleanAuthorDescription(author *models.Author) {
 	if author != nil {
 		author.Description = textutil.CleanDescription(author.Description)
+	}
+}
+
+// stampProviderMismatch marks an add-flow response when the linked record's
+// catalogue provider (derived from the foreign-ID prefix, the same way
+// providerForForeignID routes sync fetches) differs from the configured
+// primary (#2237). With metadata.primary_provider = hardcover, a Hardcover
+// search miss makes the add flow pick a record from another provider and the
+// author syncs from that provider forever; making Hardcover's search
+// exhaustive is provider behaviour we cannot fix, but the fallback happening
+// silently is ours to fix. Call before fetchAuthorBooksAsync: the spawn
+// snapshots the author, so mutating it afterwards would race the read.
+func (h *AuthorHandler) stampProviderMismatch(author *models.Author) {
+	if author == nil || h.meta == nil {
+		return
+	}
+	primary := h.meta.PrimaryProviderName()
+	if primary == "" {
+		return
+	}
+	if linked := models.AuthorProviderFromForeignID(author.ForeignID); linked != primary {
+		author.ProviderMismatch = &models.AuthorProviderMismatch{PrimaryProvider: primary, LinkedProvider: linked}
 	}
 }
 
@@ -1192,7 +1216,15 @@ func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
 	req.Name = strings.TrimSpace(req.Name)
 
 	userID := auth.UserIDFromContext(r.Context())
-	author, err := h.authors.GetByIDForUser(r.Context(), id, userID)
+	// Scope the lookup with ListScopeUserID (not UserIDFromContext), matching
+	// Get and Delete: unscoped unless tenancy enforcement is on and the caller
+	// is a non-admin. Passing the raw context user id here 404ed relinks for
+	// any caller whose id differed from the author's owner even with
+	// BINDERY_ENFORCE_TENANCY off, while every sibling endpoint let the same
+	// caller read and delete that author (#2243). CheckOwnership below stays
+	// the per-item authorisation gate, so the enforcement-on posture is
+	// unchanged.
+	author, err := h.authors.GetByIDForUser(r.Context(), id, auth.ListScopeUserID(r.Context()))
 	if err != nil {
 		writeServerError(w, r, err)
 		return
@@ -1270,12 +1302,20 @@ func (h *AuthorHandler) RelinkCandidates(w http.ResponseWriter, r *http.Request)
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
 		return
 	}
-	author, err := h.authors.GetByIDForUser(r.Context(), id, auth.UserIDFromContext(r.Context()))
+	// Scoped like RelinkUpstream above: ListScopeUserID so the lookup honours
+	// tenancy enforcement being off, with CheckOwnership as the per-item
+	// authorisation gate when it is on (#2243).
+	author, err := h.authors.GetByIDForUser(r.Context(), id, auth.ListScopeUserID(r.Context()))
 	if err != nil {
 		writeServerError(w, r, err)
 		return
 	}
 	if author == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
 		return
 	}

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -3335,7 +3335,90 @@ func TestRelinkUpstream_ManualCandidateRejectsUnverifiedFallback(t *testing.T) {
 	}
 }
 
+// TestCreateAuthor_StampsProviderMismatch is the regression test for #2237:
+// with metadata.primary_provider = hardcover, a Hardcover author-search miss
+// makes the add flow create an author from another provider, and that author
+// syncs from the other provider forever. The fallback used to be silent; the
+// response must now name both providers so the UI can surface it.
+func TestCreateAuthor_StampsProviderMismatch(t *testing.T) {
+	newHandler := func(t *testing.T) *AuthorHandler {
+		t.Helper()
+		database, err := db.OpenMemory()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = database.Close() })
+		primary := &searchableAuthorProvider{
+			stubMetaProvider: stubMetaProvider{name: "hardcover"},
+			authors: map[string]*models.Author{
+				"hc:jane-doe": {
+					ForeignID:        "hc:jane-doe",
+					Name:             "Jane Doe",
+					SortName:         "Doe, Jane",
+					MetadataProvider: "hardcover",
+				},
+			},
+		}
+		enricher := &searchableAuthorProvider{
+			stubMetaProvider: stubMetaProvider{name: "openlibrary"},
+			authors: map[string]*models.Author{
+				"OL999A": {
+					ForeignID:        "OL999A",
+					Name:             "John Roe",
+					SortName:         "Roe, John",
+					MetadataProvider: "openlibrary",
+				},
+			},
+		}
+		return NewAuthorHandler(db.NewAuthorRepo(database), db.NewAuthorAliasRepo(database), db.NewBookRepo(database), nil, metadata.NewAggregator(primary, enricher), nil, db.NewMetadataProfileRepo(database), nil)
+	}
+
+	create := func(t *testing.T, h *AuthorHandler, foreignID, name string) map[string]any {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{
+			"foreignAuthorId": foreignID,
+			"authorName":      name,
+			"monitored":       true,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/author", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		h.Create(rec, req)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	t.Run("openlibrary record under hardcover primary is flagged", func(t *testing.T) {
+		resp := create(t, newHandler(t), "OL999A", "John Roe")
+		mismatch, ok := resp["providerMismatch"].(map[string]any)
+		if !ok {
+			t.Fatalf("providerMismatch missing from response: %v", resp)
+		}
+		if mismatch["primaryProvider"] != "hardcover" || mismatch["linkedProvider"] != "openlibrary" {
+			t.Fatalf("providerMismatch = %v, want hardcover/openlibrary", mismatch)
+		}
+	})
+
+	t.Run("hardcover record under hardcover primary is not flagged", func(t *testing.T) {
+		resp := create(t, newHandler(t), "hc:jane-doe", "Jane Doe")
+		if _, ok := resp["providerMismatch"]; ok {
+			t.Fatalf("unexpected providerMismatch in response: %v", resp)
+		}
+	})
+}
+
 func TestRelinkUpstream_RejectsOtherUsersAuthor(t *testing.T) {
+	// The cross-user 404 is a tenancy-enforcement property: with the gate off
+	// (the default) every read/mutate path is unscoped and the relink must
+	// succeed instead (#2243, covered below).
+	auth.SetEnforceTenancyForTests(t, true)
+
 	database, err := db.OpenMemory()
 	if err != nil {
 		t.Fatal(err)
@@ -3397,6 +3480,105 @@ func TestRelinkUpstream_RejectsOtherUsersAuthor(t *testing.T) {
 	}
 	if got.ForeignID != aliceAuthor.ForeignID || got.MetadataProvider != aliceAuthor.MetadataProvider {
 		t.Fatalf("alice author mutated: %+v", got)
+	}
+}
+
+// relinkTenancyFixture seeds alice's author and returns a handler whose
+// aggregator can resolve "hc:emilia-jae", for exercising the relink endpoints
+// from bob's context in both tenancy modes (#2243).
+func relinkTenancyFixture(t *testing.T) (*relinkUpstreamFixture, *models.Author, int64) {
+	t.Helper()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	ctx := context.Background()
+	users := db.NewUserRepo(database)
+	alice, err := users.Create(ctx, "alice", "h1")
+	if err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	bob, err := users.Create(ctx, "bob", "h2")
+	if err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+	authorRepo := db.NewAuthorRepo(database)
+	fixture := &relinkUpstreamFixture{
+		ctx:     ctx,
+		authors: authorRepo,
+		aliases: db.NewAuthorAliasRepo(database),
+		books:   db.NewBookRepo(database),
+		handler: NewAuthorHandler(authorRepo, db.NewAuthorAliasRepo(database), db.NewBookRepo(database), nil, metadata.NewAggregator(&searchableAuthorProvider{
+			stubMetaProvider: stubMetaProvider{name: "hardcover"},
+			authors: map[string]*models.Author{
+				"hc:emilia-jae": {
+					ForeignID:        "hc:emilia-jae",
+					Name:             "Emilia Jae",
+					SortName:         "Jae, Emilia",
+					MetadataProvider: "hardcover",
+				},
+			},
+		}), nil, db.NewMetadataProfileRepo(database), nil),
+	}
+	aliceAuthor := &models.Author{
+		ForeignID:        "abs:author:alice:emilia-jae",
+		Name:             "Emilia Jae",
+		SortName:         "Jae, Emilia",
+		MetadataProvider: "audiobookshelf",
+		Monitored:        true,
+	}
+	if err := authorRepo.CreateForUser(ctx, aliceAuthor, alice.ID); err != nil {
+		t.Fatalf("seed alice author: %v", err)
+	}
+	return fixture, aliceAuthor, bob.ID
+}
+
+// TestRelinkUpstream_TenancyOffAllowsCrossUserAuthor is the regression test
+// for #2243: with BINDERY_ENFORCE_TENANCY off (the default) every other
+// author endpoint lets a caller whose user id differs from the owner read and
+// delete the author, but the relink lookup passed the raw context user id to
+// GetByIDForUser and 404ed. The lookup must scope through ListScopeUserID
+// like Get and Delete.
+func TestRelinkUpstream_TenancyOffAllowsCrossUserAuthor(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, false)
+	fixture, aliceAuthor, bobID := relinkTenancyFixture(t)
+
+	rec := fixture.relinkToCandidateAs(t, bobID, aliceAuthor.ID, "hc:emilia-jae", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 with tenancy enforcement off, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := fixture.authors.GetByID(fixture.ctx, aliceAuthor.ID)
+	if err != nil || got == nil {
+		t.Fatalf("author lookup: %+v err=%v", got, err)
+	}
+	if got.ForeignID != "hc:emilia-jae" || got.MetadataProvider != "hardcover" {
+		t.Fatalf("author not relinked: foreignID=%q provider=%q", got.ForeignID, got.MetadataProvider)
+	}
+}
+
+func TestRelinkCandidates_TenancyOffAllowsCrossUserAuthor(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, false)
+	fixture, aliceAuthor, bobID := relinkTenancyFixture(t)
+
+	rec := fixture.candidatesAs(t, bobID, aliceAuthor.ID, "Emilia+Jae")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 with tenancy enforcement off, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRelinkCandidates_TenancyOnRejectsCrossUserAuthor(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	fixture, aliceAuthor, bobID := relinkTenancyFixture(t)
+
+	rec := fixture.candidatesAs(t, bobID, aliceAuthor.ID, "Emilia+Jae")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 with tenancy enforcement on, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -3341,7 +3341,7 @@ func TestRelinkUpstream_ManualCandidateRejectsUnverifiedFallback(t *testing.T) {
 // syncs from the other provider forever. The fallback used to be silent; the
 // response must now name both providers so the UI can surface it.
 func TestCreateAuthor_StampsProviderMismatch(t *testing.T) {
-	newHandler := func(t *testing.T) *AuthorHandler {
+	newHandler := func(t *testing.T) (*AuthorHandler, *db.AuthorRepo) {
 		t.Helper()
 		database, err := db.OpenMemory()
 		if err != nil {
@@ -3370,10 +3370,11 @@ func TestCreateAuthor_StampsProviderMismatch(t *testing.T) {
 				},
 			},
 		}
-		return NewAuthorHandler(db.NewAuthorRepo(database), db.NewAuthorAliasRepo(database), db.NewBookRepo(database), nil, metadata.NewAggregator(primary, enricher), nil, db.NewMetadataProfileRepo(database), nil)
+		authorRepo := db.NewAuthorRepo(database)
+		return NewAuthorHandler(authorRepo, db.NewAuthorAliasRepo(database), db.NewBookRepo(database), nil, metadata.NewAggregator(primary, enricher), nil, db.NewMetadataProfileRepo(database), nil), authorRepo
 	}
 
-	create := func(t *testing.T, h *AuthorHandler, foreignID, name string) map[string]any {
+	create := func(t *testing.T, h *AuthorHandler, foreignID, name string, wantStatus int) map[string]any {
 		t.Helper()
 		body, _ := json.Marshal(map[string]any{
 			"foreignAuthorId": foreignID,
@@ -3384,8 +3385,8 @@ func TestCreateAuthor_StampsProviderMismatch(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 		h.Create(rec, req)
-		if rec.Code != http.StatusCreated {
-			t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+		if rec.Code != wantStatus {
+			t.Fatalf("expected %d, got %d: %s", wantStatus, rec.Code, rec.Body.String())
 		}
 		var resp map[string]any
 		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
@@ -3394,8 +3395,8 @@ func TestCreateAuthor_StampsProviderMismatch(t *testing.T) {
 		return resp
 	}
 
-	t.Run("openlibrary record under hardcover primary is flagged", func(t *testing.T) {
-		resp := create(t, newHandler(t), "OL999A", "John Roe")
+	requireMismatch := func(t *testing.T, resp map[string]any) {
+		t.Helper()
 		mismatch, ok := resp["providerMismatch"].(map[string]any)
 		if !ok {
 			t.Fatalf("providerMismatch missing from response: %v", resp)
@@ -3403,12 +3404,54 @@ func TestCreateAuthor_StampsProviderMismatch(t *testing.T) {
 		if mismatch["primaryProvider"] != "hardcover" || mismatch["linkedProvider"] != "openlibrary" {
 			t.Fatalf("providerMismatch = %v, want hardcover/openlibrary", mismatch)
 		}
+	}
+
+	t.Run("openlibrary record under hardcover primary is flagged", func(t *testing.T) {
+		h, _ := newHandler(t)
+		requireMismatch(t, create(t, h, "OL999A", "John Roe", http.StatusCreated))
 	})
 
 	t.Run("hardcover record under hardcover primary is not flagged", func(t *testing.T) {
-		resp := create(t, newHandler(t), "hc:jane-doe", "Jane Doe")
+		h, _ := newHandler(t)
+		resp := create(t, h, "hc:jane-doe", "Jane Doe", http.StatusCreated)
 		if _, ok := resp["providerMismatch"]; ok {
 			t.Fatalf("unexpected providerMismatch in response: %v", resp)
+		}
+	})
+
+	// The add flow's other success path: the name matches an existing
+	// relinkable local author (abs:/calibre: import), so Create relinks it to
+	// the fetched record and returns 200 instead of 201. The stamp must ride
+	// that response too.
+	t.Run("relinked canonical author under hardcover primary is flagged", func(t *testing.T) {
+		h, authorRepo := newHandler(t)
+		local := &models.Author{
+			ForeignID:        "abs:author:john-roe",
+			Name:             "John Roe",
+			SortName:         "Roe, John",
+			MetadataProvider: "audiobookshelf",
+			Monitored:        true,
+		}
+		if err := authorRepo.Create(context.Background(), local); err != nil {
+			t.Fatalf("seed local author: %v", err)
+		}
+		requireMismatch(t, create(t, h, "OL999A", "John Roe", http.StatusOK))
+	})
+
+	// Defensive guards: a nil author, a handler without an aggregator, and an
+	// aggregator without a wired primary must all leave the record unstamped.
+	t.Run("guards leave the author unstamped", func(t *testing.T) {
+		noMeta := &AuthorHandler{}
+		noMeta.stampProviderMismatch(nil)
+		author := &models.Author{ForeignID: "OL999A"}
+		noMeta.stampProviderMismatch(author)
+		if author.ProviderMismatch != nil {
+			t.Fatalf("nil-aggregator handler stamped the author: %+v", author.ProviderMismatch)
+		}
+		noPrimary := &AuthorHandler{meta: metadata.NewAggregator(nil)}
+		noPrimary.stampProviderMismatch(author)
+		if author.ProviderMismatch != nil {
+			t.Fatalf("primaryless aggregator stamped the author: %+v", author.ProviderMismatch)
 		}
 	})
 }

--- a/internal/metadata/aggregator_providers.go
+++ b/internal/metadata/aggregator_providers.go
@@ -75,3 +75,16 @@ func (a *Aggregator) providers() []Provider {
 	providers = append(providers, a.enrichers...)
 	return providers
 }
+
+// PrimaryProviderName returns the normalized name of the provider wired as
+// primary ("openlibrary", "hardcover", ...), or "" when there is none. The
+// primary is fixed at boot (cmd/bindery), so this names the provider that
+// serves catalogue syncs for records carrying no other provider's prefix.
+// Exported so the API layer can tell when a record being linked will sync
+// from somewhere other than the configured primary (#2237).
+func (a *Aggregator) PrimaryProviderName() string {
+	if a == nil {
+		return ""
+	}
+	return normalizedProviderName(providerName(a.primary))
+}

--- a/internal/metadata/aggregator_providers_test.go
+++ b/internal/metadata/aggregator_providers_test.go
@@ -1,0 +1,30 @@
+package metadata
+
+import "testing"
+
+// PrimaryProviderName backs the add-flow provider-mismatch stamp (#2237): the
+// API layer compares it against the provider a foreign ID routes to, so it
+// must reflect the effective wired primary, normalized, and stay safe on the
+// degenerate aggregator shapes handlers can hold (nil aggregator, no primary).
+func TestPrimaryProviderName(t *testing.T) {
+	cases := []struct {
+		name string
+		agg  *Aggregator
+		want string
+	}{
+		{name: "nil aggregator", agg: nil, want: ""},
+		{name: "no primary wired", agg: NewAggregator(nil), want: ""},
+		{name: "hardcover primary", agg: NewAggregator(&mockProvider{name: "hardcover"}), want: "hardcover"},
+		{name: "dnb primary", agg: NewAggregator(&mockProvider{name: "dnb"}), want: "dnb"},
+		{name: "short alias is normalized", agg: NewAggregator(&mockProvider{name: "HC"}), want: "hardcover"},
+		{name: "openlibrary default", agg: NewAggregator(&mockProvider{name: "openlibrary"}), want: "openlibrary"},
+		{name: "unknown name passes through lowercased", agg: NewAggregator(&mockProvider{name: " Bogus "}), want: "bogus"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.agg.PrimaryProviderName(); got != tc.want {
+				t.Fatalf("PrimaryProviderName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/models/author.go
+++ b/internal/models/author.go
@@ -76,6 +76,22 @@ type Author struct {
 	// Transient: populated from the metadata provider during add/refresh; not stored in DB.
 	// Used to seed author_aliases so non-latin primary names get latin-script alternates.
 	AlternateNames []string `json:"-"`
+
+	// ProviderMismatch is stamped on add-flow responses when the record being
+	// linked routes its catalogue syncs to a provider other than the
+	// configured primary (#2237): with metadata.primary_provider = hardcover,
+	// a Hardcover search miss makes the add flow pick a record from another
+	// provider, and the author then syncs from that provider forever.
+	// Transport-only; nothing persists it.
+	ProviderMismatch *AuthorProviderMismatch `json:"providerMismatch,omitempty"`
+}
+
+// AuthorProviderMismatch reports that an author's catalogue will sync from a
+// different provider than the one configured as primary (#2237). Both fields
+// carry normalized provider names ("openlibrary", "hardcover", ...).
+type AuthorProviderMismatch struct {
+	PrimaryProvider string `json:"primaryProvider"`
+	LinkedProvider  string `json:"linkedProvider"`
 }
 
 // AuthorSyncSummary is the outcome of one catalogue sync: how many of the

--- a/web/src/api/authors.ts
+++ b/web/src/api/authors.ts
@@ -33,6 +33,17 @@ export interface Author {
   // What the last catalogue sync did with the provider's works (#1889).
   // Absent until the server has synced this author since it last started.
   lastSync?: AuthorSyncSummary
+  // Present on add-flow responses when the linked record syncs from a
+  // provider other than the configured primary (#2237).
+  providerMismatch?: AuthorProviderMismatch
+}
+
+// AuthorProviderMismatch reports that an author's catalogue will sync from a
+// different provider than the configured primary (#2237). Both fields carry
+// normalized provider keys ('openlibrary', 'hardcover', ...).
+export interface AuthorProviderMismatch {
+  primaryProvider: string
+  linkedProvider: string
 }
 
 // AuthorSyncSummary reports how many provider works became books on the last

--- a/web/src/components/AddAuthorModal.test.tsx
+++ b/web/src/components/AddAuthorModal.test.tsx
@@ -25,6 +25,12 @@ vi.mock('react-i18next', () => ({
         const count = Number(options?.count ?? 0)
         return `Show ${count} hidden result${count === 1 ? '' : 's'}`
       }
+      if (key === 'addAuthorModal.resultProvider') {
+        return `from ${String(options?.provider ?? '')}`
+      }
+      if (key === 'addAuthorModal.providerMismatchNotice') {
+        return `This record comes from ${String(options?.linked ?? '')}, not from your primary metadata provider ${String(options?.primary ?? '')}.`
+      }
       return strings[key] ?? key
     },
   }),
@@ -555,6 +561,70 @@ describe('AddAuthorModal — search error handling', () => {
       vi.mocked(api.getSetting).mockImplementation(settingsWithDefaultRoot('404'))
 
       expect(await addTolkien()).toEqual(expect.objectContaining({ rootFolderId: 7 }))
+    })
+  })
+
+  // #2237: with a primary metadata provider configured, a result that would
+  // sync from another provider must be flagged in the result list and on the
+  // confirm step instead of silently falling back.
+  describe('provider mismatch notice (#2237)', () => {
+    function settingsWithPrimary(value: string | null) {
+      return vi.fn().mockImplementation((key: string) => {
+        if (key === 'metadata.primary_provider') {
+          return value === null
+            ? Promise.reject(new Error('HTTP 404'))
+            : Promise.resolve({ key, value })
+        }
+        return Promise.reject(new Error('HTTP 404'))
+      })
+    }
+
+    async function searchDinniman() {
+      vi.mocked(api.searchAuthors).mockResolvedValue([author({
+        id: 0,
+        foreignAuthorId: 'OL3101279A',
+        authorName: 'Matt Dinniman',
+        sortName: 'Dinniman, Matt',
+        metadataProvider: 'openlibrary',
+      })])
+      render(<AddAuthorModal onClose={vi.fn()} onAdded={vi.fn()} />)
+      fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+        target: { value: 'Matt Dinniman' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+      await waitFor(() => expect(screen.getByText('Matt Dinniman')).toBeInTheDocument())
+    }
+
+    it('flags a result from another provider and warns on the confirm step', async () => {
+      vi.mocked(api.getSetting).mockImplementation(settingsWithPrimary('hardcover'))
+
+      await searchDinniman()
+      expect(await screen.findByText('from OpenLibrary')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      const notice = await screen.findByRole('alert')
+      expect(notice.textContent).toContain('OpenLibrary')
+      expect(notice.textContent).toContain('Hardcover')
+    })
+
+    it('does not flag a result from the configured primary', async () => {
+      vi.mocked(api.getSetting).mockImplementation(settingsWithPrimary('openlibrary'))
+
+      await searchDinniman()
+      expect(screen.queryByText(/^from /)).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('shows no notice when no primary provider is configured', async () => {
+      vi.mocked(api.getSetting).mockImplementation(settingsWithPrimary(null))
+
+      await searchDinniman()
+      expect(screen.queryByText(/^from /)).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
   })
 

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { api, AddAuthorRequest, Author, AuthorConflictBody, AuthorMonitorMode, MediaType, MetadataProfile, RootFolder } from '../api/client'
 import { splitAuthorSearchResults } from './addAuthorTitleGuard'
 import { useNeedsSetup } from './useNeedsSetup'
-import { canLinkAuthorMetadata, hasSparseMetadata } from '../util/authorMetadata'
+import { authorProviderKey, canLinkAuthorMetadata, hasSparseMetadata } from '../util/authorMetadata'
+import { providerDisplayName } from '../util/metadataSource'
 
 interface Props {
   onClose: () => void
@@ -66,6 +67,12 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [monitorMode, setMonitorMode] = useState<AuthorMonitorMode>(DEFAULT_MONITOR_MODE)
   const [monitorLatestCount, setMonitorLatestCount] = useState(DEFAULT_MONITOR_LATEST_COUNT)
   const [monitorOptionsChanged, setMonitorOptionsChanged] = useState(false)
+  // The configured primary metadata provider, when one is explicitly set.
+  // Used to flag results that would sync from another provider (#2237):
+  // Hardcover's author search misses some canonical records, and the add flow
+  // then silently fell back to an OpenLibrary record that syncs from
+  // OpenLibrary forever.
+  const [primaryProvider, setPrimaryProvider] = useState<string | null>(null)
 
   useEffect(() => {
     api.listMetadataProfiles().then(ps => {
@@ -115,7 +122,22 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
         if (Number.isInteger(n) && n > 0) setMonitorLatestCount(n)
       })
       .catch(() => { /* unset; keep latest count default */ })
+    api.getSetting('metadata.primary_provider')
+      .then(s => {
+        const value = (s.value || '').trim().toLowerCase()
+        // Mirror MetadataPrimaryProviders on the backend; anything else means
+        // no explicit choice, so no notice.
+        if (value === 'openlibrary' || value === 'dnb' || value === 'hardcover') setPrimaryProvider(value)
+      })
+      .catch(() => { /* unset; no provider notice needed */ })
   }, [])
+
+  const providerMismatch = (author: Author): string | null => {
+    if (!primaryProvider) return null
+    const provider = authorProviderKey(author)
+    if (!provider || provider === primaryProvider) return null
+    return provider
+  }
 
   const search = async () => {
     const q = query.trim()
@@ -220,6 +242,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
                     {author.disambiguation && <span>{t('addAuthorModal.topWork')} {author.disambiguation}</span>}
                     {author.statistics?.bookCount ? <span title={t('addAuthorModal.booksTooltip')}>{t('addAuthorModal.books', { count: author.statistics.bookCount })}</span> : null}
                     {author.ratingsCount ? <span>{t('addAuthorModal.ratings', { count: author.ratingsCount })}</span> : null}
+                    {providerMismatch(author) && <span className="text-amber-600 dark:text-amber-400">{t('addAuthorModal.resultProvider', { provider: providerDisplayName(providerMismatch(author)) })}</span>}
                   </div>
                 </div>
                 <button
@@ -258,6 +281,15 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
               <div className="font-medium">{selectedAuthor.authorName}</div>
               {selectedAuthor.disambiguation && <div className="mt-0.5 text-sm text-fg-muted">{selectedAuthor.disambiguation}</div>}
             </div>
+
+            {providerMismatch(selectedAuthor) && (
+              <p role="alert" className="mt-3 px-3 py-2 rounded bg-amber-50 dark:bg-amber-950/40 border border-amber-300 dark:border-amber-700/60 text-xs text-amber-900 dark:text-amber-200">
+                {t('addAuthorModal.providerMismatchNotice', {
+                  linked: providerDisplayName(providerMismatch(selectedAuthor)),
+                  primary: providerDisplayName(primaryProvider),
+                })}
+              </p>
+            )}
 
             <details className="mt-4 rounded-md border border-slate-300 dark:border-zinc-700">
               <summary className="cursor-pointer select-none px-3 py-2 text-sm font-medium hover:bg-slate-200/60 dark:hover:bg-zinc-800/60">

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -459,7 +459,9 @@
     "ratings": "{{count}} Bewertungen",
     "noResults": "Keine Ergebnisse gefunden",
     "searchError": "Metadatenanbieter nicht erreichbar — {{error}}",
-    "addFail": "Autor konnte nicht hinzugefügt werden"
+    "addFail": "Autor konnte nicht hinzugefügt werden",
+    "resultProvider": "von {{provider}}",
+    "providerMismatchNotice": "Dieser Eintrag stammt von {{linked}}, nicht von deinem primären Metadaten-Anbieter {{primary}}. Wenn du ihn hinzufügst, wird der Katalog dieses Autors von {{linked}} synchronisiert. {{primary}} hat den richtigen Eintrag möglicherweise trotzdem, auch wenn die Suche ihn nicht gefunden hat."
   },
   "addBookModal": {
     "title": "Buch hinzufügen",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -996,7 +996,9 @@
     "searchError": "Could not reach the metadata provider — {{error}}",
     "openExisting": "Open existing author",
     "findMetadata": "Find metadata",
-    "addFail": "Failed to add author"
+    "addFail": "Failed to add author",
+    "resultProvider": "from {{provider}}",
+    "providerMismatchNotice": "This record comes from {{linked}}, not from your primary metadata provider {{primary}}. If you add it, this author's catalogue will sync from {{linked}}. {{primary}} may still have the right record even though its search missed it."
   },
   "addBookModal": {
     "title": "Add Book",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -502,7 +502,9 @@
     "ratings": "{{count}} valoraciones",
     "noResults": "Sin resultados",
     "searchError": "No se pudo contactar con el proveedor de metadatos — {{error}}",
-    "addFail": "Error al añadir el autor"
+    "addFail": "Error al añadir el autor",
+    "resultProvider": "de {{provider}}",
+    "providerMismatchNotice": "Este registro proviene de {{linked}}, no de tu proveedor de metadatos principal {{primary}}. Si lo añades, el catálogo de este autor se sincronizará desde {{linked}}. Es posible que {{primary}} tenga el registro correcto aunque su búsqueda no lo haya encontrado."
   },
   "addBookModal": {
     "title": "Añadir libro",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -461,7 +461,9 @@
     "ratings": "{{count}} évaluations",
     "noResults": "Aucun résultat",
     "searchError": "Impossible d'atteindre le fournisseur de métadonnées — {{error}}",
-    "addFail": "Échec de l'ajout de l'auteur"
+    "addFail": "Échec de l'ajout de l'auteur",
+    "resultProvider": "de {{provider}}",
+    "providerMismatchNotice": "Cette fiche provient de {{linked}}, et non de votre fournisseur de métadonnées principal {{primary}}. Si vous l'ajoutez, le catalogue de cet auteur sera synchronisé depuis {{linked}}. Il se peut que {{primary}} possède la bonne fiche même si sa recherche ne l'a pas trouvée."
   },
   "addBookModal": {
     "title": "Ajouter un livre",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -459,7 +459,9 @@
     "ratings": "{{count}} beoordelingen",
     "noResults": "Geen resultaten gevonden",
     "searchError": "Metadataprovider niet bereikbaar — {{error}}",
-    "addFail": "Auteur toevoegen mislukt"
+    "addFail": "Auteur toevoegen mislukt",
+    "resultProvider": "van {{provider}}",
+    "providerMismatchNotice": "Dit record komt van {{linked}}, niet van je primaire metadataprovider {{primary}}. Als je het toevoegt, wordt de catalogus van deze auteur gesynchroniseerd vanaf {{linked}}. Mogelijk heeft {{primary}} het juiste record wel, ook al vond de zoekopdracht het niet."
   },
   "addBookModal": {
     "title": "Boek toevoegen",

--- a/web/src/util/authorMetadata.ts
+++ b/web/src/util/authorMetadata.ts
@@ -20,3 +20,20 @@ export function hasSparseMetadata(author?: Author): boolean {
   if (!author) return true
   return !author.description && !author.imageUrl && !author.disambiguation && (author.ratingsCount ?? 0) === 0 && (author.averageRating ?? 0) === 0
 }
+
+// authorProviderKey names the catalogue provider an author record routes to,
+// mirroring models.AuthorProviderFromForeignID on the backend: the foreign-ID
+// prefix decides where every later catalogue fetch goes. Falls back to the
+// stamped metadataProvider only when there is no foreign ID at all. Drives the
+// add-flow provider notice (#2237).
+export function authorProviderKey(author?: Pick<Author, 'foreignAuthorId' | 'metadataProvider'>): string {
+  if (!author) return ''
+  const id = (author.foreignAuthorId || '').trim().toLowerCase()
+  if (id.startsWith('gb:')) return 'googlebooks'
+  if (id.startsWith('hc:')) return 'hardcover'
+  if (id.startsWith('dnb:')) return 'dnb'
+  if (id.startsWith('calibre:')) return 'calibre'
+  if (id.startsWith('abs:')) return 'audiobookshelf'
+  if (id !== '') return 'openlibrary'
+  return (author.metadataProvider || '').trim().toLowerCase()
+}


### PR DESCRIPTION
## Summary

Two author endpoint fixes for v1.33.1, both reported with verified analyses by @ianepreston.

**#2237.** With `metadata.primary_provider = hardcover`, adding an author whose canonical record Hardcover's search misses silently created an OpenLibrary linked author, and `providerForForeignID` then routed every catalogue sync to OpenLibrary forever. The fallback is now loud: the `POST /api/v1/author` response carries a `providerMismatch` object naming both providers, the add dialog labels each result that would sync from a provider other than the configured primary, and the confirm step shows a warning before the add so the user can back out.

**#2243.** `RelinkUpstream` and `RelinkCandidates` passed the raw context user id to `GetByIDForUser`, so with `BINDERY_ENFORCE_TENANCY` unset (the default) a caller whose user id differed from the author's owner got a 404 for an author every sibling endpoint let them read and delete. Both lookups now scope through `auth.ListScopeUserID`, exactly like `Get` and `Delete`, with `CheckOwnership` kept (and added to `RelinkCandidates`, which had no per item gate) as the authorisation check. With enforcement on, cross user access stays blocked; the existing rejection test now pins that mode explicitly.

Closes #2237. Closes #2243.

## Implementation notes

- The mismatch is derived from the foreign ID prefix (`models.AuthorProviderFromForeignID`) against the effective boot time primary (`Aggregator.PrimaryProviderName()`), not from the stored setting, so it stays truthful when boot fell back from a misconfigured primary.
- `providerMismatch` is a transport only field on `models.Author` (`omitempty`); nothing persists it.
- The web notice only fires when `metadata.primary_provider` is explicitly set to a known provider, so default installs see no new UI.
- New strings landed in `en.json` plus real translations for de, es, fr, nl. The id, ko, and tl locales were left untouched rather than padded with English filler.

## Follow-ups (not in this PR)

The issue's suggestion 3, retrying a missed Hardcover search via `GetAuthor("hc:" + slugify(name))`, is deliberately not implemented. The slug is a guess against Hardcover's index, and that index contains junk contributor credit rows (`hc:dinniman`, `hc:matt-dinnamen` in the report) that resolve fine, so a guessed slug can silently link the wrong record, which is worse than a visible fallback. Suggestion 2, accepting an explicit Hardcover slug or URL in the add dialog, is the better shaped follow-up now that #2243 makes the relink workaround reachable for API clients.

## Checklist

- [x] Tests added or updated (regression tests for both issues; all three fail on main without the fix)
- [x] Doc-update gate cleared (`docs/API.md` documents `providerMismatch`; the #2243 behaviour now matches what `docs/multi-user.md` already documented)
- [x] Changelog fragment added (`changelog.d/2237-hardcover-add-fallback.md`)

## Test plan

- [x] `go build ./...`, `go vet ./cmd/... ./internal/...`, `gofmt -l` clean on touched files
- [x] `go test ./internal/...` (54 packages ok)
- [x] `cd web && npm ci && npm run build && npx vitest run` (66 files, 652 tests passed)
