### PR TITLE
fix(web): drive the queue chips from one download-state table (#2342, #2339, #2336)

### DIFF
--- a/web/src/components/downloadStatus.test.ts
+++ b/web/src/components/downloadStatus.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DOWNLOAD_STATUSES,
+  FAILED_STATUSES,
+  RETRYABLE_STATUSES,
+  downloadStatusBadge,
+  isMatchable,
+  isRetryable,
+} from './downloadStatus'
+
+// Stub t: return the key so we can assert which label path was taken without
+// depending on the loaded i18n resources.
+const t = ((key: string) => key) as unknown as Parameters<typeof downloadStatusBadge>[1]
+
+// Every DownloadState constant declared in internal/models/download_state.go.
+// Copied deliberately: if a state is added there and not here, the coverage
+// test below fails and whoever added it gets told to give it a label and a chip
+// instead of shipping a grey pill reading the raw enum (#2339).
+const GO_DOWNLOAD_STATES = [
+  'grabbed',
+  'downloading',
+  'completed',
+  'importPending',
+  'importing',
+  'imported',
+  'failed',
+  'importFailed',
+  'importBlocked',
+  'importExternal',
+  'importHeld',
+]
+
+describe('DOWNLOAD_STATUSES', () => {
+  it('covers every state internal/models/download_state.go defines', () => {
+    for (const state of GO_DOWNLOAD_STATES) {
+      expect(DOWNLOAD_STATUSES[state], `no table entry for "${state}"`).toBeDefined()
+    }
+  })
+
+  it('has no entry the Go side does not define', () => {
+    expect(Object.keys(DOWNLOAD_STATUSES).sort()).toEqual([...GO_DOWNLOAD_STATES].sort())
+  })
+
+  it('gives every state a label key and a chip class', () => {
+    for (const [state, entry] of Object.entries(DOWNLOAD_STATUSES)) {
+      expect(entry.labelKey, state).toBeTruthy()
+      expect(entry.chip, state).toBeTruthy()
+    }
+  })
+
+  it('explains the two non-terminal hand-off states', () => {
+    expect(DOWNLOAD_STATUSES.importExternal.descriptionKey).toBeTruthy()
+    expect(DOWNLOAD_STATUSES.importHeld.descriptionKey).toBeTruthy()
+  })
+})
+
+describe('derived state sets', () => {
+  it('counts the three failed states', () => {
+    expect([...FAILED_STATUSES].sort()).toEqual(['failed', 'importBlocked', 'importFailed'])
+  })
+
+  // internal/db/downloads.go ResetImportRetry updates
+  // "WHERE ... status IN (StateImportFailed, StateImportBlocked)", so the bulk
+  // retry must offer exactly those two — #2336 shipped with importFailed only.
+  it('matches the states ResetImportRetry accepts', () => {
+    expect([...RETRYABLE_STATUSES].sort()).toEqual(['importBlocked', 'importFailed'])
+    expect(isRetryable('importBlocked')).toBe(true)
+    expect(isRetryable('importFailed')).toBe(true)
+    expect(isRetryable('failed')).toBe(false)
+  })
+
+  it('treats importFailed and importBlocked as matchable and nothing else', () => {
+    expect(isMatchable('importFailed')).toBe(true)
+    expect(isMatchable('importBlocked')).toBe(true)
+    expect(isMatchable('failed')).toBe(false)
+    expect(isMatchable('importExternal')).toBe(false)
+  })
+})
+
+describe('downloadStatusBadge', () => {
+  it('reuses the existing history keys where they already say the same thing', () => {
+    expect(downloadStatusBadge('grabbed', t).label).toBe('history.events.grabbed')
+    expect(downloadStatusBadge('importFailed', t).label).toBe('history.events.importFailed')
+  })
+
+  it('labels the two states that used to render as raw enum text (#2339)', () => {
+    const ext = downloadStatusBadge('importExternal', t)
+    expect(ext.label).toBe('queue.status.importExternal')
+    expect(ext.label).not.toBe('importExternal')
+    expect(ext.chip).not.toBe('')
+    expect(ext.description).toBe('queue.status.importExternalHint')
+
+    const held = downloadStatusBadge('importHeld', t)
+    expect(held.label).toBe('queue.status.importHeld')
+    expect(held.description).toBe('queue.status.importHeldHint')
+  })
+
+  it('falls back to the raw status on a muted chip for an unknown state', () => {
+    const b = downloadStatusBadge('weird', t)
+    expect(b.label).toBe('weird')
+    expect(b.chip).toMatch(/slate|zinc/)
+    expect(b.description).toBeUndefined()
+  })
+})

