### PR TITLE
refactor(textutil): delegate the five surviving SortName copies (#2363)

### DIFF
--- a/internal/calibre/importer.go
+++ b/internal/calibre/importer.go
@@ -1036,16 +1036,10 @@ func firstNonEmpty(a ...string) string {
 }
 
 // sortNameFromFull converts "First Last" → "Last, First" as a last-resort
-// sort key when Calibre doesn't supply one. Matches the helper used
-// elsewhere in the API layer (api.sortName).
+// sort key when Calibre doesn't supply one. Delegates to textutil.SortName so
+// this file cannot drift from every other sort-name producer (#2363).
 func sortNameFromFull(name string) string {
-	fields := strings.Fields(name)
-	if len(fields) < 2 {
-		return name
-	}
-	last := fields[len(fields)-1]
-	rest := strings.Join(fields[:len(fields)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }
 
 func ptrStringIfNonEmpty(s string) *string {

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -806,14 +806,10 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book, nameIn
 	return author.ID, nil
 }
 
+// sortName delegates to textutil.SortName so list-sync authors sort the same
+// way as authors created by every other path (#2363).
 func sortName(name string) string {
-	parts := strings.Fields(name)
-	if len(parts) < 2 {
-		return name
-	}
-	last := parts[len(parts)-1]
-	rest := strings.Join(parts[:len(parts)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }
 
 // HCListSyncer is satisfied by *ListSyncer — the scheduler uses this

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // downloadArtifactExts are download-client receipt and repair files that ride
@@ -1641,14 +1642,14 @@ func sanitizePath(s string) string {
 	return strings.Join(kept, string(filepath.Separator))
 }
 
+// authorSortName backs the {SortAuthor} naming token, so its output becomes a
+// folder name on disk. It delegates to textutil.SortName: a private copy here
+// would mean the library layout and the author pages disagree the first time
+// that helper learns about particles ("van", "de", "von"). Any change to the
+// shared helper is a rename of every already-imported author folder, so it is
+// a decision that has to be made in one place (#2363).
 func authorSortName(name string) string {
-	parts := strings.Fields(name)
-	if len(parts) < 2 {
-		return name
-	}
-	last := parts[len(parts)-1]
-	rest := strings.Join(parts[:len(parts)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }
 
 // DefaultNamingTemplate returns the default naming template for reference.

--- a/internal/importer/renamer_test.go
+++ b/internal/importer/renamer_test.go
@@ -292,3 +292,41 @@ func TestUniqueDir(t *testing.T) {
 		t.Errorf("second collision: got %q want %q", got, want)
 	}
 }
+
+// TestRenamerSortAuthorFolderUnchanged pins the on-disk shape of the
+// {SortAuthor} naming token. authorSortName now delegates to
+// textutil.SortName (#2363); this asserts that delegation did not move a
+// single byte of an existing library's folder names.
+//
+// "Ursula K. Le Guin" is the interesting case: the naive last-token flip
+// produces "Guin, Ursula K. Le", which is wrong as a sort name and right as
+// a regression pin. Every library imported before #2363 has that folder on
+// disk, so a future particle-aware SortName has to be treated as a rename
+// migration rather than a display fix, and this test is what fails first.
+func TestRenamerSortAuthorFolderUnchanged(t *testing.T) {
+	r := NewRenamer("{SortAuthor}/{Title}.{ext}")
+
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"Ursula K. Le Guin", "Guin, Ursula K. Le"},
+		{"Brandon Sanderson", "Sanderson, Brandon"},
+		{"Homer", "Homer"},
+		{"Vincent van Gogh", "Gogh, Vincent van"},
+	}
+
+	for _, tc := range cases {
+		author := &models.Author{Name: tc.name}
+		book := &models.Book{Title: "A Book"}
+
+		got, err := r.DestPath("/lib", author, book, "", "", "in.epub")
+		if err != nil {
+			t.Fatalf("DestPath(%q): %v", tc.name, err)
+		}
+		want := filepath.Join("/lib", tc.want, "A Book.epub")
+		if got != want {
+			t.Errorf("author %q:\n got  %q\n want %q", tc.name, got, want)
+		}
+	}
+}

--- a/internal/metadata/googlebooks/client.go
+++ b/internal/metadata/googlebooks/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
 	"github.com/vavallee/bindery/internal/useragent"
 )
 
@@ -169,12 +170,9 @@ func (c *Client) getJSON(ctx context.Context, rawURL string, target interface{})
 	return json.NewDecoder(resp.Body).Decode(target)
 }
 
+// sortName delegates to textutil.SortName, the same way the openlibrary and
+// hardcover clients do, so all three providers stamp the same sort form on an
+// author (#2363).
 func sortName(name string) string {
-	parts := strings.Fields(name)
-	if len(parts) < 2 {
-		return name
-	}
-	last := parts[len(parts)-1]
-	rest := strings.Join(parts[:len(parts)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }

--- a/internal/migrate/goodreads.go
+++ b/internal/migrate/goodreads.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // goodreadsResolvePacing is the minimum gap between provider lookups during a
@@ -368,14 +369,10 @@ func ensureGoodreadsAuthor(ctx context.Context, authors *db.AuthorRepo, settings
 
 // goodreadsSortName derives a "Last, First" sort name from a display name.
 // A single-word name (mononym or organisation) is returned unchanged.
+// Delegates to textutil.SortName so an imported author sorts identically to
+// one added any other way (#2363).
 func goodreadsSortName(name string) string {
-	parts := strings.Fields(name)
-	if len(parts) < 2 {
-		return name
-	}
-	last := parts[len(parts)-1]
-	rest := strings.Join(parts[:len(parts)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }
 
 // summarisePreview fills the counts on a GoodreadsPreview from its rows.

--- a/internal/textutil/authorquery.go
+++ b/internal/textutil/authorquery.go
@@ -12,8 +12,13 @@ import (
 // both packages delegate.
 
 // SortName converts a display name to "Last, First Middle" sort form, leaving
-// single-token names untouched. It was copied into internal/api,
-// internal/abs, openlibrary and hardcover; all four were identical.
+// single-token names untouched. Nine packages delegate here rather than keep a
+// copy: internal/api, internal/abs, openlibrary and hardcover from the first
+// consolidation, then internal/calibre, internal/hardcoverlistsyncer,
+// internal/importer, internal/migrate and googlebooks (#2363). Keep it that
+// way. importer/renamer.go's authorSortName feeds the {SortAuthor} naming
+// token, so a change here renames folders on disk, and a divergent copy means
+// the library layout and the UI disagree about the same author.
 //
 // Deliberately naive: it flips on the last whitespace-separated token and does
 // no particle handling ("van", "de", "von") or script awareness. That is fine


### PR DESCRIPTION
Replaces the five surviving verbatim copies of `textutil.SortName` (calibre, hardcoverlistsyncer, importer/renamer, migrate/goodreads, googlebooks) with a one line delegate, the same way internal/api, internal/abs, openlibrary and hardcover already do.

I diffed all five bodies against the canonical one before touching anything: byte identical, so this changes no behaviour anywhere. The one worth caring about is `importer/renamer.go`'s `authorSortName`, which backs the `{SortAuthor}` naming token and so produces **folder names on disk**. A private copy there means the day `SortName` learns about particles ("van", "de", "von") to fix a display bug, the library layout silently stops matching the author pages.

Local function names and call sites are unchanged, so the existing `sortName` tests in `hardcoverlistsyncer` and `googlebooks` keep exercising the same entry points. The `textutil.SortName` doc comment listed four delegates and now names all nine, plus why the renamer one turns any future change into a rename migration.

Closes #2363

## Testing

New pin: `TestRenamerSortAuthorFolderUnchanged` in `internal/importer/renamer_test.go`. It asserts the full `DestPath` output for `{SortAuthor}`, including `Ursula K. Le Guin` giving `Guin, Ursula K. Le`. That is the wrong sort name and the right regression pin: it is what every library imported before this PR has on disk, so a future particle aware `SortName` has to fail here first and be handled as a rename migration rather than a display fix.

This is a refactor, so there is no fail before test. The pin is the point.

```
go build ./...                                   ok
go vet ./internal/{calibre,hardcoverlistsyncer,importer,migrate,metadata/googlebooks,textutil}/...   ok
go test ./internal/{calibre,hardcoverlistsyncer,importer,migrate,metadata/googlebooks,textutil}/...  all ok
golangci-lint run (same packages)                0 issues
```

## Sequencing

Next minor. No user visible change, this is drift prevention.

Independent of everything else in this sweep, nothing depends on it, merge whenever. It is the smallest of the three refactor PRs from this batch (#2364 and #2366 are the others) so it is the cheapest one to take first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
