### PR TITLE
feat(scheduler): log every automatic search, with what started it (#2154)

### DIFF
--- a/changelog.d/2154-search-observability.md
+++ b/changelog.d/2154-search-observability.md
@@ -1,0 +1,2 @@
+### Added
+- **Every automatic search now logs when it finishes** (#2154) — a scheduled sweep, a bulk search or a series fill that found nothing used to log nothing at all, so "the search never ran" and "the search ran and found nothing" looked identical from the log. Each one now emits a single INFO line naming what started it, the book and format, how many indexers were queried, how many results came back, how many survived filtering, and how long it took. Thanks to SturmB for the report.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -2740,7 +2740,7 @@ func runBookSearches(ctx context.Context, searcher BookSearcher, books []models.
 	// once as slots free up (#1515); shares the package pace with the bulk
 	// "search all" and series-fill fan-outs.
 	concurrency.RunBoundedPaced(ctx, books, maxConcurrent, searchPaceInterval, func(ctx context.Context, book models.Book) {
-		searcher.SearchAndGrabBook(ctx, book)
+		searcher.SearchAndGrabBook(indexer.WithSearchOrigin(ctx, indexer.OriginAuthor), book)
 	})
 }
 
@@ -3339,7 +3339,7 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	// context so the search goroutine is cancelled on shutdown rather than
 	// running against context.Background(). See #846.
 	if req.SearchOnAdd && h.searcher != nil {
-		go h.searcher.SearchAndGrabBook(h.bgCtx(), *book) // #nosec G118 -- intentional: search must outlive the request
+		go h.searcher.SearchAndGrabBook(indexer.WithSearchOrigin(h.bgCtx(), indexer.OriginAuthor), *book) // #nosec G118 -- intentional: search must outlive the request
 	}
 
 	writeJSON(w, http.StatusCreated, book)

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
+	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/textutil"
@@ -555,7 +556,7 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if autoGrabEnabled {
-			go h.searcher.SearchAndGrabBook(bgCtx, b)
+			go h.searcher.SearchAndGrabBook(indexer.WithSearchOrigin(bgCtx, indexer.OriginBook), b)
 		}
 	}
 

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/concurrency"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -372,7 +373,7 @@ func (h *BulkHandler) fanOutSearches(books []models.Book) {
 	}
 	bgCtx := h.bgCtx()
 	go concurrency.RunBoundedPaced(bgCtx, books, bulkSearchConcurrency, searchPaceInterval, func(ctx context.Context, b models.Book) {
-		h.searcher.SearchAndGrabBook(ctx, b)
+		h.searcher.SearchAndGrabBook(indexer.WithSearchOrigin(ctx, indexer.OriginBulk), b)
 	})
 }
 

--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -245,7 +246,7 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 	// Use the process-lifecycle context so the goroutine is cancelled on
 	// shutdown rather than running forever on context.Background(). See #550.
 	if h.searcher != nil && !fileFound {
-		go h.searcher.SearchAndGrabBook(h.appCtx, *book) // #nosec G118 -- intentional: search must outlive the request
+		go h.searcher.SearchAndGrabBook(indexer.WithSearchOrigin(h.appCtx, indexer.OriginRecommendation), *book) // #nosec G118 -- intentional: search must outlive the request
 	}
 
 	writeJSON(w, http.StatusCreated, book)

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/concurrency"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/seriesmatch"
@@ -601,7 +602,7 @@ func (h *SeriesHandler) fanOutSeriesSearches(ctx context.Context, books []models
 	// there is nothing on the request ctx that the search needs.
 	bgCtx := h.bgCtx()
 	go concurrency.RunBoundedPaced(bgCtx, books, seriesFillSearchConcurrency, searchPaceInterval, func(ctx context.Context, b models.Book) {
-		h.searcher.SearchAndGrabBook(ctx, b)
+		h.searcher.SearchAndGrabBook(indexer.WithSearchOrigin(ctx, indexer.OriginSeriesFill), b)
 	})
 }
 

