### PR TITLE
fix(scheduler): filter in-flight downloads per format in the wanted sweep (#2365)

### DIFF
--- a/internal/models/download_state.go
+++ b/internal/models/download_state.go
@@ -22,9 +22,10 @@ const (
 	// tool (import.mode=external). It is deliberately NON-terminal: the file
 	// has not yet been reconciled into the library, so the download is not
 	// "imported". The book stays Wanted so ScanLibrary can reconcile the file
-	// once the external tool places it; searchWanted skips books that have a
-	// download in this state so the release is not re-grabbed forever while the
-	// hand-off is outstanding (issue #706 finding 3).
+	// once the external tool places it; searchWanted skips the FORMAT this
+	// download is working toward so the release is not re-grabbed forever while
+	// the hand-off is outstanding (issue #706 finding 3). The book's other
+	// format, if it wants one, is still searched (#2365).
 	StateImportExternal DownloadState = "importExternal"
 	// StateImportHeld marks a completed drop-folder download whose format is
 	// being held back under pair gating (#942): a media_type=both book only
@@ -34,8 +35,10 @@ const (
 	// import_path — until the sibling completes and releases both together, or
 	// the pair-gating timeout drops it alone. Like StateImportExternal it is
 	// deliberately NON-terminal and is NOT swept by RecoverInterruptedImports;
-	// searchWanted skips books with a download in this state so the release is
-	// not re-grabbed while the hold is outstanding.
+	// searchWanted skips the held FORMAT so the release is not re-grabbed while
+	// the hold is outstanding. It must not skip the whole book: the sibling the
+	// hold is waiting for can only arrive via a search, so blocking both
+	// formats made the gate wait for something it had just prevented (#2365).
 	StateImportHeld DownloadState = "importHeld"
 )
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -593,6 +593,30 @@ func (s *Scheduler) Stop() {
 // It is the same logic the 12-hour wanted-scan uses, promoted so on-add and
 // status-transition hooks can trigger a search without waiting for the next run.
 func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
+	s.searchAndGrabFormats(ctx, book, neededFormats(&book))
+}
+
+// neededFormats returns the media types a book still wants and does not have
+// on disk, ebook first. It is the whole-book answer; the wanted sweep narrows
+// it further by removing formats that already have a grab in flight (#2365).
+func neededFormats(book *models.Book) []string {
+	formats := make([]string, 0, 2)
+	if book.NeedsEbook() {
+		formats = append(formats, models.MediaTypeEbook)
+	}
+	if book.NeedsAudiobook() {
+		formats = append(formats, models.MediaTypeAudiobook)
+	}
+	return formats
+}
+
+// searchAndGrabFormats runs the search for an explicit list of media types.
+// SearchAndGrabBook passes everything the book needs; the wanted sweep passes
+// only the formats that are not already being downloaded.
+func (s *Scheduler) searchAndGrabFormats(ctx context.Context, book models.Book, formats []string) {
+	if len(formats) == 0 {
+		return
+	}
 	// The global auto-grab kill switch is enforced here, at the single point
 	// where a grab is actually dispatched, rather than at each caller (#2256).
 	// Every caller reaches a download through this function, so a new dispatch
@@ -603,11 +627,8 @@ func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
 			"book_id", book.ID, "title", book.Title)
 		return
 	}
-	if book.NeedsEbook() {
-		s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
-	}
-	if book.NeedsAudiobook() {
-		s.searchAndGrabFormat(ctx, book, models.MediaTypeAudiobook)
+	for _, mediaType := range formats {
+		s.searchAndGrabFormat(ctx, book, mediaType)
 	}
 }
 
@@ -1087,19 +1108,35 @@ func (s *Scheduler) searchWanted() {
 	if len(searchQueue) == 0 {
 		return
 	}
-	concurrency.RunBoundedPaced(ctx, searchQueue, scheduledWantedSearchConcurrency, searchPaceInterval, func(ctx context.Context, book models.Book) {
-		s.SearchAndGrabBook(ctx, book)
+	concurrency.RunBoundedPaced(ctx, searchQueue, scheduledWantedSearchConcurrency, searchPaceInterval, func(ctx context.Context, w wantedSearch) {
+		s.searchAndGrabFormats(ctx, w.book, w.formats)
 	})
 }
 
+// wantedSearch is one unit of work for the sweep: a Wanted book plus the media
+// types that still need searching for it. The formats are the book's needed
+// formats minus those that already have a download in flight, so a dual-format
+// book whose ebook is parked still gets its audiobook searched (#2365).
+type wantedSearch struct {
+	book    models.Book
+	formats []string
+}
+
 // inFlightDownloadStates are the states in which a download is actively working
-// toward a completed import. A Wanted book with a download in any of these must
-// not be re-searched: nothing flips the book off Wanted when it's grabbed (that
-// happens only once the file is imported and reconciled), so a re-search would
-// grab a *second* release for the same book, and even a same-GUID hit burns
-// indexer calls. Dead states (failed / import-failed / import-blocked) are
-// intentionally excluded from this list — those are the recovery path where
-// re-searching for a different release is correct.
+// toward a completed import. A Wanted book's FORMAT with a download in any of
+// these must not be re-searched: nothing flips the book off Wanted when it's
+// grabbed (that happens only once the file is imported and reconciled), so a
+// re-search would grab a *second* release for the same format, and even a
+// same-GUID hit burns indexer calls. Dead states (failed / import-failed /
+// import-blocked) are intentionally excluded from this list — those are the
+// recovery path where re-searching for a different release is correct.
+//
+// The filter is per (book, format), not per book: StateImportExternal and
+// StateImportHeld have no automatic exit, so treating them as a whole-book
+// block left a media_type='both' book with one format parked and the other
+// never searched — which under pair gating is a deadlock, because the sibling
+// the hold is waiting for can only arrive via the search the hold disabled
+// (#2365).
 var inFlightDownloadStates = []models.DownloadState{
 	models.StateGrabbed,
 	models.StateDownloading,
@@ -1110,10 +1147,11 @@ var inFlightDownloadStates = []models.DownloadState{
 	models.StateImportHeld,     // drop-folder format held awaiting its pair (#942)
 }
 
-// wantedSearchQueue returns the Wanted books eligible for an auto-grab this
-// sweep, excluding user-excluded books and any book with a grab already in
-// flight (see inFlightDownloadStates).
-func (s *Scheduler) wantedSearchQueue(ctx context.Context) []models.Book {
+// wantedSearchQueue returns this sweep's work: the Wanted books eligible for an
+// auto-grab, each paired with the formats that still need searching. It
+// excludes user-excluded books, formats that already have a grab in flight
+// (see inFlightDownloadStates), and books left with nothing to search.
+func (s *Scheduler) wantedSearchQueue(ctx context.Context) []wantedSearch {
 	wanted, err := s.books.ListByStatus(ctx, models.BookStatusWanted)
 	if err != nil {
 		slog.Error("failed to list wanted books", "error", err)
@@ -1123,34 +1161,104 @@ func (s *Scheduler) wantedSearchQueue(ctx context.Context) []models.Book {
 		return nil
 	}
 
-	inFlightBooks := make(map[int64]bool)
-	if s.downloads != nil {
-		for _, st := range inFlightDownloadStates {
-			active, derr := s.downloads.ListByStatus(ctx, st)
-			if derr != nil {
-				slog.Warn("failed to list in-flight downloads", "state", st, "error", derr)
-				continue
-			}
-			for _, d := range active {
-				if d.BookID != nil {
-					inFlightBooks[*d.BookID] = true
-				}
-			}
-		}
-	}
+	inFlight := s.inFlightFormatsByBook(ctx)
 
-	searchQueue := make([]models.Book, 0, len(wanted))
+	searchQueue := make([]wantedSearch, 0, len(wanted))
 	for _, book := range wanted {
 		if book.Excluded {
 			continue
 		}
-		if inFlightBooks[book.ID] {
-			slog.Debug("skipping wanted search — a grab is already in flight for this book", "book", book.Title)
+		held := inFlight[book.ID]
+		// An unresolvable format blocks the whole book: guessing wrong here
+		// means grabbing a second release for a format that is already on its
+		// way, which is the bug the in-flight filter exists to prevent.
+		if held[""] {
+			slog.Debug("skipping wanted search — a grab of an undetermined format is already in flight for this book", "book", book.Title)
 			continue
 		}
-		searchQueue = append(searchQueue, book)
+		formats := make([]string, 0, 2)
+		for _, mediaType := range neededFormats(&book) {
+			if held[mediaType] {
+				continue
+			}
+			formats = append(formats, mediaType)
+		}
+		if len(formats) == 0 {
+			slog.Debug("skipping wanted search — every format this book needs already has a grab in flight", "book", book.Title)
+			continue
+		}
+		searchQueue = append(searchQueue, wantedSearch{book: book, formats: formats})
 	}
 	return searchQueue
+}
+
+// inFlightFormatsByBook maps a book id to the set of media types that already
+// have a download working toward an import. The empty-string key is the
+// catch-all for a download whose format could not be determined; the caller
+// treats it as blocking every format of that book.
+func (s *Scheduler) inFlightFormatsByBook(ctx context.Context) map[int64]map[string]bool {
+	inFlight := make(map[int64]map[string]bool)
+	if s.downloads == nil {
+		return inFlight
+	}
+	for _, st := range inFlightDownloadStates {
+		active, derr := s.downloads.ListByStatus(ctx, st)
+		if derr != nil {
+			slog.Warn("failed to list in-flight downloads", "state", st, "error", derr)
+			continue
+		}
+		for i := range active {
+			d := &active[i]
+			if d.BookID == nil {
+				continue
+			}
+			if inFlight[*d.BookID] == nil {
+				inFlight[*d.BookID] = make(map[string]bool, 2)
+			}
+			inFlight[*d.BookID][downloadMediaType(d)] = true
+		}
+	}
+	return inFlight
+}
+
+// downloadMediaType resolves which format slot a download is working toward,
+// or "" when the release names containers of both kinds or none at all.
+//
+// A download row carries no media type of its own, so this reads the same two
+// sources importer.formatForRelease does: the container tokens in the release
+// title, plus the Quality token the grab recorded. It is deliberately the more
+// cautious of the two — where the importer breaks a both-kinds tie on an
+// "unabridged"/"audiobook" marker in the title, this returns "" and lets the
+// caller block the whole book. The importer is deciding where a file it already
+// has should go; this is deciding whether to spend a grab, and a wrong guess
+// here buys a duplicate release.
+func downloadMediaType(dl *models.Download) string {
+	if dl == nil {
+		return ""
+	}
+	var audiobook, ebook bool
+	mark := func(mediaType string) {
+		switch mediaType {
+		case models.MediaTypeAudiobook:
+			audiobook = true
+		case models.MediaTypeEbook:
+			ebook = true
+		}
+	}
+	for _, token := range indexer.ReleaseFormats(dl.Title) {
+		mark(indexer.MediaTypeForFormat(token))
+	}
+	// Quality is normally one of the title's own tokens, but it is what the
+	// grab actually recorded and a title can be edited or absent, so it counts.
+	mark(indexer.MediaTypeForFormat(dl.Quality))
+	switch {
+	case audiobook && !ebook:
+		return models.MediaTypeAudiobook
+	case ebook && !audiobook:
+		return models.MediaTypeEbook
+	default:
+		return ""
+	}
 }
 
 func (s *Scheduler) refreshMetadata() {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1169,6 +1169,21 @@ func (s *Scheduler) wantedSearchQueue(ctx context.Context) []wantedSearch {
 			continue
 		}
 		held := inFlight[book.ID]
+		// A book monitored for a SINGLE format has only one slot a download can
+		// be filling, whatever container tokens the release title happens to
+		// carry, so the book's own media type settles it and inference is not
+		// consulted at all. This is the precedence importer.downloadFormat
+		// already applies to the same question (#1885). Without it an audiobook
+		// release that names a PDF booklet but no audio container ("(Unabridged)
+		// [64kbps] [PDF]") resolves to "ebook", the audiobook slot reads as
+		// free, and the sweep grabs a second copy of the release that is
+		// already downloading.
+		if book.MediaType == models.MediaTypeEbook || book.MediaType == models.MediaTypeAudiobook {
+			if len(held) > 0 {
+				slog.Debug("skipping wanted search: a grab is already in flight for this single-format book", "book", book.Title)
+				continue
+			}
+		}
 		// An unresolvable format blocks the whole book: guessing wrong here
 		// means grabbing a second release for a format that is already on its
 		// way, which is the bug the in-flight filter exists to prevent.
@@ -1232,6 +1247,12 @@ func (s *Scheduler) inFlightFormatsByBook(ctx context.Context) map[int64]map[str
 // caller block the whole book. The importer is deciding where a file it already
 // has should go; this is deciding whether to spend a grab, and a wrong guess
 // here buys a duplicate release.
+//
+// It reads the download alone and can still be wrong: an audiobook naming only
+// a PDF booklet, or a book whose own title contains a container token ("Lit"),
+// reads as an ebook. wantedSearchQueue therefore consults it only for a
+// media_type=both book, where the release is the sole per-download signal. For
+// a single-format book the book's own media type settles the slot.
 func downloadMediaType(dl *models.Download) string {
 	if dl == nil {
 		return ""

--- a/internal/scheduler/scheduler_autograb_test.go
+++ b/internal/scheduler/scheduler_autograb_test.go
@@ -125,14 +125,17 @@ func funcBody(t *testing.T, src, decl string) (body string, firstLine, lastLine 
 // is "there is exactly one place a grab is dispatched from and it checks the
 // switch". Two things have to stay true for that to keep holding:
 //
-//  1. SearchAndGrabBook consults autoGrabEnabled before it dispatches
+//  1. searchAndGrabFormats consults autoGrabEnabled before it dispatches
 //     anything, and
-//  2. nothing calls searchAndGrabFormat except SearchAndGrabBook, so no new
+//  2. nothing calls searchAndGrabFormat except searchAndGrabFormats, so no new
 //     dispatch site can route around the check.
 //
-// A new caller of SearchAndGrabBook needs no guard of its own and this guard
-// stays quiet. A new caller of searchAndGrabFormat, or a SearchAndGrabBook
-// that stops checking, fails here.
+// searchAndGrabFormats is where the check moved to when the wanted sweep gained
+// the ability to search a subset of a book's formats (#2365); SearchAndGrabBook
+// is now one of its callers rather than the chokepoint itself. A new caller of
+// either needs no guard of its own and this guard stays quiet. A new caller of
+// searchAndGrabFormat, or a searchAndGrabFormats that stops checking, fails
+// here.
 func TestAutoGrabChokepointHolds(t *testing.T) {
 	const mainFile = "scheduler.go"
 	raw, err := os.ReadFile(filepath.Join(schedulerSourceDir, mainFile))
@@ -141,18 +144,18 @@ func TestAutoGrabChokepointHolds(t *testing.T) {
 	}
 	src := string(raw)
 
-	body, first, last := funcBody(t, src, "func (s *Scheduler) SearchAndGrabBook(")
+	body, first, last := funcBody(t, src, "func (s *Scheduler) searchAndGrabFormats(")
 
 	checkAt := strings.Index(body, "s.autoGrabEnabled(ctx)")
 	if checkAt < 0 {
-		t.Fatalf("SearchAndGrabBook does not call s.autoGrabEnabled(ctx); the auto-grab kill switch (#2256) is only enforced there, so removing it un-guards every caller at once")
+		t.Fatalf("searchAndGrabFormats does not call s.autoGrabEnabled(ctx); the auto-grab kill switch (#2256) is only enforced there, so removing it un-guards every caller at once")
 	}
 	dispatchAt := strings.Index(body, "s.searchAndGrabFormat(")
 	if dispatchAt < 0 {
-		t.Fatal("SearchAndGrabBook no longer calls s.searchAndGrabFormat; update this drift guard to follow the new dispatch call")
+		t.Fatal("searchAndGrabFormats no longer calls s.searchAndGrabFormat; update this drift guard to follow the new dispatch call")
 	}
 	if checkAt > dispatchAt {
-		t.Fatal("SearchAndGrabBook dispatches a search before checking s.autoGrabEnabled(ctx); the check must gate the dispatch (#2256)")
+		t.Fatal("searchAndGrabFormats dispatches a search before checking s.autoGrabEnabled(ctx); the check must gate the dispatch (#2256)")
 	}
 
 	// autoGrabEnabled must actually read the switch it is named after.
@@ -185,9 +188,9 @@ func TestAutoGrabChokepointHolds(t *testing.T) {
 			}
 			lineNo := i + 1
 			if name == mainFile && lineNo >= first && lineNo <= last {
-				continue // inside SearchAndGrabBook, which is the guarded path
+				continue // inside searchAndGrabFormats, which is the guarded path
 			}
-			t.Errorf("%s:%d calls searchAndGrabFormat outside SearchAndGrabBook, bypassing the auto-grab kill switch (#2256). Dispatch through SearchAndGrabBook instead.", name, lineNo)
+			t.Errorf("%s:%d calls searchAndGrabFormat outside searchAndGrabFormats, bypassing the auto-grab kill switch (#2256). Dispatch through searchAndGrabFormats instead.", name, lineNo)
 		}
 	}
 }

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -437,8 +437,8 @@ func TestWantedSearchQueue_SkipsInFlightGrabs(t *testing.T) {
 	queue := s.wantedSearchQueue(ctx)
 
 	got := make(map[int64]bool, len(queue))
-	for _, b := range queue {
-		got[b.ID] = true
+	for _, w := range queue {
+		got[w.book.ID] = true
 	}
 	if got[inFlight.ID] {
 		t.Errorf("book with a downloading grab was queued for re-search (double-grab bug)")

--- a/internal/scheduler/scheduler_wanted_queue_test.go
+++ b/internal/scheduler/scheduler_wanted_queue_test.go
@@ -1,0 +1,228 @@
+package scheduler
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// wantedQueueFixture builds an in-memory library with one author and the repos
+// the wanted sweep reads, so each case below only has to describe its books and
+// downloads.
+type wantedQueueFixture struct {
+	t         *testing.T
+	ctx       context.Context
+	database  *sql.DB
+	books     *db.BookRepo
+	downloads *db.DownloadRepo
+	authorID  int64
+}
+
+func newWantedQueueFixture(t *testing.T) *wantedQueueFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL-WQ", Name: "Wanted Queue", SortName: "Wanted Queue",
+		MetadataProvider: "ol", Monitored: true,
+	}
+	if err := db.NewAuthorRepo(database).Create(ctx, author); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+	return &wantedQueueFixture{
+		t:         t,
+		ctx:       ctx,
+		database:  database,
+		books:     db.NewBookRepo(database),
+		downloads: db.NewDownloadRepo(database),
+		authorID:  author.ID,
+	}
+}
+
+func (f *wantedQueueFixture) book(title, mediaType string) *models.Book {
+	f.t.Helper()
+	b := &models.Book{
+		ForeignID: title, AuthorID: f.authorID, Title: title, SortTitle: title,
+		Status: models.BookStatusWanted, MediaType: mediaType,
+		Genres: []string{}, MetadataProvider: "ol", Monitored: true,
+	}
+	if err := f.books.Create(f.ctx, b); err != nil {
+		f.t.Fatalf("create book %s: %v", title, err)
+	}
+	return b
+}
+
+// download creates a download row for a book with an explicit format token as
+// its Quality, which is what a real grab records (see SearchAndGrabBook). The
+// state is written directly because the import states are several legal hops
+// away from StateGrabbed and the path there is not what these cases are about.
+func (f *wantedQueueFixture) download(b *models.Book, quality string, state models.DownloadState) {
+	f.t.Helper()
+	dl := &models.Download{
+		GUID:     "guid-" + b.ForeignID + "-" + quality,
+		BookID:   &b.ID,
+		Title:    b.Title + " [" + quality + "]",
+		Quality:  quality,
+		Status:   models.StateGrabbed,
+		Protocol: "torrent",
+	}
+	if err := f.downloads.Create(f.ctx, dl); err != nil {
+		f.t.Fatalf("create download for %s: %v", b.Title, err)
+	}
+	if state != models.StateGrabbed {
+		if _, err := f.database.ExecContext(f.ctx,
+			"UPDATE downloads SET status=? WHERE id=?", state, dl.ID); err != nil {
+			f.t.Fatalf("set download status %s: %v", state, err)
+		}
+	}
+}
+
+func (f *wantedQueueFixture) queue() []wantedSearch {
+	f.t.Helper()
+	s := &Scheduler{books: f.books, downloads: f.downloads}
+	return s.wantedSearchQueue(f.ctx)
+}
+
+// entryFor returns the sweep entry for a book, or nil when the sweep dropped it.
+func entryFor(queue []wantedSearch, id int64) *wantedSearch {
+	for i := range queue {
+		if queue[i].book.ID == id {
+			return &queue[i]
+		}
+	}
+	return nil
+}
+
+// TestWantedSearchQueue_ParkedFormatLeavesSiblingSearchable is the regression
+// guard for #2365: a media_type='both' book whose ebook is parked in a
+// non-terminal import state must stay in the sweep, with only the audiobook
+// left to search. Before the per-format filter the whole book was dropped, so
+// under pair gating (#942) the hold waited for a sibling that the hold itself
+// had prevented anyone from searching for.
+func TestWantedSearchQueue_ParkedFormatLeavesSiblingSearchable(t *testing.T) {
+	for _, state := range []models.DownloadState{models.StateImportHeld, models.StateImportExternal} {
+		t.Run(string(state), func(t *testing.T) {
+			f := newWantedQueueFixture(t)
+			book := f.book("Parked Ebook "+string(state), models.MediaTypeBoth)
+			f.download(book, "epub", state)
+
+			entry := entryFor(f.queue(), book.ID)
+			if entry == nil {
+				t.Fatalf("dual-format book with only its ebook parked in %s was dropped from the sweep", state)
+			}
+			if len(entry.formats) != 1 || entry.formats[0] != models.MediaTypeAudiobook {
+				t.Errorf("formats to search: want [%s], got %v", models.MediaTypeAudiobook, entry.formats)
+			}
+		})
+	}
+}
+
+// TestWantedSearchQueue_SingleFormatDownloadingStillSkipped pins the original
+// behaviour: an ebook-only book whose one grab is downloading must not be
+// re-searched (the double-grab bug the filter exists for).
+func TestWantedSearchQueue_SingleFormatDownloadingStillSkipped(t *testing.T) {
+	f := newWantedQueueFixture(t)
+	book := f.book("Single Format Downloading", models.MediaTypeEbook)
+	f.download(book, "epub", models.StateDownloading)
+
+	if entry := entryFor(f.queue(), book.ID); entry != nil {
+		t.Errorf("single-format book with a downloading grab was queued for re-search: %v", entry.formats)
+	}
+}
+
+// TestWantedSearchQueue_BothFormatsInFlightSkipped verifies the book is still
+// dropped entirely when every format it needs already has a live download.
+func TestWantedSearchQueue_BothFormatsInFlightSkipped(t *testing.T) {
+	f := newWantedQueueFixture(t)
+	book := f.book("Both In Flight", models.MediaTypeBoth)
+	f.download(book, "epub", models.StateImportHeld)
+	f.download(book, "m4b", models.StateDownloading)
+
+	if entry := entryFor(f.queue(), book.ID); entry != nil {
+		t.Errorf("book with both formats in flight was queued: %v", entry.formats)
+	}
+}
+
+// TestWantedSearchQueue_UndeterminedFormatBlocksWholeBook covers the cautious
+// direction: a download whose release names no format Bindery recognises could
+// be either slot, so it keeps blocking both rather than risk a duplicate grab.
+func TestWantedSearchQueue_UndeterminedFormatBlocksWholeBook(t *testing.T) {
+	f := newWantedQueueFixture(t)
+	book := f.book("Untyped Release", models.MediaTypeBoth)
+	f.download(book, "", models.StateDownloading)
+
+	if entry := entryFor(f.queue(), book.ID); entry != nil {
+		t.Errorf("book with an unresolvable in-flight format was queued: %v", entry.formats)
+	}
+}
+
+// TestWantedSearchQueue_FormatOnDiskNotSearched confirms the sweep still
+// respects what is already imported: a 'both' book with its ebook on disk and
+// its audiobook downloading has nothing left to search.
+func TestWantedSearchQueue_FormatOnDiskNotSearched(t *testing.T) {
+	f := newWantedQueueFixture(t)
+	book := f.book("Half Imported", models.MediaTypeBoth)
+	book.EbookFilePath = "/lib/half-imported.epub"
+	if err := f.books.Update(f.ctx, book); err != nil {
+		t.Fatalf("update book: %v", err)
+	}
+	f.download(book, "m4b", models.StateDownloading)
+
+	if entry := entryFor(f.queue(), book.ID); entry != nil {
+		t.Errorf("book with its only missing format in flight was queued: %v", entry.formats)
+	}
+}
+
+// TestSearchAndGrabFormats_SearchesOnlyGivenFormats verifies the sweep's format
+// narrowing actually reaches the indexer search, not just the queue entry.
+func TestSearchAndGrabFormats_SearchesOnlyGivenFormats(t *testing.T) {
+	ss := &stubSearcher{}
+	sched := &Scheduler{searcher: ss}
+
+	book := models.Book{Title: "The Martian", MediaType: models.MediaTypeBoth}
+	sched.searchAndGrabFormats(context.Background(), book, []string{models.MediaTypeAudiobook})
+
+	if n := int(ss.calls.Load()); n != 1 {
+		t.Fatalf("expected 1 search call, got %d", n)
+	}
+	if ss.mediaTypes[0] != models.MediaTypeAudiobook {
+		t.Errorf("searched mediaType: want %q, got %q", models.MediaTypeAudiobook, ss.mediaTypes[0])
+	}
+}
+
+// TestDownloadMediaType covers the resolver's three answers directly, including
+// the both-kinds title that has to stay undetermined.
+func TestDownloadMediaType(t *testing.T) {
+	cases := []struct {
+		name    string
+		title   string
+		quality string
+		want    string
+	}{
+		{"ebook from quality", "Some Book", "epub", models.MediaTypeEbook},
+		{"audiobook from quality", "Some Book", "m4b", models.MediaTypeAudiobook},
+		{"ebook from title", "Some Book EPUB", "", models.MediaTypeEbook},
+		{"audiobook from title", "Some Book M4B", "", models.MediaTypeAudiobook},
+		{"nothing recognisable", "Some Book", "", ""},
+		{"both kinds stays undetermined", "Some Book M4B + PDF booklet", "pdf", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := downloadMediaType(&models.Download{Title: tc.title, Quality: tc.quality})
+			if got != tc.want {
+				t.Errorf("downloadMediaType(%q, %q) = %q, want %q", tc.title, tc.quality, got, tc.want)
+			}
+		})
+	}
+	if got := downloadMediaType(nil); got != "" {
+		t.Errorf("downloadMediaType(nil) = %q, want empty", got)
+	}
+}

--- a/internal/scheduler/scheduler_wanted_queue_test.go
+++ b/internal/scheduler/scheduler_wanted_queue_test.go
@@ -181,6 +181,50 @@ func TestWantedSearchQueue_FormatOnDiskNotSearched(t *testing.T) {
 	}
 }
 
+// TestWantedSearchQueue_SingleFormatBookIgnoresReleaseTokens pins the
+// media-type precedence: a book monitored for one format has one slot, so any
+// live download for it blocks that book no matter what the release title says.
+//
+// Both titles below resolve to "ebook" through downloadMediaType while the
+// book is audiobook-only. The first names a PDF booklet and no audio
+// container; the second is Mary Karr's memoir "Lit", whose own title carries
+// the "lit" ebook token. Inferring from the release alone would leave the
+// audiobook slot looking free and grab a second copy of the release that is
+// already downloading.
+func TestWantedSearchQueue_SingleFormatBookIgnoresReleaseTokens(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+		qual  string
+	}{
+		{"pdf booklet, no audio container", "Some Author - Audio Only (Unabridged) [64kbps] [PDF booklet]", "pdf"},
+		{"format token inside the book title", "Mary Karr - Lit A Memoir (Unabridged)", "lit"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newWantedQueueFixture(t)
+			book := f.book(tc.name, models.MediaTypeAudiobook)
+			dl := &models.Download{
+				GUID:     "guid-" + tc.name,
+				BookID:   &book.ID,
+				Title:    tc.title,
+				Quality:  tc.qual,
+				Status:   models.StateDownloading,
+				Protocol: "torrent",
+			}
+			if err := f.downloads.Create(f.ctx, dl); err != nil {
+				t.Fatalf("create download: %v", err)
+			}
+			if got := downloadMediaType(dl); got != models.MediaTypeEbook {
+				t.Fatalf("precondition: this case only bites when the release reads as an ebook, got %q", got)
+			}
+			if entry := entryFor(f.queue(), book.ID); entry != nil {
+				t.Errorf("audiobook-only book with its audiobook downloading was queued anyway: %v (duplicate grab)", entry.formats)
+			}
+		})
+	}
+}
+
 // TestSearchAndGrabFormats_SearchesOnlyGivenFormats verifies the sweep's format
 // narrowing actually reaches the indexer search, not just the queue entry.
 func TestSearchAndGrabFormats_SearchesOnlyGivenFormats(t *testing.T) {


### PR DESCRIPTION
The wanted sweep's in-flight filter was keyed on book id, but a grab is per format. That is harmless for the short-lived states and wrong for `importExternal` and `importHeld`, which have no automatic exit: a `media_type=both` book with one format parked was dropped from the sweep entirely, so its other format was never auto-searched. Under pair gating (#942) that is a deadlock, because the sibling the hold waits for can only arrive via the search the hold just switched off.

`wantedSearchQueue` now returns each book paired with the formats that still need searching, and the sweep dispatches only those. A download's format comes from the container tokens in its release title plus the `Quality` the grab recorded; a release naming both kinds or neither stays undetermined and keeps blocking the whole book, which is the safe direction since a wrong guess buys a duplicate grab. The auto-grab kill switch moved down one level into the new `searchAndGrabFormats` along with the dispatch loop, and the #2256 drift guard follows it there.

Closes #2365

### Testing

New `internal/scheduler/scheduler_wanted_queue_test.go`. `TestWantedSearchQueue_ParkedFormatLeavesSiblingSearchable` is the one that fails before and passes after, for both `importHeld` and `importExternal`:

```
--- FAIL: TestWantedSearchQueue_ParkedFormatLeavesSiblingSearchable (0.28s)
    dual-format book with only its ebook parked in importHeld was dropped from the sweep
    dual-format book with only its ebook parked in importExternal was dropped from the sweep
```

The rest pin what must not change: a single-format book with a `downloading` row is still skipped, a book with both formats in flight is still skipped, an unresolvable format still blocks the whole book, and a format already on disk is not searched. `TestDownloadMediaType` covers the resolver directly.

Ran: `go build ./...`, `go vet ./internal/scheduler/... ./internal/models/...`, `go test ./internal/scheduler/... ./internal/models/...` (ok), `golangci-lint run ./internal/scheduler/... ./internal/models/...` (0 issues).

### Sequencing

Patch-release material: a monitored format is silently never searched, and this is what unblocks the pair-gating happy path. Nothing to merge before it. Three follow-ups touch the same file and say "merge after this one": the stall-removal fix (#2367), the sweep-invariant hoisting (#2370), and the jobs-group wiring (#2371 / #2372).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
