### PR TITLE
fix(downloader): accept an empty qBittorrent add response as success (#2304)

### DIFF
--- a/changelog.d/2304-qbittorrent-empty-add-body.md
+++ b/changelog.d/2304-qbittorrent-empty-add-body.md
@@ -1,0 +1,2 @@
+### Fixed
+- **qBittorrent-API download clients that return an empty add response are no longer treated as failures** (#2304) — rdt-client and other emulators answer `POST /torrents/add` with HTTP 200 and no body, where qBittorrent itself writes `Ok.`. Bindery read the empty body as a rejection and marked every grab failed with `add torrent failed:` and no message, while the torrent was in fact accepted, downloaded to completion, and then sat there unimported. An empty body on a 200 is now an accept; a non-empty rejection body such as `Fails.` still fails the grab.

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -371,7 +371,17 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	// The read error matters here in a way it does not at the other call sites
+	// in this file. Below, an empty body on a 200 is an ACCEPT (the emulator
+	// case, #2304), so a truncated read would be promoted to success: a
+	// connection reset after the headers but before qBittorrent's "Fails."
+	// arrives would report a grab that never happened, against a hash the
+	// client will never hold. The other readers treat empty as a non-match and
+	// fail closed, which is why they can keep discarding it.
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if readErr != nil {
+		return "", fmt.Errorf("add torrent: read response: %w", readErr)
+	}
 	text := strings.TrimSpace(string(body))
 
 	// qBittorrent answers POST /torrents/add with 409 Conflict when it already

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -410,12 +410,21 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		return "", fmt.Errorf("add torrent HTTP %d: %s", resp.StatusCode, text)
 	}
 
-	// qBittorrent v4.x: plaintext body "Ok." on success, anything else is failure.
-	// qBittorrent v5.x: JSON body {"added_torrent_ids":[...],"success_count":N,...}.
-	// Accept either shape; on v5 prefer added_torrent_ids[0] as the infohash so we
-	// can skip the hash-poll fallback when the API already returned the hash.
+	// Three accepted success shapes on a 200:
+	//   qBittorrent v4.x: plaintext body "Ok."
+	//   qBittorrent v5.x: JSON {"added_torrent_ids":[...],"success_count":N,...}
+	//   API emulators:    no body at all
+	// On v5 prefer added_torrent_ids[0] as the infohash so we can skip the
+	// hash-poll fallback when the API already returned the hash.
+	//
+	// The empty case is rdt-client and friends, which accept the torrent and
+	// write nothing where qBittorrent writes "Ok." (#2304). Treating that as a
+	// failure marked every grab failed while the download completed and sat
+	// there unimported. qBittorrent signals a rejection with a NON-empty body
+	// ("Fails."), so an empty body carries no rejection signal to lose, which
+	// is why Sonarr and Radarr read it the same way.
 	v5Hash := ""
-	if text != "Ok." {
+	if text != "" && text != "Ok." {
 		var v5 struct {
 			AddedTorrentIDs []string `json:"added_torrent_ids"`
 			SuccessCount    int      `json:"success_count"`

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -2261,3 +2261,43 @@ func TestSetShareLimits_HTTPError(t *testing.T) {
 		t.Fatal("expected error on HTTP 500")
 	}
 }
+
+// TestAddTorrent_TruncatedBodyIsNotSuccess pins the hazard that accepting an
+// empty body creates (#2304). An empty body from the SERVER is the emulator
+// case and is a legitimate accept. An empty body because Bindery could not
+// finish reading is not: qBittorrent may well have written "Fails." into a
+// response that was cut off in transit, and treating that as success would
+// report a grab that never happened against a hash the client will never hold.
+func TestAddTorrent_TruncatedBodyIsNotSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			// Promise a body, then hang up before writing it, so io.ReadAll
+			// returns an unexpected EOF with no bytes.
+			w.Header().Set("Content-Length", "6")
+			w.WriteHeader(http.StatusOK)
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("test server does not support hijacking")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err == nil {
+				_ = conn.Close()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	c.loggedIn = true
+
+	if _, err := c.AddTorrent(context.Background(),
+		"magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c", "bindery", ""); err == nil {
+		t.Fatal("a truncated response body was accepted as a successful add")
+	} else if !strings.Contains(err.Error(), "read response") {
+		t.Errorf("error = %q, want it to name the read failure", err)
+	}
+}

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -597,6 +597,80 @@ func TestAddTorrent_FailsBody(t *testing.T) {
 	}
 }
 
+// TestAddTorrent_EmptyBody200_Magnet covers rdt-client and the other
+// qBittorrent-API emulators, which accept a torrent with HTTP 200 and no
+// response body where qBittorrent writes "Ok." (#2304). Reading that as a
+// failure marked every grab failed while the download ran to completion in
+// the client and was never imported. The magnet supplies the infohash, so no
+// hash poll is needed.
+func TestAddTorrent_EmptyBody200_Magnet(t *testing.T) {
+	const magnetHash = "dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			w.WriteHeader(http.StatusOK) // no body, as rdt-client answers
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	c.loggedIn = true
+
+	got, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:"+magnetHash, "bindery", "")
+	if err != nil {
+		t.Fatalf("empty 200 body must be accepted: %v", err)
+	}
+	if got != magnetHash {
+		t.Errorf("hash: want %q, got %q", magnetHash, got)
+	}
+}
+
+// TestAddTorrent_EmptyBody200_TorrentFile is the shape the #2304 reporter
+// actually hit: a private tracker behind Jackett, so Bindery uploads the
+// .torrent rather than passing a magnet, and the infohash can only come from
+// the post-add poll. The empty body must not short-circuit that.
+func TestAddTorrent_EmptyBody200_TorrentFile(t *testing.T) {
+	const polledHash = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+	added := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			added = true
+			w.WriteHeader(http.StatusOK) // no body
+		case "/api/v2/torrents/info":
+			if !added {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			_, _ = w.Write([]byte(`[{"hash":"` + polledHash + `","name":"x","added_on":1}]`))
+		case "/api/v2/torrents/setCategory", "/api/v2/torrents/setAutoManagement":
+			_, _ = w.Write([]byte("Ok."))
+		}
+	}))
+	defer srv.Close()
+
+	indexer := newFakeIndexer(t)
+	defer indexer.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
+	c.loggedIn = true
+
+	got, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "bindery", "")
+	if err != nil {
+		t.Fatalf("empty 200 body must be accepted for a .torrent upload: %v", err)
+	}
+	if got != polledHash {
+		t.Errorf("hash from post-add poll: want %q, got %q", polledHash, got)
+	}
+}
+
 func TestAddTorrent_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