--- a/internal/indexer/origin.go
+++ b/internal/indexer/origin.go
@@ -1,0 +1,53 @@
+package indexer
+
+import "context"
+
+// SearchOrigin names the thing that started a search. Every automatic search
+// funnels through Scheduler.SearchAndGrabBook, which cannot otherwise tell a
+// scheduled wanted sweep apart from a bulk action or a series fill, so a log
+// line saying "search finished, nothing found" left the user unable to answer
+// "did the sweep I just triggered actually run?" (#2154).
+//
+// It rides on the context rather than a parameter because the call chain
+// crosses package boundaries (api handlers hold a BookSearcher interface, not
+// a *Scheduler) and because the background pools in api/bulk.go already carry
+// their own context into the goroutine that runs the search.
+type SearchOrigin string
+
+const (
+	// OriginScheduled is the periodic wanted sweep.
+	OriginScheduled SearchOrigin = "scheduled"
+	// OriginBulk is POST /api/v1/book/bulk or /api/v1/wanted/bulk.
+	OriginBulk SearchOrigin = "bulk"
+	// OriginSeriesFill is the series Fill action.
+	OriginSeriesFill SearchOrigin = "series-fill"
+	// OriginAuthor is an author-level search or an author refresh that found
+	// new books.
+	OriginAuthor SearchOrigin = "author"
+	// OriginBook is a single-book search started from the book page.
+	OriginBook SearchOrigin = "book"
+	// OriginRecommendation is an accepted recommendation.
+	OriginRecommendation SearchOrigin = "recommendation"
+	// OriginRequeue is the automatic re-search after a stalled download was
+	// removed and blocklisted.
+	OriginRequeue SearchOrigin = "requeue"
+	// OriginUnknown is the fallback for a caller that did not set one. It is a
+	// real value rather than an empty string so the log line always carries the
+	// field and a missing origin reads as a gap rather than as absence.
+	OriginUnknown SearchOrigin = "unknown"
+)
+
+type searchOriginKey struct{}
+
+// WithSearchOrigin returns ctx tagged with the origin of the search about to run.
+func WithSearchOrigin(ctx context.Context, o SearchOrigin) context.Context {
+	return context.WithValue(ctx, searchOriginKey{}, o)
+}
+
+// SearchOriginFrom returns the origin ctx was tagged with, or OriginUnknown.
+func SearchOriginFrom(ctx context.Context) SearchOrigin {
+	if o, ok := ctx.Value(searchOriginKey{}).(SearchOrigin); ok && o != "" {
+		return o
+	}
+	return OriginUnknown
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -839,11 +839,36 @@ func freeleechOnlyIndexerIDs(idxs []models.Indexer) map[int64]bool {
 // searchAndGrabFormat searches for and grabs a specific format of a book.
 // mediaType must be MediaTypeEbook or MediaTypeAudiobook.
 func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, mediaType string, sweep *sweepContext) {
+	// #2154: a search that found nothing used to log nothing at all, so "the
+	// sweep never ran" and "the sweep ran and found nothing" were
+	// indistinguishable from the outside. Every return path below now leaves
+	// exactly one INFO line. The counters are filled in as the search
+	// progresses, so a path that returns early leaves them at zero, which is
+	// the honest reading of how far it got.
+	started := time.Now()
+	outcome := "aborted"
+	var indexerCount, rawResults, afterFilters, approved int
+	defer func() {
+		slog.Info("book search finished",
+			"origin", string(indexer.SearchOriginFrom(ctx)),
+			"book", book.Title,
+			"book_id", book.ID,
+			"format", mediaType,
+			"indexers", indexerCount,
+			"raw_results", rawResults,
+			"after_filters", afterFilters,
+			"approved", approved,
+			"outcome", outcome,
+			"elapsed_ms", time.Since(started).Milliseconds())
+	}()
+
 	idxs, err := s.sweepIndexers(ctx, sweep)
 	if err != nil {
 		slog.Error("SearchAndGrabBook: failed to list indexers", "error", err)
+		outcome = "indexer list failed"
 		return
 	}
+	indexerCount = len(idxs)
 
 	lang := s.sweepPreferredLanguage(ctx, sweep)
 
@@ -887,6 +912,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	}
 
 	results, outcomes := s.searchBookWithOutcomes(ctx, idxs, crit)
+	rawResults = len(results)
 	// An indexer that failed contributed zero results and is otherwise
 	// indistinguishable from one that answered with nothing, so a grab decided
 	// on a shrunken pool used to leave no trace at all. Recording only: what
@@ -912,6 +938,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	} else {
 		results = indexer.FilterByLanguage(results, lang)
 	}
