### PR TITLE
fix(release): correct the v1.33.1 fix count in the release narrative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 **A series fill could grab your whole library with auto-grab switched off.**
 
-Nine fixes for faults reported within a day of v1.33.0, most of them found by
+Ten fixes for faults reported within a day of v1.33.0, most of them found by
 one person exercising Hardcover as the primary metadata provider harder than it
 had been exercised before. Four are in series fill, which turned out to be the
 one action that ignored the auto-grab kill switch, could add the wrong book,


### PR DESCRIPTION
## Summary

The v1.33.1 narrative says "Nine fixes" while the section carries ten bullets. I wrote the paragraph before #2256 was folded into the release and did not update the count when adding its bullet.

One word. No other change. `Four are in series fill` in the same paragraph is still correct (#2242, #2238, #2239, #2245).

The published GitHub release body is corrected to match. The Discord announcement is left as posted rather than edited, since it is a point-in-time announcement and re-posting would be noisier than the error.

## Checklist

- [x] Tests added or updated (not applicable, documentation)
- [x] Doc-update gate cleared (this is the doc update)
- [x] Wiki pages updated if user-facing behaviour changed (not applicable)

## Test plan

- [x] Bullet count in the v1.33.1 section is ten, matching the corrected wording
- [x] Verified in the commit with `git show HEAD:CHANGELOG.md`, not the worktree