### PR TITLE
fix(migrate): validate imported indexer and client URLs against SSRF (#2349)

### DIFF
--- a/docs/Migrating-From-Readarr-Wiki.md
+++ b/docs/Migrating-From-Readarr-Wiki.md
@@ -13,6 +13,8 @@ Each imported author's catalogue is populated from metadata. Nothing is auto-gra
 
 The import dedupes by metadata id, so re-running it is safe: authors that already exist are skipped.
 
+An indexer or download client whose address Bindery will not call (link-local and cloud-metadata addresses) is reported as failed rather than imported, with the same message you would get typing it into the Add form.
+
 ## Two Readarr instances (separate ebook / audiobook)
 
 Bindery is a single instance. One author record covers ebook, audiobook, or both, set per author or per book.

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -48,17 +48,11 @@ func applyHostToClient(w http.ResponseWriter, c *models.DownloadClient) bool {
 }
 
 // downloadClientURL assembles the effective URL that would be hit for a
-// download client, so httpsec.ValidateOutboundURL can check it.
+// download client, so httpsec.ValidateOutboundURL can check it. The assembly
+// lives in clienthost so the Readarr migration can run the same check on the
+// rows it creates without a second copy of the rules (#2349).
 func downloadClientURL(c *models.DownloadClient) string {
-	scheme := "http"
-	if c.UseSSL {
-		scheme = "https"
-	}
-	port := c.Port
-	if port == 0 {
-		port = 8080
-	}
-	return fmt.Sprintf("%s://%s/", scheme, clienthost.Authority(c.Host, port))
+	return clienthost.URL(c.Host, c.Port, c.UseSSL)
 }
 
 type DownloadClientHandler struct {

--- a/internal/downloader/clienthost/clienthost.go
+++ b/internal/downloader/clienthost/clienthost.go
@@ -100,6 +100,25 @@ func Authority(host string, port int) string {
 	return net.JoinHostPort(Unbracket(strings.TrimSpace(host)), strconv.Itoa(port))
 }
 
+// URL renders the base URL a download client would be reached on from the
+// three fields the connection is stored as, so a caller holding a Host, a Port
+// and a Use SSL flag can hand a single string to httpsec.ValidateOutboundURL.
+//
+// A zero port falls back to 8080. Nothing here builds a request that is
+// actually sent, and the SSRF check reads only the scheme and the host, so the
+// fallback exists to keep the string parseable rather than to guess a real
+// port.
+func URL(host string, port int, ssl bool) string {
+	scheme := "http"
+	if ssl {
+		scheme = "https"
+	}
+	if port == 0 {
+		port = 8080
+	}
+	return fmt.Sprintf("%s://%s/", scheme, Authority(host, port))
+}
+
 // Unbracket strips the brackets from an IPv6 literal, leaving every other
 // host untouched.
 func Unbracket(host string) string {

--- a/internal/migrate/outbound.go
+++ b/internal/migrate/outbound.go
@@ -1,0 +1,25 @@
+package migrate
+
+import (
+	"github.com/vavallee/bindery/internal/httpsec"
+)
+
+// validateMigratedURL is the SSRF guard a migration runs over every outbound
+// URL it is about to store. It is the same check, under the same policy, that
+// the API create and update handlers apply to the identical fields
+// (internal/api/indexers.go, internal/api/download_clients.go): a LAN or
+// loopback indexer is an ordinary self-hosted setup, while link-local and
+// cloud-metadata destinations never are.
+//
+// Until #2349 the migration was the one door into the indexer and download
+// client tables that skipped this, and its input is an uploaded database file
+// rather than a form an operator filled in field by field.
+//
+// It is a package var only so tests can substitute a check that does not need
+// DNS. ValidateOutboundURL resolves the hostname and fails closed when the
+// lookup fails, so fixture hosts like "sab.local" would otherwise make the
+// migration tests depend on a working resolver. Never reassign it from
+// production code.
+var validateMigratedURL = func(raw string) error {
+	return httpsec.ValidateOutboundURL(raw, httpsec.PolicyLANLoopback)
+}

--- a/internal/migrate/readarr.go
+++ b/internal/migrate/readarr.go
@@ -238,6 +238,14 @@ func importReadarrIndexers(ctx context.Context, src *sql.DB, repo *db.IndexerRep
 			Categories: cats,
 			Enabled:    enableRss,
 		}
+		// Same SSRF check the Add Indexer form runs (#2349). A Readarr
+		// database is a file, not a form, so a row pointing at
+		// 169.254.169.254 would otherwise be created and then polled with
+		// whatever API key came with it.
+		if err := validateMigratedURL(idx.URL); err != nil {
+			res.fail(name, err.Error())
+			continue
+		}
 		if err := repo.Create(ctx, idx); err != nil {
 			res.fail(name, err.Error())
 			continue
@@ -300,6 +308,13 @@ func importReadarrDownloadClients(ctx context.Context, src *sql.DB, repo *db.Dow
 			Category: cat,
 			UseSSL:   s.UseSsl,
 			Enabled:  enable,
+		}
+		// Same SSRF check the Add Download Client form runs (#2349). The RPC
+		// clients have no dial-time guard of their own, so an unvalidated host
+		// here is polled with its credentials attached.
+		if err := validateMigratedURL(clienthost.URL(c.Host, c.Port, c.UseSSL)); err != nil {
+			res.fail(name, err.Error())
+			continue
 		}
 		if err := repo.Create(ctx, c); err != nil {
 			res.fail(name, err.Error())

--- a/internal/migrate/readarr_test.go
+++ b/internal/migrate/readarr_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
+	neturl "net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -14,6 +16,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -70,6 +73,30 @@ func newReadarrDB(t *testing.T) string {
 	return path
 }
 
+// stubMigratedURLValidator swaps validateMigratedURL for one that applies the
+// real httpsec policy to a resolved address without touching DNS. The fixture
+// databases use hosts like "sab.local" and "news.example.com", which no
+// resolver answers for, and validateMigratedURL fails closed on a lookup
+// failure — so without this the fixtures would exercise the error path for the
+// wrong reason. IP literals are still checked for real; every other host is
+// treated as if it resolved to a public address.
+func stubMigratedURLValidator(t *testing.T) {
+	t.Helper()
+	prev := validateMigratedURL
+	t.Cleanup(func() { validateMigratedURL = prev })
+	validateMigratedURL = func(raw string) error {
+		u, err := neturl.Parse(raw)
+		if err != nil {
+			return err
+		}
+		ip := net.ParseIP(u.Hostname())
+		if ip == nil {
+			ip = net.ParseIP("93.184.216.34")
+		}
+		return httpsec.ValidateIP(ip, httpsec.PolicyLANLoopback)
+	}
+}
+
 func TestImportReadarr_EmptyDBPath(t *testing.T) {
 	_, err := ImportReadarr(context.Background(), "", nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
@@ -87,6 +114,7 @@ func TestImportReadarr_BadPath(t *testing.T) {
 }
 
 func TestImportReadarr_HappyPath(t *testing.T) {
+	stubMigratedURLValidator(t)
 	path := newReadarrDB(t)
 
 	// Seed Readarr-shaped rows.
@@ -496,6 +524,7 @@ func TestImportReadarr_CatalogueFetchIsBoundedAndSurvivesCancellation(t *testing
 // under a Bindery banner. Failing the row names the client and the problem
 // while the operator is still looking at the migration report.
 func TestImportReadarrDownloadClients_MalformedHost(t *testing.T) {
+	stubMigratedURLValidator(t)
 	path := filepath.Join(t.TempDir(), "readarr.db")
 	src, err := sql.Open("sqlite", "file:"+path)
 	if err != nil {
@@ -536,4 +565,101 @@ func TestImportReadarrDownloadClients_MalformedHost(t *testing.T) {
 	if len(clients) != 1 || clients[0].Name != "Good" {
 		t.Fatalf("imported clients = %+v, want only Good", clients)
 	}
+}
+
+// TestImportReadarr_RejectsSSRFTargets covers #2349. A Readarr database is an
+// uploaded file, so its indexer and download client rows have never been past
+// the validation the Add forms run. A row pointing at the cloud-metadata
+// address must be reported failed and must not reach the database, or it gets
+// polled on a schedule with the credentials that came with it.
+//
+// This test deliberately does NOT stub validateMigratedURL: the hosts are IP
+// literals, which ValidateOutboundURL checks without touching DNS.
+func TestImportReadarr_RejectsSSRFTargets(t *testing.T) {
+	path := newReadarrDB(t)
+	src, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = src.Exec(`INSERT INTO Indexers (Name, Implementation, Settings, EnableRss) VALUES
+		('GoodIdx', 'Newznab', ?, 1),
+		('MetaIdx', 'Newznab', ?, 1)`,
+		`{"baseUrl":"http://93.184.216.34:9117/","apiKey":"abc"}`,
+		`{"baseUrl":"http://169.254.169.254/","apiKey":"abc"}`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = src.Exec(`INSERT INTO DownloadClients (Name, Implementation, Settings, Enable) VALUES
+		('GoodQBT', 'QBittorrent', ?, 1),
+		('MetaQBT', 'QBittorrent', ?, 1)`,
+		`{"host":"93.184.216.34","port":8080,"username":"u","password":"p"}`,
+		`{"host":"169.254.169.254","port":80,"username":"u","password":"p"}`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src.Close()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	indexerRepo := db.NewIndexerRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	ctx := context.Background()
+
+	var idxRes Result
+	if err := importReadarrIndexers(ctx, mustOpenReadarr(t, path), indexerRepo, &idxRes); err != nil {
+		t.Fatalf("importReadarrIndexers: %v", err)
+	}
+	if idxRes.Added != 1 || idxRes.Errors != 1 {
+		t.Fatalf("indexers Added=%d Errors=%d, want 1 and 1 (%v)", idxRes.Added, idxRes.Errors, idxRes.Failures)
+	}
+	idxList, err := indexerRepo.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(idxList) != 1 || idxList[0].Name != "GoodIdx" {
+		t.Fatalf("imported indexers = %+v, want only GoodIdx", idxList)
+	}
+
+	var clientRes Result
+	if err := importReadarrDownloadClients(ctx, mustOpenReadarr(t, path), clientRepo, &clientRes); err != nil {
+		t.Fatalf("importReadarrDownloadClients: %v", err)
+	}
+	if clientRes.Added != 1 || clientRes.Errors != 1 {
+		t.Fatalf("clients Added=%d Errors=%d, want 1 and 1 (%v)", clientRes.Added, clientRes.Errors, clientRes.Failures)
+	}
+	clients, err := clientRepo.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(clients) != 1 || clients[0].Name != "GoodQBT" {
+		t.Fatalf("imported clients = %+v, want only GoodQBT", clients)
+	}
+
+	// The report has to name the row and say why, or the operator cannot tell
+	// a refused row from one that was never in the Readarr database.
+	if !strings.Contains(clientRes.Failures["MetaQBT"], "url not allowed") {
+		t.Errorf("MetaQBT failure = %q, want the SSRF refusal", clientRes.Failures["MetaQBT"])
+	}
+	if !strings.Contains(idxRes.Failures["MetaIdx"], "url not allowed") {
+		t.Errorf("MetaIdx failure = %q, want the SSRF refusal", idxRes.Failures["MetaIdx"])
+	}
+}
+
+// mustOpenReadarr reopens the fixture database. importReadarrIndexers and
+// importReadarrDownloadClients each take their own *sql.DB in the production
+// path, so the test hands each one a fresh handle rather than sharing a single
+// connection across two open cursors.
+func mustOpenReadarr(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	src, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	t.Cleanup(func() { src.Close() })
+	return src
 }


### PR DESCRIPTION
The Readarr DB import created indexer and download client rows straight out of the uploaded file with no SSRF check, which made it the only door into those two tables that skipped what every API create and update path runs. A row pointing at `169.254.169.254` was created and then polled on a schedule with whatever API key or password came with it, and the RPC clients have no dial time guard of their own.

Both loops now validate under `PolicyLANLoopback`, the same policy `internal/api/indexers.go` and `internal/api/download_clients.go` apply to the identical fields, and take the existing `res.fail(name, ...)` path so the migration report names the row and says why.

Two supporting changes:

* `downloadClientURL` moves out of `internal/api` into `clienthost.URL(host, port, ssl)`, so the migration checks the same string the handler does instead of a second copy of the assembly rules.
* `validateMigratedURL` in `internal/migrate/outbound.go` is a package var. `ValidateOutboundURL` resolves the hostname and fails closed on a lookup failure, and the existing fixtures use hosts like `sab.local` that no resolver answers for, so the two tests carrying those fixtures substitute a check that applies the real policy to a stubbed address. The new test does not stub anything: its hosts are IP literals, which the real validator handles without DNS.

Closes #2349

### Testing

* `go test -count=1 ./internal/migrate/` passes. `TestImportReadarr_RejectsSSRFTargets` is the new case: with the fix reverted it fails with `indexers Added=2 Errors=0, want 1 and 1`, and passes with it.
* `go test ./internal/api/... ./internal/downloader/clienthost/...` green, which covers the existing `downloadClientURL` table test through the new delegate.
* `go vet` and `golangci-lint run` clean on all three changed packages.

### Sequencing

Independent of the rest of the security sweep. Nothing blocks it and it blocks nothing. Next minor rather than a patch: reaching it needs an admin uploading a hostile Readarr database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
