### PR TITLE
docs: correct the v1.32.1 series claim in the changelog (#2328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,7 +297,7 @@ minute.
 
 - **Adding a second volume of a series did nothing** (#2116). The query that fetches a single book never asked Hardcover for its series, so the duplicate guard had nothing to compare and always let the merge through. The same field was missing from the ISBN lookup.
 
-- **Hardcover supplemented author catalogues had no series information** (#2121). Works pulled from Hardcover to fill out an author's bibliography arrived with no series membership, so those books were never linked into a series and an author set to monitor a specific series never picked them up. They now carry the series and volume number Hardcover holds. Existing books gain their links on the next author refresh.
+- **Hardcover supplemented author catalogues had no series information** (#2121). Works pulled from Hardcover to fill out an author's bibliography arrived with no series membership, so those books were never linked into a series and an author set to monitor a specific series never picked them up. They now carry the series and volume number Hardcover holds. Correction to this entry as first published: books already in your library do not gain their links on the next author refresh. A refresh only links series for books it creates, so an existing book keeps whatever series it already had. That gap is tracked as #2328.
 
 - **Readarr migration turned every non qBittorrent download client into SABnzbd** (#1983). All six client types Bindery supports are now mapped by name, and a Readarr client with no Bindery equivalent, such as NZBVortex or a blackhole, is reported as a skipped row instead of becoming a SABnzbd client that cannot work.
 


### PR DESCRIPTION
## What

The v1.32.1 entry for #2121 ended with "Existing books gain their links on the next author refresh." That is not true, so this replaces that sentence with a correction that points at #2328.

The rest of the entry stays as it was. The #2121 fix was real: Hardcover supplemented works do carry series membership when they are created.

## Why

Series membership is written in one place on the author sync path, `handleNewWantedBook` (`internal/api/authors.go:2722`), and the sync calls it only from the created books loop (`internal/api/authors.go:2584`). Every branch that resolves an incoming work to a row the library already has ends in `continue` before it:

* identity match, `resolveExistingBook` at `internal/api/authors.go:2241`, continues at `:2412`
* title dedup, `seenTitles.Lookup` at `internal/api/authors.go:2425`, continues at `:2491`

Both update ratings, cover, genres and reparenting only. So a refresh never adds a series link to a book that already exists. Tracked as #2328.

## Also checked

Swept the rest of the changelog for the same shape of promise. These all hold up against the code:

* #1779 "those books come back on the next author refresh" is about works the filter never created, so the refresh creates them
* #1748 cover backfill, #1130 genre backfill and the v1.4.1 ratings backfill are all done by the existing book branch above
* #2186 "a library scan repairs books that were already stuck this way" is backed by the scanner stale path sweep
* #2042 "keys are recomputed automatically on the next start" is backed by the boot rewrite in `internal/db/db.go:442`

One soft spot left alone: the v1.19.0 `{Genre}` entry says to refresh an author to backfill genres onto older books. The backfill is gated on Hardcover provenance, so on an OpenLibrary only install it does nothing. True for the configuration the feature is about, overstated for the other one. Left as is rather than rewriting a June entry, say the word if you want it corrected too.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP