### PR TITLE
feat(series): paginate GET /series (#2345)

### DIFF
--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -166,10 +166,51 @@ func validateSeriesTitle(title string) (string, string) {
 	return title, ""
 }
 
+const (
+	seriesListDefaultLimit = 100
+	seriesListMaxLimit     = 500
+)
+
+// seriesListResponse is the paginated wrapper GET /series returns when the
+// caller asks for a page. Same shape as authorListResponse.
+type seriesListResponse struct {
+	Items  []models.Series `json:"items"`
+	Total  int             `json:"total"`
+	Limit  int             `json:"limit"`
+	Offset int             `json:"offset"`
+}
+
+// List returns the series collection with each series' linked books attached.
+//
+// Pagination is opt-in (#2345): pass limit and/or offset and the response is a
+// seriesListResponse envelope; pass neither and it stays the bare array it has
+// always been. Authors and books got the envelope unconditionally and that was
+// a breaking change for every client; there is no reason to repeat it here
+// when the only in-tree consumer (web/src/pages/SeriesPage.tsx) still wants
+// the whole collection. Switching that page to paged loads, and then making
+// the envelope the default, is the follow-up.
 func (h *SeriesHandler) List(w http.ResponseWriter, r *http.Request) {
 	// Owner-scoped books (#1457): a non-admin must not enumerate other
 	// users' titles through the series view. Series rows stay global.
-	series, err := h.series.ListWithBooksForUser(r.Context(), auth.ListScopeUserID(r.Context()))
+	userID := auth.ListScopeUserID(r.Context())
+
+	q := r.URL.Query()
+	paged := strings.TrimSpace(q.Get("limit")) != "" || strings.TrimSpace(q.Get("offset")) != ""
+	if !paged {
+		series, err := h.series.ListWithBooksForUser(r.Context(), userID)
+		if err != nil {
+			writeServerError(w, r, err)
+			return
+		}
+		if series == nil {
+			series = []models.Series{}
+		}
+		writeJSON(w, http.StatusOK, series)
+		return
+	}
+
+	limit, offset := parseLimitOffset(r, seriesListDefaultLimit, seriesListMaxLimit)
+	series, total, err := h.series.ListPageWithBooksForUser(r.Context(), userID, limit, offset)
 	if err != nil {
 		writeServerError(w, r, err)
 		return
@@ -177,7 +218,12 @@ func (h *SeriesHandler) List(w http.ResponseWriter, r *http.Request) {
 	if series == nil {
 		series = []models.Series{}
 	}
-	writeJSON(w, http.StatusOK, series)
+	writeJSON(w, http.StatusOK, seriesListResponse{
+		Items:  series,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 func (h *SeriesHandler) Get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/series_pagination_test.go
+++ b/internal/api/series_pagination_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// seedSeriesForPaging creates n series, each with one linked book, titled so
+// that title order matches creation order.
+func seedSeriesForPaging(t *testing.T, seriesRepo *db.SeriesRepo, authorRepo *db.AuthorRepo, bookRepo *db.BookRepo, n int) {
+	t.Helper()
+	ctx := context.Background()
+	author := &models.Author{ForeignID: "OL-PG-A", Name: "Pager", SortName: "Pager"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= n; i++ {
+		suffix := strconv.Itoa(100 + i)[1:] // "01".."99"
+		book := &models.Book{
+			ForeignID: "OL-PG-B" + suffix,
+			AuthorID:  author.ID,
+			Title:     "Book " + suffix,
+			Status:    models.BookStatusWanted,
+		}
+		if err := bookRepo.Create(ctx, book); err != nil {
+			t.Fatal(err)
+		}
+		s := &models.Series{ForeignID: "OL-PG-S" + suffix, Title: "Series " + suffix}
+		if err := seriesRepo.Create(ctx, s); err != nil {
+			t.Fatal(err)
+		}
+		if err := seriesRepo.LinkBook(ctx, s.ID, book.ID, "1", true); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestSeriesList_DefaultStaysABareArray is the compatibility guard for #2345.
+// Pagination is opt-in, so a request with no limit and no offset must still
+// return the bare array web/src/api/series.ts expects.
+func TestSeriesList_DefaultStaysABareArray(t *testing.T) {
+	h, seriesRepo, authorRepo, bookRepo := seriesFixture(t)
+	seedSeriesForPaging(t, seriesRepo, authorRepo, bookRepo, 5)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
+		t.Fatalf("body is not a JSON array: %s", rec.Body.String())
+	}
+	var list []models.Series
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list) != 5 {
+		t.Errorf("got %d series, want all 5", len(list))
+	}
+	for _, s := range list {
+		if len(s.Books) != 1 {
+			t.Errorf("series %q carries %d books, want 1", s.Title, len(s.Books))
+		}
+	}
+}
+
+// TestSeriesList_Paginated covers the opt-in envelope: limit and offset walk
+// the collection in title order and every page reports the full total.
+func TestSeriesList_Paginated(t *testing.T) {
+	h, seriesRepo, authorRepo, bookRepo := seriesFixture(t)
+	seedSeriesForPaging(t, seriesRepo, authorRepo, bookRepo, 5)
+
+	get := func(query string) seriesListResponse {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series?"+query, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d for ?%s, want 200", rec.Code, query)
+		}
+		var resp seriesListResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode ?%s: %v (body %s)", query, err, rec.Body.String())
+		}
+		return resp
+	}
+
+	first := get("limit=2")
+	if first.Total != 5 || first.Limit != 2 || first.Offset != 0 {
+		t.Errorf("first page envelope = %+v, want total 5 limit 2 offset 0", first)
+	}
+	if len(first.Items) != 2 || first.Items[0].Title != "Series 01" || first.Items[1].Title != "Series 02" {
+		t.Fatalf("first page items = %v", titlesOf(first.Items))
+	}
+	if len(first.Items[0].Books) != 1 {
+		t.Errorf("paged series lost its books: %+v", first.Items[0].Books)
+	}
+
+	second := get("limit=2&offset=2")
+	if len(second.Items) != 2 || second.Items[0].Title != "Series 03" {
+		t.Errorf("second page items = %v", titlesOf(second.Items))
+	}
+
+	// offset alone opts in too, at the default limit.
+	tail := get("offset=4")
+	if tail.Limit != seriesListDefaultLimit {
+		t.Errorf("offset-only limit = %d, want the default %d", tail.Limit, seriesListDefaultLimit)
+	}
+	if len(tail.Items) != 1 || tail.Items[0].Title != "Series 05" {
+		t.Errorf("offset-only page = %v", titlesOf(tail.Items))
+	}
+
+	// Past the end is an empty items array, not null and not an error.
+	past := get("limit=2&offset=99")
+	if past.Total != 5 || past.Items == nil || len(past.Items) != 0 {
+		t.Errorf("past-the-end page = %+v, want total 5 and an empty items array", past)
+	}
+
+	// An over-large limit clamps rather than erroring.
+	clamped := get("limit=100000")
+	if clamped.Limit != seriesListMaxLimit {
+		t.Errorf("limit = %d, want it clamped to %d", clamped.Limit, seriesListMaxLimit)
+	}
+}
+
+func titlesOf(series []models.Series) []string {
+	out := make([]string, len(series))
+	for i, s := range series {
+		out[i] = s.Title
+	}
+	return out
+}

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -74,12 +74,86 @@ func (r *SeriesRepo) ListWithBooks(ctx context.Context) ([]models.Series, error)
 // used by the book and history lists. Series rows themselves are global —
 // one series can span books owned by different users.
 func (r *SeriesRepo) ListWithBooksForUser(ctx context.Context, userID int64) ([]models.Series, error) {
+	return r.listWithBooksForUser(ctx, userID, nil)
+}
+
+// ListPageWithBooksForUser is ListWithBooksForUser for one page of series,
+// ordered by title, plus the unpaginated total (#2345). GET /series used to
+// return every series with every linked book, which on a large library is a
+// response proportional to the whole catalogue.
+//
+// It runs as two queries rather than one windowed JOIN on purpose: LIMIT
+// applies to result rows, and the JOIN produces one row per book, so a single
+// query would cut a series in half at the page boundary. The first query picks
+// the page's series ids by title; the second is the same JOIN the unpaginated
+// path uses, restricted to those ids.
+//
+// Total counts series rows, which are global — one series can span books owned
+// by different users, and the unpaginated path returns every series row too,
+// so scoping the count would make it disagree with the rows it describes.
+func (r *SeriesRepo) ListPageWithBooksForUser(ctx context.Context, userID int64, limit, offset int) ([]models.Series, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var total int
+	if err := r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM series").Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count series: %w", err)
+	}
+
+	ids, err := func() ([]int64, error) {
+		rows, err := r.db.QueryContext(ctx, "SELECT id FROM series ORDER BY title LIMIT ? OFFSET ?", limit, offset)
+		if err != nil {
+			return nil, fmt.Errorf("list series page ids: %w", err)
+		}
+		defer rows.Close()
+		var out []int64
+		for rows.Next() {
+			var id int64
+			if err := rows.Scan(&id); err != nil {
+				return nil, fmt.Errorf("scan series page id: %w", err)
+			}
+			out = append(out, id)
+		}
+		return out, rows.Err()
+	}()
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(ids) == 0 {
+		return []models.Series{}, total, nil
+	}
+
+	series, err := r.listWithBooksForUser(ctx, userID, ids)
+	if err != nil {
+		return nil, 0, err
+	}
+	return series, total, nil
+}
+
+// listWithBooksForUser backs both the full list and one page of it. A nil
+// seriesIDs means every series; otherwise the JOIN is restricted to those ids,
+// in the same title order.
+func (r *SeriesRepo) listWithBooksForUser(ctx context.Context, userID int64, seriesIDs []int64) ([]models.Series, error) {
 	bookJoin := "LEFT JOIN books b ON b.id = sb.book_id"
 	args := []any{}
 	if userID != 0 {
 		bookJoin += " AND (b.owner_user_id = ? OR b.owner_user_id IS NULL)"
 		args = append(args, userID)
 	}
+	where := ""
+	if seriesIDs != nil {
+		placeholders := make([]string, len(seriesIDs))
+		for i, id := range seriesIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		where = " WHERE s.id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	//nolint:gosec // G202: the interpolated fragments are a fixed join clause and generated ? placeholders; every user value stays a bound arg
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT s.id, s.foreign_id, s.title, s.description, s.monitored, s.genre_override, s.created_at,
 		       sb.series_id, sb.book_id, sb.position_in_series, sb.primary_series,
@@ -87,7 +161,7 @@ func (r *SeriesRepo) ListWithBooksForUser(ctx context.Context, userID int64) ([]
 		       b.monitored, b.image_url, b.release_date, b.created_at, b.updated_at
 		FROM series s
 		LEFT JOIN series_books sb ON sb.series_id = s.id
-		`+bookJoin+`
+		`+bookJoin+where+`
 		ORDER BY s.title, CAST(NULLIF(sb.position_in_series, '') AS REAL), sb.position_in_series, b.sort_title`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list series with books: %w", err)

--- a/internal/db/series_page_test.go
+++ b/internal/db/series_page_test.go
@@ -1,0 +1,201 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// seedPagedSeries creates n series titled "Series 01".."Series NN" (zero
+// padded so title order matches creation order) each with one linked book.
+func seedPagedSeries(t *testing.T, database *seriesPageFixture, n int) {
+	t.Helper()
+	ctx := context.Background()
+	author := &models.Author{ForeignID: "OL-PAGE-A", Name: "Paged Author", SortName: "Paged Author"}
+	if err := database.authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= n; i++ {
+		suffix := string(rune('0'+i/10)) + string(rune('0'+i%10))
+		book := &models.Book{
+			ForeignID: "OL-PAGE-B" + suffix,
+			AuthorID:  author.ID,
+			Title:     "Book " + suffix,
+			SortTitle: "Book " + suffix,
+			Status:    models.BookStatusWanted,
+		}
+		if err := database.books.Create(ctx, book); err != nil {
+			t.Fatal(err)
+		}
+		s := &models.Series{ForeignID: "OL-PAGE-S" + suffix, Title: "Series " + suffix}
+		if err := database.series.Create(ctx, s); err != nil {
+			t.Fatal(err)
+		}
+		if err := database.series.LinkBook(ctx, s.ID, book.ID, "1", true); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+type seriesPageFixture struct {
+	series  *SeriesRepo
+	books   *BookRepo
+	authors *AuthorRepo
+	users   *UserRepo
+}
+
+func newSeriesPageFixture(t *testing.T) *seriesPageFixture {
+	t.Helper()
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return &seriesPageFixture{
+		series:  NewSeriesRepo(database),
+		books:   NewBookRepo(database),
+		authors: NewAuthorRepo(database),
+		users:   NewUserRepo(database),
+	}
+}
+
+// TestListPageWithBooksForUser_PagesInTitleOrder covers #2345: the page query
+// must walk the collection in title order with no gaps and no repeats, and
+// report the unpaginated total on every page.
+func TestListPageWithBooksForUser_PagesInTitleOrder(t *testing.T) {
+	f := newSeriesPageFixture(t)
+	seedPagedSeries(t, f, 7)
+	ctx := context.Background()
+
+	var seen []string
+	for offset := 0; offset < 7; offset += 3 {
+		page, total, err := f.series.ListPageWithBooksForUser(ctx, 0, 3, offset)
+		if err != nil {
+			t.Fatalf("page at offset %d: %v", offset, err)
+		}
+		if total != 7 {
+			t.Errorf("total at offset %d = %d, want 7", offset, total)
+		}
+		for _, s := range page {
+			seen = append(seen, s.Title)
+		}
+	}
+	if len(seen) != 7 {
+		t.Fatalf("paged through %d series, want 7: %v", len(seen), seen)
+	}
+	for i, title := range seen {
+		want := "Series 0" + string(rune('0'+i+1))
+		if title != want {
+			t.Errorf("series %d = %q, want %q", i, title, want)
+		}
+	}
+
+	// Past the end is an empty page, not an error, and still carries the total.
+	page, total, err := f.series.ListPageWithBooksForUser(ctx, 0, 3, 99)
+	if err != nil {
+		t.Fatalf("page past the end: %v", err)
+	}
+	if len(page) != 0 || total != 7 {
+		t.Errorf("page past the end = %d rows, total %d; want 0 rows, total 7", len(page), total)
+	}
+}
+
+// TestListPageWithBooksForUser_KeepsBooksWholePerSeries is why the page runs as
+// two queries. LIMIT applies to result rows and the JOIN emits one row per
+// book, so a naive windowed JOIN would truncate a series' book list at the page
+// boundary.
+func TestListPageWithBooksForUser_KeepsBooksWholePerSeries(t *testing.T) {
+	f := newSeriesPageFixture(t)
+	ctx := context.Background()
+
+	author := &models.Author{ForeignID: "OL-WHOLE-A", Name: "Whole", SortName: "Whole"}
+	if err := f.authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	s := &models.Series{ForeignID: "OL-WHOLE-S", Title: "Fat Series"}
+	if err := f.series.Create(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 5; i++ {
+		book := &models.Book{
+			ForeignID: "OL-WHOLE-B" + string(rune('0'+i)),
+			AuthorID:  author.ID,
+			Title:     "Volume " + string(rune('0'+i)),
+			Status:    models.BookStatusWanted,
+		}
+		if err := f.books.Create(ctx, book); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.series.LinkBook(ctx, s.ID, book.ID, string(rune('0'+i)), true); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page, total, err := f.series.ListPageWithBooksForUser(ctx, 0, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(page) != 1 {
+		t.Fatalf("page = %d rows, total %d; want 1 and 1", len(page), total)
+	}
+	if len(page[0].Books) != 5 {
+		t.Errorf("series carries %d books on a limit=1 page, want all 5", len(page[0].Books))
+	}
+}
+
+// TestListPageWithBooksForUser_ScopesBooksByOwner checks the paged path applies
+// the same per-user book predicate as the unpaginated one (#1457): series rows
+// are global, the books hanging off them are not.
+func TestListPageWithBooksForUser_ScopesBooksByOwner(t *testing.T) {
+	f := newSeriesPageFixture(t)
+	ctx := context.Background()
+
+	author := &models.Author{ForeignID: "OL-OWN-A", Name: "Owned", SortName: "Owned"}
+	if err := f.authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	s := &models.Series{ForeignID: "OL-OWN-S", Title: "Shared Series"}
+	if err := f.series.Create(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+	// books.owner_user_id carries a foreign key, so the owners have to exist.
+	alice, err := f.users.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-alice", "alice", "alice@example.com", "Alice", "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := f.users.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-bob", "bob", "bob@example.com", "Bob", "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mine := &models.Book{ForeignID: "OL-OWN-B1", AuthorID: author.ID, Title: "Mine", Status: models.BookStatusWanted, OwnerUserID: alice.ID}
+	theirs := &models.Book{ForeignID: "OL-OWN-B2", AuthorID: author.ID, Title: "Theirs", Status: models.BookStatusWanted, OwnerUserID: bob.ID}
+	for _, b := range []*models.Book{mine, theirs} {
+		if err := f.books.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.series.LinkBook(ctx, s.ID, b.ID, "1", true); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page, _, err := f.series.ListPageWithBooksForUser(ctx, alice.ID, 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 1 {
+		t.Fatalf("page = %d series, want 1", len(page))
+	}
+	if len(page[0].Books) != 1 || page[0].Books[0].BookID != mine.ID {
+		t.Errorf("alice sees %+v, want only their own book", page[0].Books)
+	}
+
+	unscoped, _, err := f.series.ListPageWithBooksForUser(ctx, 0, 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unscoped) != 1 || len(unscoped[0].Books) != 2 {
+		t.Errorf("unscoped page = %d series with %d books, want 1 series with 2 books", len(unscoped), len(unscoped[0].Books))
+	}
+}


### PR DESCRIPTION
`GET /series` returned every series with every linked book, so the response was proportional to the whole catalogue. Authors and books already had `ListPageFiltered` and the `{items,total,limit,offset}` envelope; series never did.

Pagination is opt-in. Pass `limit` and/or `offset` and you get the envelope, pass neither and the response stays the bare array it has always been. Authors and books took the envelope unconditionally and that broke every client; there is no reason to repeat it here when the only in-tree consumer (`web/src/pages/SeriesPage.tsx`, via `listSeries` in `web/src/api/series.ts`) still asks for the whole collection. **Follow-up:** switch that page to paged loads, then make the envelope the default.

`ListPageWithBooksForUser` runs two queries rather than one windowed JOIN, on purpose: `LIMIT` applies to result rows and the JOIN emits one row per book, so a single query would cut a series' book list in half at the page boundary. The first query picks the page's series ids by title, the second is the same JOIN the unpaginated path uses, restricted to those ids. Both paths now go through one private `listWithBooksForUser`, so the `#1457` owner predicate cannot drift between them. Total counts series rows unscoped, matching the unpaginated path, since a series is global while its books are not.

Closes #2345

## Tests

`internal/db/series_page_test.go`:
- `TestListPageWithBooksForUser_PagesInTitleOrder` walks 7 series in pages of 3, asserts no gaps or repeats, the total on each page, and an empty page past the end.
- `TestListPageWithBooksForUser_KeepsBooksWholePerSeries` is the guard on the two-query shape: `limit=1` on a 5 book series must return all 5 books.
- `TestListPageWithBooksForUser_ScopesBooksByOwner` asserts the paged path applies the same per-user book predicate as the unpaginated one.

`internal/api/series_pagination_test.go`:
- `TestSeriesList_DefaultStaysABareArray` is the compatibility guard for the current frontend.
- `TestSeriesList_Paginated` covers the envelope, offset-only opting in at the default limit, an empty (not null) items array past the end, and the max-limit clamp.

Ran:

```
go build ./...                                        ok
go vet ./internal/api/... ./internal/db/...           ok
go test ./internal/db/... ./internal/api/... -count=1 ok (db 24.5s, api 129.6s)
golangci-lint run ./internal/api/... ./internal/db/... 0 issues
```

## Sequencing

Next minor. Independent of everything else in this batch, no merge order constraint. Unblocks the frontend follow-up that switches the Series page to paged loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