+	afterFilters = len(results)
 
 	var specs []decision.Specification
 	if entries, ok := s.sweepBlocklist(ctx, sweep); ok {
@@ -991,13 +1018,20 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		// Re-evaluate any existing pending releases for this book/format with the current age.
 		best = s.checkPendingReleases(ctx, book, mediaType, dm)
 		if best == nil {
+			if rawResults == 0 {
+				outcome = "no results"
+			} else {
+				outcome = "nothing approved"
+			}
 			return
 		}
 	}
+	approved = 1
 
 	candidates, err := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
 	if err != nil {
 		slog.Error("SearchAndGrabBook: failed to list download clients", "protocol", best.Protocol, "error", err)
+		outcome = "download client lookup failed"
 		return
 	}
 	client := db.PickClientForMediaType(candidates, mediaType)
@@ -1006,7 +1040,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	// as a torrent, and report "hash could not be determined"), and vice versa.
 	if client == nil {
 		slog.Warn("SearchAndGrabBook: no enabled download client for protocol", "book", book.Title, "protocol", best.Protocol)
-
+		outcome = "no download client for protocol"
 		return
 	}
 
@@ -1024,9 +1058,11 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	existing, err := s.downloads.GetByGUID(ctx, best.GUID)
 	if err != nil {
 		slog.Warn("failed to check existing download", "guid", best.GUID, "error", err)
+		outcome = "duplicate check failed"
 		return
 	}
 	if existing != nil {
+		outcome = "already grabbed"
 		return
 	}
 
@@ -1046,6 +1082,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 
 	if err := s.downloads.Create(ctx, dl); err != nil {
 		slog.Error("SearchAndGrabBook: failed to create download record", "error", err)
+		outcome = "download record failed"
 		return
 	}
 
@@ -1060,6 +1097,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		if setErr := s.downloads.SetError(ctx, dl.ID, err.Error()); setErr != nil {
 			slog.Warn("failed to persist download error", "download_id", dl.ID, "error", setErr)
 		}
+		outcome = "send to downloader failed"
 		return
 	}
 	if sendRes.RemoteID != "" {
@@ -1077,6 +1115,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	if err := s.downloads.UpdateStatus(ctx, dl.ID, models.StateDownloading); err != nil {
 		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.StateDownloading, "error", err)
 	}
+	outcome = "grabbed"
 	slog.Info("sent to downloader", "client", client.Type, "title", best.Title)
 	// Record history for the auto-grab. Without this the History tab is
 	// empty for every scheduler-initiated grab (manual grabs via the queue
@@ -1221,7 +1260,7 @@ func (s *Scheduler) searchWanted() {
 	// once per book (#2370).
 	sweep := s.newSweepContext(ctx)
 	concurrency.RunBoundedPaced(ctx, searchQueue, scheduledWantedSearchConcurrency, searchPaceInterval, func(ctx context.Context, w wantedSearch) {
-		s.searchAndGrabFormats(ctx, w.book, w.formats, sweep)
+		s.searchAndGrabFormats(indexer.WithSearchOrigin(ctx, indexer.OriginScheduled), w.book, w.formats, sweep)
 	})
 }
 
@@ -1596,7 +1635,7 @@ func (s *Scheduler) handleStalledDownload(ctx context.Context, dl *models.Downlo
 	s.bgWg.Add(1)
 	go func() {
 		defer s.bgWg.Done()
-		s.SearchAndGrabBook(ctx, *book)
+		s.SearchAndGrabBook(indexer.WithSearchOrigin(ctx, indexer.OriginRequeue), *book)
 	}()
 }
 

