### PR TITLE
fix(abs): keep a no-sequence item off the wrong Hardcover volume (#2347)

### DIFF
--- a/internal/abs/import_hardcover_series.go
+++ b/internal/abs/import_hardcover_series.go
@@ -264,7 +264,24 @@ func matchHardcoverCatalogBook(item NormalizedLibraryItem, sequence string, book
 		if sequence != "" && !positionMatched {
 			continue
 		}
-		score := shelfarrTitleScore(item.Title, firstNonEmpty(book.Title, book.Book.Title))
+		candidateTitle := firstNonEmpty(book.Title, book.Book.Title)
+		// With no sequence there is no position filter, so every volume in the
+		// catalog is scored against the item title and the volume numbers are
+		// the only thing separating them (#2347). The 88 threshold below sits
+		// under the 93-100 band that sibling volumes of one series score
+		// against each other, so all of them clear it, and PartialRatio hands
+		// "X Vol. 13" a perfect 100 against "X Vol. 1". The matches==1 tie
+		// guard at the bottom does not catch that: the wrong volume wins
+		// outright rather than tying.
+		//
+		// Only on the no-sequence path. When a sequence is present the
+		// position filter has already narrowed the candidates on harder
+		// evidence, and vetoing there would drop a legitimate match whose
+		// catalog title spells a different volume marker than the item does.
+		if sequence == "" && seriesmatch.DifferentVolumes(item.Title, candidateTitle) {
+			continue
+		}
+		score := shelfarrTitleScore(item.Title, candidateTitle)
 		threshold := 88
 		if positionMatched {
 			threshold = 70

--- a/internal/abs/import_hardcover_volume_match_test.go
+++ b/internal/abs/import_hardcover_volume_match_test.go
@@ -1,0 +1,87 @@
+package abs
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// datingSimVolumes builds Hardcover catalog entries for the given volume
+// numbers of a light novel series: every title differs from every other by one
+// digit in an otherwise identical string, which is the shape TitleScore cannot
+// separate (#2347).
+func datingSimVolumes(numbers ...int) []metadata.SeriesCatalogBook {
+	books := make([]metadata.SeriesCatalogBook, 0, len(numbers))
+	for _, n := range numbers {
+		title := fmt.Sprintf("Trapped in a Dating Sim Vol. %d", n)
+		foreignID := fmt.Sprintf("hc:dating-sim-vol-%d", n)
+		books = append(books, metadata.SeriesCatalogBook{
+			ForeignID:  foreignID,
+			ProviderID: strconv.Itoa(700 + n),
+			Title:      title,
+			Position:   strconv.Itoa(n),
+			Book: models.Book{
+				ForeignID: foreignID,
+				Title:     title,
+			},
+		})
+	}
+	return books
+}
+
+// TestMatchHardcoverCatalogBookNoSequenceVolumes is the #2347 regression guard.
+// An Audiobookshelf item whose record carries no series sequence gets no
+// position filter, so every volume in the catalog is scored at a threshold of
+// 88, well under the 93-100 band sibling volumes score against each other.
+// PartialRatio then hands "Vol. 13" a perfect 100 against "Vol. 1".
+func TestMatchHardcoverCatalogBookNoSequenceVolumes(t *testing.T) {
+	// The volume the user owns is in the catalog, so it must be found. Before
+	// the fix volume 1 tied volume 13 at 100 and the matches==1 guard refused
+	// to bind anything, leaving the item unmatched.
+	t.Run("binds the volume it actually is", func(t *testing.T) {
+		item := NormalizedLibraryItem{Title: "Trapped in a Dating Sim Vol. 13"}
+		books := datingSimVolumes(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+
+		best, score, positionMatched, ok := matchHardcoverCatalogBook(item, "", books)
+		if !ok {
+			t.Fatalf("expected a match for the volume the item is, got none")
+		}
+		if best.ForeignID != "hc:dating-sim-vol-13" {
+			t.Fatalf("matched %q (score %d), want hc:dating-sim-vol-13", best.ForeignID, score)
+		}
+		if positionMatched {
+			t.Fatal("positionMatched should be false with no sequence")
+		}
+	})
+
+	// The volume the user owns is NOT in the catalog. Before the fix volume 1
+	// scored 100 against volume 13 on its own, matches==1, and the item was
+	// bound to the wrong volume.
+	t.Run("binds nothing rather than the wrong volume", func(t *testing.T) {
+		item := NormalizedLibraryItem{Title: "Trapped in a Dating Sim Vol. 1"}
+		books := datingSimVolumes(13)
+
+		best, score, _, ok := matchHardcoverCatalogBook(item, "", books)
+		if ok {
+			t.Fatalf("volume 1 was bound to %q at score %d; the catalog does not hold volume 1", best.ForeignID, score)
+		}
+	})
+
+	// A sequence keeps its own filter and is unaffected: the position narrows
+	// the candidates first, on harder evidence than the title.
+	t.Run("a sequence still binds by position", func(t *testing.T) {
+		item := NormalizedLibraryItem{Title: "Trapped in a Dating Sim Vol. 1"}
+		books := datingSimVolumes(1, 2, 3, 13)
+
+		best, _, positionMatched, ok := matchHardcoverCatalogBook(item, "1", books)
+		if !ok || best.ForeignID != "hc:dating-sim-vol-1" {
+			t.Fatalf("matched %q (ok=%v), want hc:dating-sim-vol-1", best.ForeignID, ok)
+		}
+		if !positionMatched {
+			t.Fatal("positionMatched should be true when the sequence lines up")
+		}
+	})
+}


### PR DESCRIPTION
When an Audiobookshelf record carries no series sequence, `matchHardcoverCatalogBook` skips the position filter and scores every volume in the catalog against the item title at a threshold of 88. That sits under the 93 to 100 band that sibling volumes of one series score against each other (the numbers are measured in `seriesmatch.DifferentVolumes`'s doc comment), so all of them clear it, and PartialRatio hands "X Vol. 13" a perfect 100 against "X Vol. 1".

Two ways it goes wrong. When the catalog holds the item's own volume, the right answer ties the wrong one and the `matches == 1` guard refuses to bind anything, so a legitimate match is silently dropped. When it does not hold it, the wrong volume wins outright and the item gets bound to it.

The veto is added on the no-sequence path only. Where a sequence is present the position filter has already narrowed the candidates on harder evidence, and vetoing there could drop a match whose catalog title spells the volume marker differently than the item does.

Closes #2347

### Tests

`TestMatchHardcoverCatalogBookNoSequenceVolumes` in the new `internal/abs/import_hardcover_volume_match_test.go`, three subtests. The first two fail on `main`:

```
--- FAIL: .../binds_the_volume_it_actually_is
    expected a match for the volume the item is, got none
--- FAIL: .../binds_nothing_rather_than_the_wrong_volume
    volume 1 was bound to "hc:dating-sim-vol-13" at score 100; the catalog does not hold volume 1
```

The third (`a sequence still binds by position`) passes both before and after, and is there to pin that the sequence path is untouched.

Ran: `go build ./...`, `go vet ./internal/abs/...`, `go test ./internal/abs/...` (ok, 5.2s), `golangci-lint run ./internal/abs/...` (0 issues).

### Sequencing

Patch release material, same class as #2343 (`bestCatalogMatch` in the series diff). Different file, different function, no shared code, so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