--- a/web/src/components/downloadStatus.ts
+++ b/web/src/components/downloadStatus.ts
@@ -1,0 +1,136 @@
+// Shared download-state table for the queue, in the same spirit as
+// bookStatus.ts: one place that knows every state the backend can put a
+// download in, so the label, the chip colour and the "which actions apply"
+// predicates cannot drift apart the way four hand-maintained lists in
+// QueuePage did (#2342).
+//
+// The keys MUST stay in sync with the DownloadState constants in
+// internal/models/download_state.go. downloadStatus.test.ts asserts that, so a
+// state added on the Go side fails CI here instead of shipping as a grey chip
+// reading the raw enum (#2339).
+
+import type { TFunction } from 'i18next'
+
+export interface DownloadStatusEntry {
+  /** i18n key for the chip label. */
+  labelKey: string
+  /** Tailwind classes for the chip. */
+  chip: string
+  /**
+   * i18n key for a short explanation shown under the row and as the chip's
+   * title attribute. Only set for states whose name does not explain itself.
+   */
+  descriptionKey?: string
+  /** Counted by the "N failed" bar and cleared by "Clear all failed". */
+  failed?: boolean
+  /**
+   * Accepted by POST /queue/{id}/retry-import. Mirrors the status filter in
+   * DownloadRepo.ResetImportRetry (internal/db/downloads.go), which takes
+   * StateImportFailed and StateImportBlocked. A plain `failed` grab never
+   * produced a file, so there is nothing to re-import (#2336).
+   */
+  retryable?: boolean
+  /**
+   * The download's files are on disk waiting for a book, so the manual
+   * match/retry controls apply.
+   */
+  matchable?: boolean
+}
+
+// Saturated red is reserved for these small chips. Error detail below a row is
+// rendered muted, not as a full red row.
+export const DOWNLOAD_STATUSES: Record<string, DownloadStatusEntry> = {
+  grabbed: {
+    labelKey: 'history.events.grabbed',
+    chip: 'bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300',
+  },
+  downloading: {
+    labelKey: 'queue.status.downloading',
+    chip: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  },
+  completed: {
+    labelKey: 'queue.status.completed',
+    chip: 'bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300',
+  },
+  importPending: {
+    labelKey: 'queue.status.importPending',
+    chip: 'bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-300',
+  },
+  importing: {
+    labelKey: 'queue.status.importing',
+    chip: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  },
+  imported: {
+    labelKey: 'queue.status.imported',
+    chip: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
+  },
+  failed: {
+    labelKey: 'queue.status.failed',
+    chip: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+    failed: true,
+  },
+  importFailed: {
+    labelKey: 'history.events.importFailed',
+    chip: 'bg-orange-100 text-orange-900 dark:bg-orange-950 dark:text-orange-300',
+    failed: true,
+    retryable: true,
+    matchable: true,
+  },
+  importBlocked: {
+    labelKey: 'queue.status.importBlocked',
+    chip: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+    failed: true,
+    retryable: true,
+    matchable: true,
+  },
+  // Non-terminal by design: the file was handed to an external import tool and
+  // Bindery is waiting for it to be placed, so the row lives in the queue until
+  // a manual retry or a library scan reconciles it. Without a label of its own
+  // this rendered as the raw string "importExternal" (#2339).
+  importExternal: {
+    labelKey: 'queue.status.importExternal',
+    chip: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300',
+    descriptionKey: 'queue.status.importExternalHint',
+  },
+  // Also non-terminal: pair gating (#942) parks the first-arriving format of a
+  // media_type=both book until its sibling completes.
+  importHeld: {
+    labelKey: 'queue.status.importHeld',
+    chip: 'bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-300',
+    descriptionKey: 'queue.status.importHeldHint',
+  },
+}
+
+const UNKNOWN_CHIP = 'bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300'
+
+/** States counted by the failed bar. Derived, never hand-listed. */
+export const FAILED_STATUSES: ReadonlySet<string> = new Set(
+  Object.entries(DOWNLOAD_STATUSES).filter(([, e]) => e.failed).map(([k]) => k),
+)
+
+/** States the retry-import endpoint accepts. */
+export const RETRYABLE_STATUSES: ReadonlySet<string> = new Set(
+  Object.entries(DOWNLOAD_STATUSES).filter(([, e]) => e.retryable).map(([k]) => k),
+)
+
+export const isFailed = (status: string): boolean => FAILED_STATUSES.has(status)
+export const isRetryable = (status: string): boolean => RETRYABLE_STATUSES.has(status)
+export const isMatchable = (status: string): boolean => DOWNLOAD_STATUSES[status]?.matchable === true
+
+/**
+ * downloadStatusBadge returns the label, chip classes and optional explanation
+ * for a download's status pill. Pass i18next's `t`. An unrecognised state falls
+ * back to the raw string on a muted chip, same as before.
+ */
+export function downloadStatusBadge(
+  status: string,
+  t: TFunction,
+): { label: string; chip: string; description?: string } {
+  const entry = DOWNLOAD_STATUSES[status]
+  if (!entry) return { label: status, chip: UNKNOWN_CHIP }
+  return {
+    label: t(entry.labelKey, { defaultValue: status }),
+    chip: entry.chip,
+    description: entry.descriptionKey ? t(entry.descriptionKey) : undefined,
+  }
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -452,7 +452,20 @@
     "removeDeleteFiles": "Also delete downloaded files from disk",
     "removeDeleteFilesHint": "Deletes the data in the download client. For torrents this also stops seeding. Leave unchecked to keep the files.",
     "removeConfirm": "Remove",
-    "removeCancel": "Cancel"
+    "removeCancel": "Cancel",
+    "status": {
+      "downloading": "Downloading",
+      "completed": "Completed",
+      "importPending": "Import Pending",
+      "importing": "Importing",
+      "imported": "Imported",
+      "failed": "Failed",
+      "importBlocked": "Import Blocked",
+      "importExternal": "External Import",
+      "importExternalHint": "Handed off to the external import tool. Bindery is waiting for the external importer to place the file, so this row stays here until it does.",
+      "importHeld": "Held for Pair",
+      "importHeldHint": "Held until the paired format arrives. This book wants both an ebook and an audiobook, and both are imported together."
+    }
   },
   "importHints": {
     "heading": "Already have files on disk?",

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -41,6 +41,21 @@ vi.mock('react-i18next', () => ({
         'queue.errorDetails': 'Show full error',
         'queue.clearAllFailed': 'Clear all failed',
         'queue.retryAllFailed': 'Retry all failed',
+        // Download-state chip labels now come from the shared table in
+        // components/downloadStatus.ts (#2342), so the mock has to resolve them.
+        'history.events.grabbed': 'Grabbed',
+        'history.events.importFailed': 'Import Failed',
+        'queue.status.downloading': 'Downloading',
+        'queue.status.completed': 'Completed',
+        'queue.status.importPending': 'Import Pending',
+        'queue.status.importing': 'Importing',
+        'queue.status.imported': 'Imported',
+        'queue.status.failed': 'Failed',
+        'queue.status.importBlocked': 'Import Blocked',
+        'queue.status.importExternal': 'External Import',
+        'queue.status.importExternalHint': 'Handed off to the external import tool.',
+        'queue.status.importHeld': 'Held for Pair',
+        'queue.status.importHeldHint': 'Held until the paired format arrives.',
         'queue.selectAll': 'Select all',
         'queue.removeSelected': 'Remove selected',
         'queue.clearSelection': 'Clear selection',
@@ -596,6 +611,52 @@ describe('QueuePage manual match (#1589)', () => {
     fireEvent.click(await screen.findByText('Retry import'))
     await waitFor(() => expect(api.retryImport).toHaveBeenCalledWith(10))
     expect(api.matchDownload).not.toHaveBeenCalled()
+  })
+
+  it('retries every state the retry endpoint accepts, not just importFailed (#2336)', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([
+      makeQueueItem({ id: 20, title: 'Failed Import', status: 'importFailed' }),
+      makeQueueItem({ id: 21, title: 'Blocked Import', status: 'importBlocked' }),
+      // A plain failed grab produced no file, so there is nothing to re-import.
+      makeQueueItem({ id: 22, title: 'Failed Grab', status: 'failed' }),
+    ])
+
+    renderQueuePage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry all failed' }))
+    await waitFor(() => expect(api.retryImport).toHaveBeenCalledWith(20))
+    expect(api.retryImport).toHaveBeenCalledWith(21)
+    expect(api.retryImport).not.toHaveBeenCalledWith(22)
+    expect(api.retryImport).toHaveBeenCalledTimes(2)
+  })
+
+  it('offers Retry all failed when only blocked imports are queued (#2336)', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([
+      makeQueueItem({ id: 23, title: 'Blocked Import', status: 'importBlocked' }),
+    ])
+
+    renderQueuePage()
+
+    expect(await screen.findByRole('button', { name: 'Retry all failed' })).toBeInTheDocument()
+  })
+
+  it('labels importExternal and importHeld instead of showing the raw enum (#2339)', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([
+      makeQueueItem({ id: 30, title: 'Handed Off', status: 'importExternal' }),
+      makeQueueItem({ id: 31, title: 'Waiting For Sibling', status: 'importHeld' }),
+    ])
+
+    renderQueuePage()
+
+    expect(await screen.findByText('External Import')).toBeInTheDocument()
+    expect(screen.getByText('Held for Pair')).toBeInTheDocument()
+    expect(screen.queryByText('importExternal')).not.toBeInTheDocument()
+    expect(screen.queryByText('importHeld')).not.toBeInTheDocument()
+    // Both states sit in the queue indefinitely by design, so the row says why.
+    expect(screen.getByText('Handed off to the external import tool.')).toBeInTheDocument()
+    expect(screen.getByText('Held until the paired format arrives.')).toBeInTheDocument()
+    // Neither is a failure, so they stay out of the failed bar and its actions.
+    expect(screen.queryByRole('button', { name: 'Clear all failed' })).not.toBeInTheDocument()
   })
 
   it('surfaces an error when the match request fails', async () => {

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -7,6 +7,7 @@ import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 import { summarizeError, ERROR_SUMMARY_LEN } from './queueError'
 import { btn, btnSize } from '../components/buttons'
+import { downloadStatusBadge, isFailed, isMatchable, isRetryable } from '../components/downloadStatus'
 
 export default function QueuePage() {
   const { t } = useTranslation()
@@ -194,41 +195,17 @@ export default function QueuePage() {
   }
 
 
-  const statusLabels: Record<string, string> = {
-    grabbed: 'Grabbed',
-    downloading: 'Downloading',
-    completed: 'Completed',
-    importPending: 'Import Pending',
-    importing: 'Importing',
-    imported: 'Imported',
-    failed: 'Failed',
-    importFailed: 'Import Failed',
-    importBlocked: 'Import Blocked',
-  }
-
-  // Status pill (chip) styles. Saturated red is reserved for these small chips
-  // — error detail below is rendered muted, not as a full red row.
-  const statusChip: Record<string, string> = {
-    grabbed: 'bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300',
-    downloading: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
-    completed: 'bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300',
-    importPending: 'bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-300',
-    importing: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
-    imported: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
-    failed: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
-    importFailed: 'bg-orange-100 text-orange-900 dark:bg-orange-950 dark:text-orange-300',
-    importBlocked: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
-  }
-  const FAILED_STATUSES = new Set(['failed', 'importFailed', 'importBlocked'])
-  const failedItems = queue.filter(q => FAILED_STATUSES.has(q.status))
-  // A download can be manually matched/retried when its files are waiting: an
-  // unmatched import failure, or one blocked after exhausting its retry budget
-  // ("stuck after three attempts", #1589). A plain 'failed' download never got
-  // files, so it isn't matchable.
-  const isMatchable = (status: string) => status === 'importFailed' || status === 'importBlocked'
+  // Labels, chip colours and the failed/retryable/matchable predicates all come
+  // from one table keyed by every state internal/models/download_state.go
+  // defines, so they cannot drift apart (#2342).
+  const failedItems = queue.filter(q => isFailed(q.status))
 
   // Bulk actions over failed/blocked items, done client-side over the existing
-  // per-item endpoints (no new API). Retry only applies to importFailed.
+  // per-item endpoints (no new API). Retry covers every state the retry-import
+  // endpoint accepts, which is importFailed AND importBlocked. The button used
+  // to act on importFailed alone while the count beside it included all three
+  // failed states (#2336). A plain 'failed' grab produced no file, so there is
+  // nothing to re-import and it stays out.
   const [bulkBusy, setBulkBusy] = useState(false)
   const clearAllFailed = async () => {
     if (failedItems.length === 0 || !confirm(t('queue.clearAllConfirm', { count: failedItems.length, defaultValue: 'Remove {{count}} failed item(s) from the queue?' }))) return
@@ -241,7 +218,7 @@ export default function QueuePage() {
     }
   }
   const retryAllFailed = async () => {
-    const retryable = queue.filter(q => q.status === 'importFailed')
+    const retryable = queue.filter(q => isRetryable(q.status))
     if (retryable.length === 0) return
     setBulkBusy(true)
     try {
@@ -336,7 +313,7 @@ export default function QueuePage() {
                     {t('queue.failedCount', { count: failedItems.length, defaultValue: '{{count}} failed' })}
                   </span>
                   <div className="flex gap-2">
-                    {queue.some(q => q.status === 'importFailed') && (
+                    {queue.some(q => isRetryable(q.status)) && (
                       <button
                         onClick={retryAllFailed}
                         disabled={bulkBusy}
@@ -426,9 +403,7 @@ export default function QueuePage() {
                     <h3 className="font-medium text-sm truncate">{item.title}</h3>
                     <BookAuthorLink book={item.book} />
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs">
-                      <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${statusChip[item.status] ?? 'bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300'}`}>
-                        {statusLabels[item.status] ?? item.status}
-                      </span>
+                      <DownloadStatusChip status={item.status} />
                       <span className="text-slate-600 dark:text-zinc-500">{formatSize(item.size)}</span>
                       {item.percentage && (
                         <span className="text-blue-400">{item.percentage}%</span>
@@ -448,6 +423,7 @@ export default function QueuePage() {
                         ) : null
                       })()}
                     </div>
+                    <DownloadStatusHint status={item.status} />
                     {/* Retry import clears error_message, so a re-armed row would
                         otherwise show an "Import Failed" pill with no explanation
                         until the next scanner check writes a new one. */}
@@ -641,6 +617,38 @@ export default function QueuePage() {
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+// DownloadStatusChip renders the status pill from the shared download-state
+// table, so the queue can never show a raw enum for a state the backend knows
+// about (#2339). The tooltip carries the explanation for the two non-terminal
+// hand-off states.
+function DownloadStatusChip({ status }: { status: string }) {
+  const { t } = useTranslation()
+  const badge = downloadStatusBadge(status, t)
+  return (
+    <span
+      title={badge.description}
+      className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${badge.chip}`}
+    >
+      {badge.label}
+    </span>
+  )
+}
+
+// DownloadStatusHint is the secondary line under a row for states whose name
+// does not explain itself: importExternal ("waiting for the external importer")
+// and importHeld ("held until the paired format arrives"). Both sit in the
+// queue indefinitely by design, so the row has to say why.
+function DownloadStatusHint({ status }: { status: string }) {
+  const { t } = useTranslation()
+  const { description } = downloadStatusBadge(status, t)
+  if (!description) return null
+  return (
+    <div className="mt-1 text-xs text-slate-600 dark:text-zinc-400 bg-slate-200/60 dark:bg-zinc-800/60 rounded px-2 py-1">
+      {description}
     </div>
   )
 }


### PR DESCRIPTION
The queue page kept four partial hand maintained copies of the download state enum (`statusLabels`, `statusChip`, `FAILED_STATUSES`, `isMatchable`) plus a fifth inline literal in `retryAllFailed`, and two of them had already fallen behind `internal/models/download_state.go`. This replaces all five with one table in `web/src/components/downloadStatus.ts`, in the shape of the existing `bookStatus.ts`, keyed by every state the Go side defines and carrying an i18n label key, a chip class, an optional explanation and the failed / retryable / matchable flags.

Three user visible fixes fall out of it:

* `importExternal` and `importHeld` get a real label, a chip colour and a line saying why the row is parked, instead of a grey pill reading the raw enum. Both are non terminal by design so those rows can sit in the queue indefinitely.
* **Retry all failed** now retries every state `DownloadRepo.ResetImportRetry` accepts (`importFailed` and `importBlocked`), so a blocked row is no longer skipped by a button whose neighbouring count included it. A plain `failed` grab produced no file, so it correctly stays out.
* The chip labels go through i18n instead of nine hardcoded English strings. `grabbed` and `importFailed` reuse the `history.events.*` keys that already say the same thing in Korean, the one other locale that translates them; the rest are new `queue.status.*` keys added to `en.json` only, so the other locales fall back to English rather than carrying filler.

Part of #2342, which stays open for the drift guard: the coverage test here is a hand copied list, not a real pin against `download_state.go`.
Closes #2339
Closes #2336

## Tests

New `web/src/components/downloadStatus.test.ts` asserts the table covers exactly the state list in `download_state.go` (the Go list is copied in with a comment pointing at the file), that the derived failed and retryable sets match `ResetImportRetry`, and that the two hand off states resolve to a label rather than the raw string.

Three new cases in `QueuePage.test.tsx` are the fails before / passes after ones:

* `retries every state the retry endpoint accepts, not just importFailed (#2336)`
* `offers Retry all failed when only blocked imports are queued (#2336)`
* `labels importExternal and importHeld instead of showing the raw enum (#2339)`

Verified they fail on `origin/main`'s `QueuePage.tsx` (3 failed, 28 passed) and pass with the change.

```
cd web
npm run typecheck   # clean
npm run lint        # 0 errors, 6 pre-existing warnings
npm test            # 68 files, 671 tests, all passing
npm run build       # clean
```

## Sequencing

First of four frontend PRs. Nothing to land before it. Patch release material: #2339 and #2336 are both user visible wrong results on the queue page.

It unblocks the next three, all of which touch `QueuePage.tsx` and say "merge after this one":

1. this PR
2. `formatBytes` consolidation (#2350)
3. `ConfirmDialog` rollout (#2359)
4. `usePolling` hook (#2360)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP

