### PR TITLE
fix(authors): only save latin alternate-name aliases for a non-latin author (#2268)

### DIFF
--- a/changelog.d/2268-author-alias-latin-guard.md
+++ b/changelog.d/2268-author-alias-latin-guard.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Author aliases** (#2268): a latin-script author (a pen name, or a two-author collaboration credit) no longer has other real authors' OpenLibrary alternate names saved as its aliases. Alternate-name aliases are kept only for authors whose primary name is non-latin, which is the case they exist for.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -3484,6 +3484,17 @@ func (h *AuthorHandler) saveAlternateNames(ctx context.Context, author *models.A
 	if h.aliases == nil || len(author.AlternateNames) == 0 {
 		return
 	}
+	// These latin-script aliases exist only so a non-latin primary name can be
+	// reached by a latin release name (e.g. "Murakami" -> "村上春樹"). For a
+	// latin-script author every alternate name is just another latin name, and
+	// minting it as an alias would file unrelated real authors (a pen name, or a
+	// co-author credit) under this one. Only save them when the author's own name
+	// is non-latin, mirroring the read-side guard in aliasBindsAuthor
+	// (importer.go), which binds an unattributed latin alias only when the
+	// canonical name is non-latin.
+	if isAllASCII(author.Name) {
+		return
+	}
 	for _, name := range author.AlternateNames {
 		if !isAllASCII(name) {
 			continue

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -8071,3 +8071,65 @@ func TestFetchAuthorBooks_StillWidensAnUnownedBook(t *testing.T) {
 		t.Errorf("mediaType = %q, want both — an unowned book still merges", books[0].MediaType)
 	}
 }
+
+// TestSaveAlternateNames_OnlyBindsNonLatinAuthor is the regression test for
+// #2268: saveAlternateNames minted every all-ASCII OpenLibrary alternate name
+// as an alias without checking the author's own name, so a latin-script author
+// (a pen name, or a two-author collaboration credit) had unrelated real
+// authors' names filed under it as aliases. Latin aliases must only be saved
+// when the author's primary name is non-latin, mirroring aliasBindsAuthor on
+// the read side.
+func TestSaveAlternateNames_OnlyBindsNonLatinAuthor(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	aliasRepo := db.NewAuthorAliasRepo(database)
+	h := &AuthorHandler{authors: authorRepo, aliases: aliasRepo}
+
+	// A latin-script author (here a pen name) whose OpenLibrary "alternate
+	// names" are in fact other real authors. None of these may become aliases.
+	penName := &models.Author{
+		ForeignID:      "ol:kem-antilles",
+		Name:           "Kem Antilles",
+		SortName:       "Antilles, Kem",
+		AlternateNames: []string{"Kevin J. Anderson", "Rebecca Moesta"},
+	}
+	if err := authorRepo.Create(ctx, penName); err != nil {
+		t.Fatalf("create latin-script author: %v", err)
+	}
+	h.saveAlternateNames(ctx, penName)
+	if got, err := aliasRepo.ListByAuthor(ctx, penName.ID); err != nil {
+		t.Fatalf("list aliases for latin-script author: %v", err)
+	} else if len(got) != 0 {
+		t.Fatalf("latin-script author minted %d aliases, want 0: %+v", len(got), got)
+	}
+
+	// A non-latin author still gets its latin alternate names as aliases, so a
+	// latin release name can reach the non-latin primary name (the feature).
+	murakami := &models.Author{
+		ForeignID:      "ol:murakami",
+		Name:           "村上春樹",
+		SortName:       "村上春樹",
+		AlternateNames: []string{"Haruki Murakami", "Murakami"},
+	}
+	if err := authorRepo.Create(ctx, murakami); err != nil {
+		t.Fatalf("create non-latin author: %v", err)
+	}
+	h.saveAlternateNames(ctx, murakami)
+	got, err := aliasRepo.ListByAuthor(ctx, murakami.ID)
+	if err != nil {
+		t.Fatalf("list aliases for non-latin author: %v", err)
+	}
+	names := map[string]bool{}
+	for _, a := range got {
+		names[a.Name] = true
+	}
+	if len(got) != 2 || !names["Haruki Murakami"] || !names["Murakami"] {
+		t.Fatalf("non-latin author aliases = %+v, want exactly [Haruki Murakami, Murakami] (feature regressed)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2268. `saveAlternateNames` persists an author's OpenLibrary "alternate names" as `author_aliases` rows, keeping only the all-ASCII (latin) ones, so a non-latin primary name (for example 村上春樹) can be reached by a latin release name (Murakami). It never checked the author's own name, so a latin-script author (a pen name, or a two-author collaboration credit) had other real authors' alternate names minted as its aliases.

The read side already guards exactly this: `aliasBindsAuthor` (internal/calibre/importer.go) binds an unattributed latin alias only when the canonical name is non-latin (`!isAllASCII(canonical.Name) && isAllASCII(alias.Name)`). This adds the missing write-side half: `saveAlternateNames` returns early when the author's own name is all-ASCII. The latin same-name variants that legitimately bind (initials, comma-sort, punctuation) are written elsewhere with provenance (`recordAuthorCreateAlias` stamps a `SourceOLID`), so nothing that should bind is lost, only the unattributed OL dump for latin authors is dropped.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` (no env, config, or upgrade change)
- [x] Added a changelog fragment under `changelog.d/`
- [ ] Wiki (no new user-facing surface, only the incorrect-alias behaviour is fixed)

## Test plan

Backend-only change, no frontend touched.

- `go build ./...` and `go vet ./internal/api/` clean, `gofmt` clean.
- `go test ./internal/api/ ./internal/calibre/` pass (the affected packages, including the read-side `aliasBindsAuthor`).
- Added `TestSaveAlternateNames_OnlyBindsNonLatinAuthor`: a latin-script author with two collaborator names as alternates mints zero aliases (this fails without the guard, minting both names), and a non-latin author still gets its latin alternate names, so the feature it exists for is preserved.