## Summary

Fixes #2304.

rdt-client and other qBittorrent-API emulators answer `POST /api/v2/torrents/add` with HTTP 200 and no response body, where qBittorrent itself writes `Ok.`. The success check was `if text != "Ok."`, so an empty body fell through to the v5 JSON branch, failed to unmarshal, and returned `add torrent failed: ` with an empty message. Every grab was marked failed while the torrent was in fact accepted, downloaded to completion, and then left sitting there unimported.

qBittorrent signals a rejection with a NON-empty body (`Fails.`), so an empty body carries no rejection signal to lose. Sonarr and Radarr read it the same way, which is why rdt-client works as a download client there today.

The check becomes `if text != "" && text != "Ok."`. An empty body now falls through to the existing hash resolution: the magnet infohash when there is one, otherwise the post-add poll.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated: n/a, no env var, config or upgrade-path change
- [x] Added a changelog fragment under `changelog.d/`
- [ ] Wiki pages updated: n/a, fixes broken behaviour rather than changing documented behaviour

## Test plan

- [x] `gofmt -l` clean, `go vet ./internal/downloader/...` clean
- [x] `go build ./...`
- [x] `go test ./internal/downloader/...`, all eight packages green

Two new tests in `internal/downloader/qbittorrent/client_test.go`, covering both shapes a reporter can hit:

- `TestAddTorrent_EmptyBody200_Magnet`: the infohash comes from the magnet URI, no poll needed
- `TestAddTorrent_EmptyBody200_TorrentFile`: the #2304 reporter's actual case, a private tracker behind Jackett so Bindery uploads the `.torrent`, and the infohash can only come from the post-add poll

Both fail against the unpatched line. The rejection paths still fail as they should: `TestAddTorrent_FailsBody`, `TestAddTorrent_V5JSONResponse_FailureCount` and `TestAddTorrent_HTTPError` all still pass.
