### PR TITLE
fix(api): stop the series diff collapsing volumes onto one catalog entry (#2343)

### DIFF
--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -975,7 +975,7 @@ func hardcoverCandidateHasBookOverlap(series *models.Series, result seriesHardco
 		if local.Book == nil {
 			continue
 		}
-		if catalog != nil && bestCatalogMatch(local, catalog.Books).score >= 85 {
+		if catalog != nil && bestCatalogMatch(local, catalog.Books, nil).score >= 85 {
 			return true
 		}
 		for _, title := range result.Books {
@@ -1060,7 +1060,7 @@ func scoreHardcoverCandidate(series *models.Series, result seriesHardcoverSearch
 				continue
 			}
 			checked++
-			if bestCatalogMatch(local, catalog.Books).score >= 85 {
+			if bestCatalogMatch(local, catalog.Books, nil).score >= 85 {
 				matches++
 			}
 		}
@@ -1147,12 +1147,21 @@ func buildHardcoverDiff(ctx context.Context, books *db.BookRepo, userID int64, s
 		LocalOnly: []seriesHardcoverDiffBook{},
 		Uncertain: []seriesHardcoverDiffBook{},
 	}
+	// matchedCatalog doubles as the exclusion set for bestCatalogMatch: a
+	// catalog entry a previous local book already claimed is off the table for
+	// every later one (#2343). Without it two locals could resolve to the same
+	// index, which duplicated the row in Present, over-counted PresentCount,
+	// and pushed the second local's real catalog entry into Missing behind an
+	// Add button that ensureHardcoverCatalogBook's guards then refuse. A local
+	// whose best candidate is taken falls through to its next best, and to
+	// LocalOnly when it has none. First local seen wins the tie, matching the
+	// order this loop has always used.
 	matchedCatalog := make(map[int]struct{})
 	for _, local := range series.Books {
 		if local.Book == nil {
 			continue
 		}
-		match := bestCatalogMatch(local, catalog.Books)
+		match := bestCatalogMatch(local, catalog.Books, matchedCatalog)
 		localItem := localDiffBook(local)
 		if match.index < 0 {
 			diff.LocalOnly = append(diff.LocalOnly, localItem)
@@ -1192,18 +1201,41 @@ type catalogMatch struct {
 	foreignID bool
 }
 
-func bestCatalogMatch(local models.SeriesBook, books []metadata.SeriesCatalogBook) catalogMatch {
+// bestCatalogMatch picks the catalog entry a local series book corresponds to.
+// claimed holds the indices earlier local books already took; they are skipped
+// so one catalog entry cannot back two Present rows (#2343). Pass nil when
+// there is nothing to exclude.
+func bestCatalogMatch(local models.SeriesBook, books []metadata.SeriesCatalogBook, claimed map[int]struct{}) catalogMatch {
 	best := catalogMatch{index: -1}
 	if local.Book == nil {
 		return best
 	}
 	for i, candidate := range books {
+		if _, taken := claimed[i]; taken {
+			continue
+		}
+		candidateTitle := firstNonEmpty(candidate.Title, candidate.Book.Title)
 		foreignMatch := local.Book.ForeignID != "" && (local.Book.ForeignID == candidate.ForeignID || local.Book.ForeignID == candidate.Book.ForeignID)
 		score := 0
 		if foreignMatch {
 			score = 100
 		} else {
-			score = seriesmatch.TitleScore(local.Book.Title, firstNonEmpty(candidate.Title, candidate.Book.Title))
+			// Volume numbers veto the similarity score, the same way the add
+			// path at ensureHardcoverCatalogBook does (#1682). TitleScore
+			// cannot separate the volumes of a light novel or manga series:
+			// "… Vol. 1" against "… Vol. 13" scores 100 because PartialRatio
+			// reads "vol 1" as a substring of "vol 13". A local book imported
+			// from ABS or Calibre usually carries no PositionInSeries, so the
+			// SamePosition boost below never fires and nothing else separates
+			// them, which showed the last volume as Present under volume 1's
+			// title and dropped it out of Missing entirely (#2343).
+			//
+			// Only on the title path. A foreign-ID match is an explicit
+			// identity and outranks any title heuristic.
+			if seriesmatch.DifferentVolumes(local.Book.Title, candidateTitle) {
+				continue
+			}
+			score = seriesmatch.TitleScore(local.Book.Title, candidateTitle)
 			if seriesmatch.SamePosition(local.PositionInSeries, candidate.Position) && score >= 70 {
 				score = max(score, 90)
 			}

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -1227,8 +1227,12 @@ func bestCatalogMatch(local models.SeriesBook, books []metadata.SeriesCatalogBoo
 			// reads "vol 1" as a substring of "vol 13". A local book imported
 			// from ABS or Calibre usually carries no PositionInSeries, so the
 			// SamePosition boost below never fires and nothing else separates
-			// them, which showed the last volume as Present under volume 1's
-			// title and dropped it out of Missing entirely (#2343).
+			// them. Because `score > best.score` keeps the first index on a
+			// tie, the collapse runs toward the low volume: owning Vol. 13
+			// showed catalog Vol. 1 as Present carrying Vol. 13's local
+			// title, while Vol. 13 itself stayed in Missing (#2343). Only
+			// numbers that carry an earlier number as a digit prefix collide
+			// this way, 10 through 19 against 1, 21 against 2, and so on.
 			//
 			// Only on the title path. A foreign-ID match is an explicit
 			// identity and outranks any title heuristic.

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -3229,3 +3229,169 @@ func TestEnsureHardcoverLinkFromForeignIDKeepsAManualLink(t *testing.T) {
 		t.Fatalf("manual link was not preserved: %+v", link)
 	}
 }
+
+// datingSimCatalog is a 13-volume light-novel catalog in position order, the
+// shape that exposes #2343: every volume differs from every other by one digit
+// in an otherwise identical string.
+func datingSimCatalog() *metadata.SeriesCatalog {
+	author := &models.Author{
+		ForeignID:        "hc:yomu-mishima",
+		Name:             "Yomu Mishima",
+		SortName:         "Mishima, Yomu",
+		MetadataProvider: "hardcover",
+	}
+	books := make([]metadata.SeriesCatalogBook, 0, 13)
+	for i := 1; i <= 13; i++ {
+		title := fmt.Sprintf("Trapped in a Dating Sim Vol. %d", i)
+		foreignID := fmt.Sprintf("hc:dating-sim-vol-%d", i)
+		books = append(books, metadata.SeriesCatalogBook{
+			ForeignID:  foreignID,
+			ProviderID: strconv.Itoa(700 + i),
+			Title:      title,
+			Position:   strconv.Itoa(i),
+			Book: models.Book{
+				ForeignID:        foreignID,
+				Title:            title,
+				SortTitle:        title,
+				MetadataProvider: "hardcover",
+				Author:           author,
+			},
+		})
+	}
+	return &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:7001",
+		ProviderID: "7001",
+		Title:      "Trapped in a Dating Sim",
+		AuthorName: "Yomu Mishima",
+		BookCount:  len(books),
+		Books:      books,
+	}
+}
+
+// localSeriesBook builds an unlinked local library book for the diff. The
+// foreign id is deliberately a Calibre-style synthetic one so it can never
+// foreign-ID-match a catalog entry, which is the situation the bug needs: an
+// imported book with no provider identity and no PositionInSeries.
+func localSeriesBook(id int64, title string) models.SeriesBook {
+	return models.SeriesBook{
+		BookID: id,
+		Book: &models.Book{
+			ID:        id,
+			ForeignID: fmt.Sprintf("calibre:book:%d", id),
+			Title:     title,
+			SortTitle: title,
+			Status:    models.BookStatusImported,
+		},
+	}
+}
+
+func diffForeignIDs(rows []seriesHardcoverDiffBook) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ForeignBookID)
+	}
+	return ids
+}
+
+// TestBuildHardcoverDiffKeepsVolumesApart is the #2343 regression guard for the
+// missing DifferentVolumes veto. Local "Vol. 13" scores a perfect 100 against
+// catalog "Vol. 1" because PartialRatio reads "vol 1" as a substring of
+// "vol 13", and index 0 wins the tie, so before the fix the diff reported
+// volume 1 as Present under volume 13's local title and left volume 13 in
+// Missing with an Add button that would refuse to add it.
+func TestBuildHardcoverDiffKeepsVolumesApart(t *testing.T) {
+	catalog := datingSimCatalog()
+	series := &models.Series{
+		ID:    1,
+		Title: "Trapped in a Dating Sim",
+		Books: []models.SeriesBook{localSeriesBook(1, "Trapped in a Dating Sim Vol. 13")},
+	}
+	link := &models.SeriesHardcoverLink{SeriesID: series.ID, HardcoverSeriesID: catalog.ForeignID}
+
+	diff := buildHardcoverDiff(context.Background(), nil, 0, series, link, catalog)
+
+	if len(diff.Present) != 1 {
+		t.Fatalf("Present = %v, want exactly one row", diffForeignIDs(diff.Present))
+	}
+	if diff.Present[0].ForeignBookID != "hc:dating-sim-vol-13" {
+		t.Fatalf("Present row = %q, want hc:dating-sim-vol-13", diff.Present[0].ForeignBookID)
+	}
+	if diff.Present[0].LocalBookID == nil || *diff.Present[0].LocalBookID != 1 {
+		t.Fatalf("Present row LocalBookID = %v, want 1", diff.Present[0].LocalBookID)
+	}
+	if len(diff.LocalOnly) != 0 {
+		t.Fatalf("LocalOnly = %+v, want empty", diff.LocalOnly)
+	}
+
+	missing := map[string]bool{}
+	for _, row := range diff.Missing {
+		missing[row.ForeignBookID] = true
+	}
+	if missing["hc:dating-sim-vol-13"] {
+		t.Fatalf("volume 13 is in the library but was reported Missing: %v", diffForeignIDs(diff.Missing))
+	}
+	for i := 1; i <= 12; i++ {
+		id := fmt.Sprintf("hc:dating-sim-vol-%d", i)
+		if !missing[id] {
+			t.Fatalf("volume %d is not in the library but is not Missing: %v", i, diffForeignIDs(diff.Missing))
+		}
+	}
+	if diff.MissingCount != 12 || diff.PresentCount != 1 {
+		t.Fatalf("counts = present %d / missing %d, want 1 / 12", diff.PresentCount, diff.MissingCount)
+	}
+}
+
+// TestBuildHardcoverDiffDoesNotDoubleClaimOneCatalogEntry is the #2343
+// regression guard for the missing exclusion set. Neither title carries a
+// volume marker, so DifferentVolumes cannot help here: both locals score 100
+// against catalog index 0 (PartialRatio again), and before the fix both
+// claimed it, which duplicated that row in Present, over-counted PresentCount
+// and pushed the second local's real catalog entry into Missing.
+func TestBuildHardcoverDiffDoesNotDoubleClaimOneCatalogEntry(t *testing.T) {
+	catalog := stormlightCatalog()
+	catalog.Books = append(catalog.Books, metadata.SeriesCatalogBook{
+		ForeignID:  "hc:the-way-of-kings-prime",
+		ProviderID: "104",
+		Title:      "The Way of Kings Prime",
+		Position:   "2",
+		Book: models.Book{
+			ForeignID: "hc:the-way-of-kings-prime",
+			Title:     "The Way of Kings Prime",
+			Author:    catalog.Books[0].Book.Author,
+		},
+	})
+	catalog.BookCount = len(catalog.Books)
+
+	series := &models.Series{
+		ID:    1,
+		Title: "The Stormlight Archive",
+		Books: []models.SeriesBook{
+			localSeriesBook(1, "The Way of Kings"),
+			localSeriesBook(2, "The Way of Kings Prime"),
+		},
+	}
+	link := &models.SeriesHardcoverLink{SeriesID: series.ID, HardcoverSeriesID: catalog.ForeignID}
+
+	diff := buildHardcoverDiff(context.Background(), nil, 0, series, link, catalog)
+
+	seen := map[string]int{}
+	for _, row := range diff.Present {
+		seen[row.ForeignBookID]++
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Fatalf("catalog entry %q appears %d times in Present: %v", id, n, diffForeignIDs(diff.Present))
+		}
+	}
+	if len(diff.Present) != 2 || diff.PresentCount != 2 {
+		t.Fatalf("Present = %v (count %d), want both catalog entries once", diffForeignIDs(diff.Present), diff.PresentCount)
+	}
+	for _, row := range diff.Missing {
+		if row.ForeignBookID == "hc:the-way-of-kings-prime" {
+			t.Fatalf("the second local book's own catalog entry was reported Missing: %v", diffForeignIDs(diff.Missing))
+		}
+	}
+	if len(diff.Missing) != 0 {
+		t.Fatalf("Missing = %v, want empty", diffForeignIDs(diff.Missing))
+	}
+}


### PR DESCRIPTION
`bestCatalogMatch` picked the catalog entry for a local series book purely by `seriesmatch.TitleScore`, which cannot separate the volumes of a light novel or manga series. Local "X Vol. 13" scores 100 against catalog "X Vol. 1" because PartialRatio reads "vol 1" as a substring of "vol 13", and a book imported from ABS or Calibre usually has no `PositionInSeries` so the `SamePosition` boost never fires. Index 0 wins the tie, so the diff showed volume 1 as Present under volume 13's local title and left volume 13 in Missing behind an Add button the add-path guards then refuse.

This adds the `DifferentVolumes` veto that `ensureHardcoverCatalogBook` has carried since #1682, on the title path only so an explicit foreign-ID match still wins. The second half is the exclusion set: `bestCatalogMatch` ran over the whole catalog per local book with nothing stopping two locals resolving to one index, so `matchedCatalog` (already the exclusion set for the Missing pass) is now passed in and a local whose best candidate is taken falls through to its next best.

The two overlap-scoring callers at `series.go:978` and `:1063` pass nil. They ask whether the library overlaps a candidate series at all rather than claiming entries, so there is nothing to exclude. They do pick up the volume veto, which makes that overlap signal a little stricter: a local Vol. 1 no longer counts as overlap against a catalog that only has Vol. 13.

Closes #2343

### Tests

Two new cases in `internal/api/series_test.go`, both failing on `main` and passing here:

* `TestBuildHardcoverDiffKeepsVolumesApart` (the veto) fails before with `Present row = "hc:dating-sim-vol-1", want hc:dating-sim-vol-13`
* `TestBuildHardcoverDiffDoesNotDoubleClaimOneCatalogEntry` (the exclusion set) fails before with `catalog entry "hc:the-way-of-kings" appears 2 times in Present`. Neither title in that one carries a volume marker, so it isolates the exclusion set from the veto.

Ran: `go build ./...`, `go vet ./internal/api/...`, `go test ./internal/api/...` (ok, 158s), `golangci-lint run ./internal/api/...` (0 issues).

### Sequencing

Patch release material. User-visible wrong result on the series page with no workaround from the UI. Lands independently of everything else in flight; #2347 is the same class of bug in the ABS import path and touches a different file, so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
