### PR TITLE
fix(series): exclude hidden books from series fill and genre apply (#2302)

### DIFF
--- a/internal/abs/import_rollback.go
+++ b/internal/abs/import_rollback.go
@@ -1044,7 +1044,9 @@ func (i *Importer) hasMatchingProvenanceOutsideRun(ctx context.Context, entity m
 }
 
 func (i *Importer) remainingSeriesBooksAfterRunRollback(ctx context.Context, seriesID int64, runOwnedBookIDs map[int64]struct{}) (int, error) {
-	books, err := i.series.ListBooksInSeries(ctx, seriesID)
+	// Count every book still in the series, including excluded ones: an excluded
+	// book left behind still keeps the series non-empty (#2302).
+	books, err := i.series.ListBooksInSeriesIncludingExcluded(ctx, seriesID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -278,14 +278,33 @@ func (r *SeriesRepo) UpdateTitle(ctx context.Context, id int64, title string) er
 	return nil
 }
 
-// ListBooksInSeries returns all books linked to the given series, with status.
+// ListBooksInSeries returns the books linked to a series, skipping books the
+// user has excluded. Callers that act on the result (series fill, genre apply)
+// must not touch excluded books, the same way the author-level listings in
+// books.go filter them (#2302).
 func (r *SeriesRepo) ListBooksInSeries(ctx context.Context, seriesID int64) ([]models.Book, error) {
+	return r.listBooksInSeries(ctx, seriesID, false)
+}
+
+// ListBooksInSeriesIncludingExcluded is ListBooksInSeries without the excluded
+// filter, for callers that must account for every book in the series regardless
+// of its excluded flag (e.g. counting how many books an import-run rollback
+// leaves behind, where an excluded book still keeps the series non-empty).
+func (r *SeriesRepo) ListBooksInSeriesIncludingExcluded(ctx context.Context, seriesID int64) ([]models.Book, error) {
+	return r.listBooksInSeries(ctx, seriesID, true)
+}
+
+func (r *SeriesRepo) listBooksInSeries(ctx context.Context, seriesID int64, includeExcluded bool) ([]models.Book, error) {
+	where := "WHERE sb.series_id = ? AND b.excluded = 0"
+	if includeExcluded {
+		where = "WHERE sb.series_id = ?"
+	}
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status, b.monitored,
 		       b.image_url, b.release_date, b.language, b.media_type, b.created_at, b.updated_at
 		FROM series_books sb
 		JOIN books b ON b.id = sb.book_id
-		WHERE sb.series_id = ?`, seriesID)
+		`+where, seriesID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/series_test.go
+++ b/internal/db/series_test.go
@@ -135,6 +135,86 @@ func TestSeriesLinkBook(t *testing.T) {
 	}
 }
 
+// TestSeriesListBooksExcludesHidden covers #2302: ListBooksInSeries must skip
+// excluded books so series fill and genre apply do not act on them, while
+// ListBooksInSeriesIncludingExcluded still returns them for callers that count
+// every book in the series (e.g. import-run rollback).
+func TestSeriesListBooksExcludesHidden(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL-2302-A", Name: "Robert Jordan", SortName: "Jordan, Robert",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	kept := &models.Book{
+		ForeignID: "OL-2302-K", AuthorID: author.ID, Title: "The Eye of the World", SortTitle: "Eye of the World",
+		Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, kept); err != nil {
+		t.Fatal(err)
+	}
+	hidden := &models.Book{
+		ForeignID: "OL-2302-H", AuthorID: author.ID, Title: "New Spring", SortTitle: "New Spring",
+		Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, hidden); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &models.Series{ForeignID: "ol-series:wheel-of-time", Title: "The Wheel of Time"}
+	if err := seriesRepo.CreateOrGet(ctx, s); err != nil {
+		t.Fatalf("CreateOrGet: %v", err)
+	}
+	if err := seriesRepo.LinkBook(ctx, s.ID, kept.ID, "1", true); err != nil {
+		t.Fatalf("LinkBook kept: %v", err)
+	}
+	if err := seriesRepo.LinkBook(ctx, s.ID, hidden.ID, "2", true); err != nil {
+		t.Fatalf("LinkBook hidden: %v", err)
+	}
+
+	// Exclude the second book after linking it.
+	if err := bookRepo.SetExcluded(ctx, hidden.ID, true); err != nil {
+		t.Fatalf("SetExcluded: %v", err)
+	}
+
+	// ListBooksInSeries hides the excluded book (used by series fill / genre apply).
+	visible, err := seriesRepo.ListBooksInSeries(ctx, s.ID)
+	if err != nil {
+		t.Fatalf("ListBooksInSeries: %v", err)
+	}
+	if len(visible) != 1 || visible[0].ID != kept.ID {
+		t.Fatalf("ListBooksInSeries should hide the excluded book, got %+v", visible)
+	}
+
+	// ListBooksInSeriesIncludingExcluded still returns both (used by rollback counting).
+	all, err := seriesRepo.ListBooksInSeriesIncludingExcluded(ctx, s.ID)
+	if err != nil {
+		t.Fatalf("ListBooksInSeriesIncludingExcluded: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("ListBooksInSeriesIncludingExcluded should return both books, got %d: %+v", len(all), all)
+	}
+	gotIDs := map[int64]bool{}
+	for _, b := range all {
+		gotIDs[b.ID] = true
+	}
+	if !gotIDs[kept.ID] || !gotIDs[hidden.ID] {
+		t.Fatalf("ListBooksInSeriesIncludingExcluded should include both the kept and the excluded book, got %+v", all)
+	}
+}
+
 func TestSeriesManualManagement(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {


### PR DESCRIPTION
Fixes #2302.

The bug:
ListBooksInSeries (internal/db/series.go) selects from books but never filters books.excluded, unlike every author-level listing in books.go (List, ListByAuthor, ListByStatus, and so on all carry excluded = 0). Two callers act on that list:
- SeriesHandler.Fill (internal/api/series.go) builds its acquisition work list from it, and queueSeriesBook gates only on status, so an excluded book at "wanted" gets MarkWantedMonitored then SearchAndGrabBook. Series fill re-acquires the exact books the user excluded, the opposite of what excluding means.
- The series genre apply (internal/api/genre_apply.go) writes genres onto excluded books too.

The fix:
Filter excluded = 0 in ListBooksInSeries so both action paths skip excluded books, matching the author-level queries. The one caller that must still see every book regardless of the flag is remainingSeriesBooksAfterRunRollback (internal/abs/import_rollback.go), which counts the books a rollback leaves behind to decide whether the series is now empty; an excluded book still keeps the series non-empty, so that path calls a new ListBooksInSeriesIncludingExcluded. This mirrors the existing ListByAuthor / ListByAuthorIncludingExcluded split.

Testing:
- Added TestSeriesListBooksExcludesHidden (internal/db/series_test.go): with one series and two linked wanted books, one excluded, ListBooksInSeries returns only the kept book and ListBooksInSeriesIncludingExcluded returns both. It fails without the filter (ListBooksInSeries returns both), so it pins the bug.
- go test ./internal/db/ ./internal/abs/ ./internal/api/ pass; go build ./..., gofmt, go vet and golangci-lint are clean.

Scope note: this fixes the non-cosmetic behaviour (fill re-acquiring excluded books, genre apply touching them). The two series-display reads, ListWithBooksForUser and GetByIDForUser, also return excluded books, and since excluded is not in their SELECT the API reports excluded=false for them. Whether the series page should hide those (consistent with the author view) or show them greyed out is a UI call, so I left it out of this change; happy to follow up whichever way you prefer.