--- a/internal/scheduler/search_observability_test.go
+++ b/internal/scheduler/search_observability_test.go
@@ -1,0 +1,217 @@
+package scheduler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// captureLogs redirects the default slog logger into a buffer for the duration
+// of the test and returns the buffer.
+//
+// The level is deliberately Info, not Debug: #2154 asks for evidence at the
+// level an operator actually runs at, so a completion line demoted to Debug
+// must fail these tests rather than pass them.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func newEmptyScheduler(t *testing.T) *Scheduler {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return &Scheduler{
+		searcher:  indexer.NewSearcher(),
+		indexers:  db.NewIndexerRepo(database),
+		authors:   db.NewAuthorRepo(database),
+		settings:  db.NewSettingsRepo(database),
+		blocklist: db.NewBlocklistRepo(database),
+	}
+}
+
+// A search that finds nothing used to return in silence, so a user could not
+// tell a sweep that ran and found nothing from one that never ran at all
+// (#2154). Every automatic search must leave exactly one completion line.
+func TestSearchAndGrabBook_LogsCompletionWhenNothingIsFound(t *testing.T) {
+	s := newEmptyScheduler(t)
+	buf := captureLogs(t)
+
+	s.SearchAndGrabBook(context.Background(), models.Book{
+		ID: 42, Title: "Dune", MediaType: models.MediaTypeEbook,
+	})
+
+	out := buf.String()
+	if n := strings.Count(out, "book search finished"); n != 1 {
+		t.Fatalf("want exactly one completion line, got %d:\n%s", n, out)
+	}
+	for _, want := range []string{
+		"book=Dune", "book_id=42", "format=ebook",
+		"indexers=0", "raw_results=0", "after_filters=0", "approved=0",
+		`outcome="no results"`, "elapsed_ms=",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("completion line is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// The origin is the field that answers "did the thing I just clicked run?",
+// so it has to survive the trip from the handler's fan-out into the scheduler.
+func TestSearchAndGrabBook_LogsTheOriginItWasGiven(t *testing.T) {
+	cases := map[string]indexer.SearchOrigin{
+		"scheduled":      indexer.OriginScheduled,
+		"bulk":           indexer.OriginBulk,
+		"series-fill":    indexer.OriginSeriesFill,
+		"author":         indexer.OriginAuthor,
+		"book":           indexer.OriginBook,
+		"recommendation": indexer.OriginRecommendation,
+		"requeue":        indexer.OriginRequeue,
+	}
+	for want, origin := range cases {
+		t.Run(want, func(t *testing.T) {
+			s := newEmptyScheduler(t)
+			buf := captureLogs(t)
+
+			ctx := indexer.WithSearchOrigin(context.Background(), origin)
+			s.SearchAndGrabBook(ctx, models.Book{ID: 1, Title: "Dune", MediaType: models.MediaTypeEbook})
+
+			if got := buf.String(); !strings.Contains(got, "origin="+want) {
+				t.Fatalf("want origin=%s in the completion line, got:\n%s", want, got)
+			}
+		})
+	}
+}
+
+// An untagged caller must still produce a line. "unknown" is a real value
+// rather than an empty field so a gap in the tagging reads as a gap.
+func TestSearchAndGrabBook_UntaggedCallerLogsUnknownOrigin(t *testing.T) {
+	s := newEmptyScheduler(t)
+	buf := captureLogs(t)
+
+	s.SearchAndGrabBook(context.Background(), models.Book{ID: 1, Title: "Dune", MediaType: models.MediaTypeEbook})
+
+	if got := buf.String(); !strings.Contains(got, "origin=unknown") {
+		t.Fatalf("want origin=unknown, got:\n%s", got)
+	}
+}
+
+// The kill switch returns before searchAndGrabFormat is reached, so it keeps
+// its own dedicated line and must not also claim a search finished.
+func TestSearchAndGrabBook_DisabledAutoGrabDoesNotClaimASearchRan(t *testing.T) {
+	s := newEmptyScheduler(t)
+	if err := s.settings.Set(context.Background(), "autoGrab.enabled", "false"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	buf := captureLogs(t)
+
+	s.SearchAndGrabBook(context.Background(), models.Book{ID: 1, Title: "Dune", MediaType: models.MediaTypeEbook})
+
+	out := buf.String()
+	if strings.Contains(out, "book search finished") {
+		t.Fatalf("a skipped search must not log a completion line:\n%s", out)
+	}
+	if !strings.Contains(out, "auto-grab disabled globally") {
+		t.Fatalf("the skip must still be logged:\n%s", out)
+	}
+}
+
+// A "both" book searches twice, once per format, and each search is its own
+// event: one line each, not one line for the pair.
+func TestSearchAndGrabBook_LogsOncePerFormat(t *testing.T) {
+	s := newEmptyScheduler(t)
+	buf := captureLogs(t)
+
+	s.SearchAndGrabBook(context.Background(), models.Book{
+		ID: 7, Title: "Dune", MediaType: models.MediaTypeBoth,
+	})
+
+	out := buf.String()
+	if n := strings.Count(out, "book search finished"); n != 2 {
+		t.Fatalf("want one completion line per format, got %d:\n%s", n, out)
+	}
+	if !strings.Contains(out, "format=ebook") || !strings.Contains(out, "format=audiobook") {
+		t.Fatalf("both formats must be named:\n%s", out)
+	}
+}
+
+// TestEverySearchCallSiteTagsItsOrigin is the drift guard for the origin field.
+//
+// The completion line is only useful if "origin" says something. A new fan-out
+// added without a WithSearchOrigin wrapper still logs, but logs "unknown",
+// which is exactly the ambiguity #2154 was filed about. Rather than trust every
+// future caller to remember, assert the structural property: in production
+// code, every call of SearchAndGrabBook passes a context that was tagged on the
+// spot.
+//
+// The check is textual because the call sites live in three packages and the
+// tag is applied inline at each one. A caller that legitimately cannot tag on
+// the same line should tag its context earlier and be added to the exemption
+// list here, with a comment saying why.
+func TestEverySearchCallSiteTagsItsOrigin(t *testing.T) {
+	// Only the two source trees that ship. Walking the repo root would also
+	// pick up .claude/worktrees, which holds stale copies of these same files.
+	roots := []string{filepath.Join("..", "..", "cmd"), filepath.Join("..", "..", "internal")}
+	var untagged []string
+
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			raw, err := os.ReadFile(path) //nolint:gosec // test-only walk of the repo's own source
+			if err != nil {
+				return err
+			}
+			for i, line := range strings.Split(string(raw), "\n") {
+				trimmed := strings.TrimSpace(line)
+				if !strings.Contains(trimmed, "SearchAndGrabBook(") {
+					continue
+				}
+				switch {
+				case strings.HasPrefix(trimmed, "//"):
+					// Prose about the call, not the call.
+					continue
+				case strings.Contains(trimmed, "func "):
+					// The method declaration.
+					continue
+				case strings.Contains(trimmed, "context.Context"):
+					// The BookSearcher interface method in api/helpers.go.
+					continue
+				case strings.Contains(trimmed, "WithSearchOrigin("):
+					continue
+				}
+				untagged = append(untagged, fmt.Sprintf("%s:%d: %s", path, i+1, trimmed))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v (this guard needs the full checkout)", root, err)
+		}
+	}
+
+	if len(untagged) > 0 {
+		t.Fatalf("these searches would log origin=unknown; wrap the context in indexer.WithSearchOrigin (#2154):\n  %s",
+			strings.Join(untagged, "\n  "))
+	}
+}


### PR DESCRIPTION
Addresses point 1 of #2154. Points 2 and 3 are confirmed but deliberately not in this PR — see below.

## What was wrong

I traced all three points in @SturmB's report against `main`. All three are real, and the mechanism in each case is exactly as described.

**Point 1, the one this PR fixes.** `Scheduler.searchAndGrabFormat` had three INFO lines and every one of them is conditional:

- `"searching with an incomplete indexer pool"` — only when an indexer hard-failed
- `"skipping a multi-book pack for a single-book search"` — only when a pack was a candidate
- `"auto-grabbing book"` — only on success

A clean no-result search fell through `if best == nil { ... return }` and logged nothing whatsoever. So "the sweep never ran" and "the sweep ran and found nothing" were genuinely indistinguishable, which is what the report says.

## The fix

One INFO line on **every** return path out of `searchAndGrabFormat`, carrying the fields the report asked for:

```
level=INFO msg="book search finished" origin=bulk book=Dune book_id=42 format=ebook
  indexers=3 raw_results=17 after_filters=4 approved=1 outcome=grabbed elapsed_ms=2841
```

`outcome` distinguishes the ways a search can end: `no results`, `nothing approved`, `grabbed`, `already grabbed`, `no download client for protocol`, and the error paths. The counters fill in as the search progresses, so an early return leaves them at zero — an honest reading of how far it got rather than a fabricated one.

### Why the origin is on the context

`origin` is the field that actually answers "did the thing I just clicked run?", and it is the awkward one: the call chain crosses three packages and the API handlers hold a `BookSearcher` interface, not a `*Scheduler`, so a parameter would have to be threaded through an interface every caller implements. The bounded pools in `bulk.go`, `series.go` and `authors.go` already carry their own context into the search goroutine, so the context is the thing that is already going where the value needs to go.

`indexer.WithSearchOrigin` / `indexer.SearchOriginFrom`, same shape as the existing context-carried values in this codebase. Eight production call sites, all tagged:

| origin | site |
| --- | --- |
| `scheduled` | the periodic wanted sweep |
| `bulk` | `POST /api/v1/book/bulk` and `/wanted/bulk` |
| `series-fill` | series Fill |
| `author` | author auto-search and add-with-search |
| `book` | a book flipping to wanted |
| `recommendation` | an accepted recommendation |
| `requeue` | the re-search after a stalled download is blocklisted |
| `unknown` | the fallback, a real value so a gap reads as a gap |

`TestEverySearchCallSiteTagsItsOrigin` asserts that structurally by reading the source, so a fan-out added later fails the suite instead of quietly logging `origin=unknown`.

## Verification

Five tests, and the log capture runs at `LevelInfo` on purpose — #2154 asks for evidence at the level an operator actually runs at, so a line demoted to Debug has to fail rather than pass.

Negative controls, all three run:

| control | result |
| --- | --- |
| demote the line to `slog.Debug` | 3 tests fail |
| remove the line entirely | 4 tests fail |
| untag one call site | the drift guard fails, naming the file and line |

Also asserted: a `both` book logs one line per format, not one for the pair, and the auto-grab kill switch keeps its own dedicated line without claiming a search ran.

## What is not here, and why

Points 2 and 3 are confirmed but are API contract changes, not logging, and each needs a decision I did not want to bury in this PR.

**Point 2 — bulk reports success before doing the work.** `BulkHandler.BooksBulk` sets `bulkItemResult{OK: true}` per id in the request loop, then calls `fanOutSearches` after it, and that helper is documented fire-and-forget by design. So `ok:true` means accepted, exactly as the report says. Fixing it means either renaming the field's meaning (a breaking response change) or introducing a job id the caller can poll. That is a design decision, not a bug fix.

**Point 3 — `last-debug` is partitioned and incompletely written.** `lastDebugStore` is keyed by user id and `set` is called from exactly one place, the interactive `SearchBook` handler. `LastSearchDebug` reads `auth.UserIDFromContext`, which is 0 for an API key. So an API-key reader and a browser session are looking at different buckets, and the scheduled and bulk paths write to neither. The correction in the report about the UI using the interactive handler is right.

The awkward part is that the store lives on `IndexerHandler` in `internal/api` while the searches that need to write to it run in `internal/scheduler`, so populating it from those paths means either moving the store or handing the scheduler a writer interface. That is worth doing and worth doing deliberately.

@SturmB — this gets you the evidence trail. Does the completion line carry what you need for the scheduled and bulk cases, and would you rather see point 2 solved by a job id you can poll or by the response field just saying "queued" honestly?
