### PR TITLE
fix(httpsec): guard the Prowlarr and OIDC dials, refuse proxied SVG (#2353, #2355)

### DIFF
--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -95,6 +95,32 @@ func imageProxyTransport() http.RoundTripper {
 	}
 }
 
+// allowedImageContentType reports whether a Content-Type may be proxied back
+// to the browser. It is "any image/* except SVG".
+//
+// SVG is the exception because it is a scripting document, not a picture:
+// /api/v1/images is same-origin with the app, so a proxied SVG is served from
+// Bindery's own origin. Today the CSP's script-src 'self' and the blanket
+// nosniff header (internal/api/securityheaders.go) mean an inline script in
+// one does not execute, so this is defence in depth rather than a live hole
+// (#2355) — but the whole point is that it stops depending on a CSP nobody
+// will remember to re-check the next time it is edited.
+//
+// Nothing legitimate is lost: cover art from every metadata provider is JPEG,
+// PNG or WebP.
+func allowedImageContentType(ct string) bool {
+	// Strip any parameters ("image/svg+xml; charset=utf-8") and normalise, so
+	// the refusal cannot be sidestepped with a charset or unusual casing.
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	if !strings.HasPrefix(ct, "image/") {
+		return false
+	}
+	return ct != "image/svg+xml" && ct != "image/svg"
+}
+
 // Serve handles GET /api/v1/images?url=<encoded-external-url>.
 func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 	raw := r.URL.Query().Get("url")
@@ -121,6 +147,13 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 		ct, _ := os.ReadFile(ctFile) //nolint:gosec // #nosec -- path derived from sha256(url), not user input
 		if len(ct) == 0 {
 			ct = []byte("image/jpeg")
+		}
+		// Apply the same content-type rule the fetch path applies, so an entry
+		// cached before the svg refusal landed is not still served from disk
+		// for the rest of its 30-day TTL (#2355).
+		if !allowedImageContentType(string(ct)) {
+			http.Error(w, "upstream response is not an image", http.StatusBadGateway)
+			return
 		}
 		w.Header().Set("Content-Type", string(ct))
 		w.Header().Set("Cache-Control", "public, max-age=2592000")
@@ -151,7 +184,7 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ct := resp.Header.Get("Content-Type")
-	if !strings.HasPrefix(ct, "image/") {
+	if !allowedImageContentType(ct) {
 		http.Error(w, "upstream response is not an image", http.StatusBadGateway)
 		return
 	}

--- a/internal/api/imageproxy_test.go
+++ b/internal/api/imageproxy_test.go
@@ -146,6 +146,91 @@ func TestImageProxy_NonImageRejected(t *testing.T) {
 	}
 }
 
+// TestImageProxy_SVGRejected covers #2355. SVG is a scripting document, and
+// /api/v1/images serves it same-origin with the app, so it does not get to
+// count as an image however the upstream labels it. Nothing legitimate is
+// lost: provider cover art is JPEG, PNG or WebP.
+func TestImageProxy_SVGRejected(t *testing.T) {
+	for _, ct := range []string{"image/svg+xml", "IMAGE/SVG+XML", "image/svg+xml; charset=utf-8"} {
+		t.Run(ct, func(t *testing.T) {
+			upstream := newFakeUpstream(ct, []byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`), http.StatusOK)
+			defer upstream.Close()
+
+			dir := t.TempDir()
+			h := newTestHandler(dir, upstream)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+upstream.URL+"/cover.svg", nil)
+			rr := httptest.NewRecorder()
+			h.Serve(rr, req)
+			if rr.Code != http.StatusBadGateway {
+				t.Errorf("status = %d, want 502 for %q", rr.Code, ct)
+			}
+
+			// A refused response must not leave anything behind for the cache
+			// path to serve on the next request.
+			entries, err := os.ReadDir(filepath.Join(dir, "image-cache"))
+			if err == nil && len(entries) > 0 {
+				t.Errorf("refused svg left %d cache entries behind", len(entries))
+			}
+		})
+	}
+}
+
+// TestImageProxy_CacheHitSVGRejected checks the other half: an SVG cached
+// before the refusal landed must not keep being served for the rest of its
+// 30-day TTL.
+func TestImageProxy_CacheHitSVGRejected(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "image-cache")
+
+	const rawURL = "https://example.com/legacy.svg"
+	sum := sha256.Sum256([]byte(rawURL))
+	key := fmt.Sprintf("%x", sum)
+	shardDir := filepath.Join(cacheDir, key[:2])
+	if err := os.MkdirAll(shardDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shardDir, key), []byte("<svg/>"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shardDir, key+".ct"), []byte("image/svg+xml"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewImageProxyHandler(dir)
+	h.validateURL = func(_ string) error { return nil }
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+rawURL, nil)
+	rr := httptest.NewRecorder()
+	h.Serve(rr, req)
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 for a cached svg", rr.Code)
+	}
+}
+
+// TestAllowedImageContentType pins the rule the two paths share.
+func TestAllowedImageContentType(t *testing.T) {
+	cases := map[string]bool{
+		"image/jpeg":                   true,
+		"image/png":                    true,
+		"image/webp":                   true,
+		"image/jpeg; charset=binary":   true,
+		"IMAGE/PNG":                    true,
+		"image/svg+xml":                false,
+		"image/svg+xml; charset=utf-8": false,
+		"image/svg":                    false,
+		"IMAGE/SVG+XML":                false,
+		"text/html":                    false,
+		"":                             false,
+		"application/xml":              false,
+	}
+	for ct, want := range cases {
+		if got := allowedImageContentType(ct); got != want {
+			t.Errorf("allowedImageContentType(%q) = %v, want %v", ct, got, want)
+		}
+	}
+}
+
 // TestImageProxy_UpstreamNon200 ensures a non-200 from upstream returns 502.
 func TestImageProxy_UpstreamNon200(t *testing.T) {
 	upstream := newFakeUpstream("image/jpeg", nil, http.StatusNotFound)

--- a/internal/auth/oidc/discover.go
+++ b/internal/auth/oidc/discover.go
@@ -46,6 +46,33 @@ func DiscoverMaxRedirects(n int) DiscoverOption {
 	}
 }
 
+// discoverTransport returns the RoundTripper the discovery client should use
+// under policy. It mirrors the image proxy and notifier transports: on the
+// direct path it clones the shared proxy transport and installs a per-dial
+// SSRF re-validation, and when an outbound proxy is configured it hands back
+// the shared transport unchanged, because the dial then targets the
+// operator-trusted proxy rather than the IdP and a per-dial check would reject
+// a LAN or loopback proxy.
+//
+// A nil policy returns nil, which http.Client reads as "use the default
+// transport". That is the documented no-guardrails mode DiscoverPolicy exists
+// to opt out of, used by in-process tests against httptest.NewServer.
+func discoverTransport(policy *httpsec.Policy) http.RoundTripper {
+	if policy == nil {
+		return nil
+	}
+	base := httpsec.DefaultProxyTransport()
+	if httpsec.ProxyFunc() != nil {
+		return base
+	}
+	if t, ok := base.(*http.Transport); ok {
+		c := t.Clone()
+		c.DialContext = httpsec.NewDialContext(*policy)
+		return c
+	}
+	return &http.Transport{DialContext: httpsec.NewDialContext(*policy)}
+}
+
 // DiscoveryDoc is the subset of the OIDC provider metadata document that the
 // Settings UI's "Test discovery" button surfaces. The fields here match the
 // OpenID Connect Discovery 1.0 spec (§4.2) — only the ones admins need to see
@@ -105,6 +132,13 @@ func Discover(ctx context.Context, issuer string, opts ...DiscoverOption) (*Disc
 
 	client := &http.Client{
 		Timeout: 8 * time.Second,
+		// Per-dial SSRF re-validation on the direct path (#2353). The up-front
+		// check in the handler and the per-hop check below both resolve the
+		// hostname; a name that answers with a public address for those and a
+		// private one for the connect would otherwise slip past both. Nil when
+		// no policy is installed, which is http.Client's "use the default
+		// transport" and keeps the in-process tests pointing at loopback.
+		Transport: discoverTransport(cfg.policy),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			// Cap hop count to prevent redirect-loop / blow-up abuse. Default
 			// 5 mirrors Go's stdlib default, but we set it explicitly so the

--- a/internal/auth/oidc/discover_transport_test.go
+++ b/internal/auth/oidc/discover_transport_test.go
@@ -1,0 +1,57 @@
+package oidc
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/httpsec"
+)
+
+// A caller with no DiscoverPolicy is the documented no-guardrails mode (an
+// in-process test pointed at httptest.NewServer). It must keep getting the
+// default transport, which http.Client reads a nil RoundTripper as.
+func TestDiscoverTransport_NilPolicyKeepsDefault(t *testing.T) {
+	if got := discoverTransport(nil); got != nil {
+		t.Errorf("discoverTransport(nil) = %#v, want nil (http.Client's default transport)", got)
+	}
+}
+
+// TestDiscoverTransport_DialGuardWhenDirect covers #2353. Discover validated
+// the issuer up front and re-validated every redirect hop, but dialled without
+// re-checking, so a name answering with a public address for the lookups and a
+// private one for the connect got through both.
+func TestDiscoverTransport_DialGuardWhenDirect(t *testing.T) {
+	t.Cleanup(func() { _, _ = httpsec.ConfigureOutboundProxy("", "", true) })
+	if _, err := httpsec.ConfigureOutboundProxy("", "", true); err != nil {
+		t.Fatalf("ConfigureOutboundProxy reset: %v", err)
+	}
+
+	policy := httpsec.PolicyLAN
+	got := discoverTransport(&policy)
+	tr, ok := got.(*http.Transport)
+	if !ok {
+		t.Fatalf("discoverTransport = %T, want *http.Transport on the direct path", got)
+	}
+	if tr.DialContext == nil {
+		t.Error("direct-path transport must install a DialContext (the rebind re-check)")
+	}
+	if got == httpsec.DefaultProxyTransport() {
+		t.Error("direct-path transport must be a clone, not the shared default transport")
+	}
+}
+
+// With an outbound proxy configured the dial targets the proxy rather than the
+// IdP, so the per-dial re-check is skipped and the shared transport is returned
+// unchanged. Without this a loopback or LAN proxy would be rejected by the
+// guard meant for the IdP.
+func TestDiscoverTransport_NoDialGuardWhenProxied(t *testing.T) {
+	t.Cleanup(func() { _, _ = httpsec.ConfigureOutboundProxy("", "", true) })
+	if _, err := httpsec.ConfigureOutboundProxy("http://127.0.0.1:0", "", true); err != nil {
+		t.Fatalf("ConfigureOutboundProxy: %v", err)
+	}
+
+	policy := httpsec.PolicyLAN
+	if got := discoverTransport(&policy); got != httpsec.DefaultProxyTransport() {
+		t.Errorf("with a proxy configured, discoverTransport must return the shared proxy transport unchanged; got %#v", got)
+	}
+}

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vavallee/bindery/internal/httpsec"
@@ -38,8 +39,54 @@ func NewWithTimeout(baseURL, apiKey string, timeout time.Duration) *Client {
 		// to the same Prowlarr/Jackett hosts. Without the proxy transport, a
 		// Prowlarr reachable only through the configured egress proxy fails on
 		// the sync/test path while indexer searches succeed (#proxy-bypass).
-		http: &http.Client{Timeout: timeout, Transport: httpsec.DefaultProxyTransport()},
+		http: &http.Client{Timeout: timeout, Transport: sharedGuardedTransport()},
 	}
+}
+
+var (
+	guardedTransportOnce   sync.Once
+	guardedTransportShared http.RoundTripper
+)
+
+// sharedGuardedTransport returns the process-wide Prowlarr transport, built
+// once so every client keeps sharing a single connection pool the way they did
+// when they all held httpsec.DefaultProxyTransport directly. A syncer builds a
+// client per run, and a pool per run is not something to trade for the dial
+// guard.
+//
+// Building it once is safe because ConfigureOutboundProxy runs at startup,
+// before any outbound client is constructed, so the proxy decision baked in
+// here is the final one.
+func sharedGuardedTransport() http.RoundTripper {
+	guardedTransportOnce.Do(func() { guardedTransportShared = guardedTransport() })
+	return guardedTransportShared
+}
+
+// guardedTransport mirrors the image proxy and notifier transports. On the
+// direct path it installs a per-dial SSRF re-validation, closing the DNS-rebind
+// TOCTOU between the up-front ValidateOutboundURL in the Prowlarr handlers
+// (internal/api/prowlarr.go) and the connect that actually happens (#2353).
+//
+// When an outbound proxy is configured the dial targets the operator-trusted
+// proxy rather than the Prowlarr host, so a per-dial check would re-validate
+// the proxy's own address and reject a LAN or loopback proxy. In that shape we
+// return the shared proxy transport unchanged and the up-front validation
+// carries the guard, which is all a rebind check could see past a proxy anyway.
+//
+// PolicyLANLoopback matches what the create and update handlers validate
+// against: a Prowlarr on the LAN, or on the Bindery host itself, is the normal
+// deployment.
+func guardedTransport() http.RoundTripper {
+	base := httpsec.DefaultProxyTransport()
+	if httpsec.ProxyFunc() != nil {
+		return base
+	}
+	if t, ok := base.(*http.Transport); ok {
+		c := t.Clone()
+		c.DialContext = httpsec.NewDialContext(httpsec.PolicyLANLoopback)
+		return c
+	}
+	return &http.Transport{DialContext: httpsec.NewDialContext(httpsec.PolicyLANLoopback)}
 }
 
 // remoteIndexer is the shape of each element in GET /api/v1/indexer.

--- a/internal/prowlarr/proxy_transport_test.go
+++ b/internal/prowlarr/proxy_transport_test.go
@@ -1,6 +1,7 @@
 package prowlarr
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -10,12 +11,56 @@ import (
 // The Prowlarr client must route through the shared outbound-proxy transport
 // like the newznab search client that talks to the same hosts, so sync/test
 // calls honor BINDERY_OUTBOUND_PROXY instead of dialing Prowlarr directly.
-func TestNewWithTimeout_UsesProxyTransport(t *testing.T) {
-	c := NewWithTimeout("http://prowlarr:9696", "key", 30*time.Second)
-	if c.http.Transport != httpsec.DefaultProxyTransport() {
-		t.Errorf("NewWithTimeout must use the shared proxy transport; got %#v", c.http.Transport)
+// With a proxy configured the transport is handed back untouched: the dial
+// targets the operator-trusted proxy, and a per-dial SSRF re-check there would
+// reject a LAN or loopback proxy and break every sync.
+func TestGuardedTransport_UsesProxyTransportWhenProxied(t *testing.T) {
+	t.Cleanup(func() { _, _ = httpsec.ConfigureOutboundProxy("", "", true) })
+
+	if _, err := httpsec.ConfigureOutboundProxy("http://127.0.0.1:0", "", true); err != nil {
+		t.Fatalf("ConfigureOutboundProxy: %v", err)
 	}
-	if New("http://prowlarr:9696", "key").http.Transport != httpsec.DefaultProxyTransport() {
-		t.Error("New must use the shared proxy transport")
+
+	if got := guardedTransport(); got != httpsec.DefaultProxyTransport() {
+		t.Errorf("with a proxy configured, guardedTransport() must return the shared proxy transport unchanged; got %#v", got)
+	}
+}
+
+// TestGuardedTransport_DialGuardWhenDirect covers #2353. On the direct path the
+// transport carries the per-dial SSRF re-check, which is what closes the
+// rebind window between the handler's ValidateOutboundURL and the connect.
+func TestGuardedTransport_DialGuardWhenDirect(t *testing.T) {
+	t.Cleanup(func() { _, _ = httpsec.ConfigureOutboundProxy("", "", true) })
+	if _, err := httpsec.ConfigureOutboundProxy("", "", true); err != nil {
+		t.Fatalf("ConfigureOutboundProxy reset: %v", err)
+	}
+
+	got := guardedTransport()
+	tr, ok := got.(*http.Transport)
+	if !ok {
+		t.Fatalf("guardedTransport() = %T, want *http.Transport on the direct path", got)
+	}
+	if tr.DialContext == nil {
+		t.Error("direct-path transport must install a DialContext (the rebind re-check)")
+	}
+	if got == httpsec.DefaultProxyTransport() {
+		t.Error("direct-path transport must be a clone, not the shared default transport")
+	}
+	if tr.Proxy == nil {
+		t.Error("the clone must keep the proxy resolver so BINDERY_OUTBOUND_PROXY still applies")
+	}
+}
+
+// Every client shares one transport, and therefore one connection pool. A
+// syncer builds a client per run, so a fresh pool per construction would be a
+// real cost for the dial guard.
+func TestNewWithTimeout_SharesOneTransport(t *testing.T) {
+	a := NewWithTimeout("http://prowlarr:9696", "key", 30*time.Second)
+	b := New("http://prowlarr:9696", "key")
+	if a.http.Transport != b.http.Transport {
+		t.Errorf("clients must share one transport; got %#v and %#v", a.http.Transport, b.http.Transport)
+	}
+	if a.http.Transport == nil {
+		t.Error("client transport must not be nil (that would bypass the proxy and the dial guard)")
 	}
 }


### PR DESCRIPTION
Two outbound clients validated the URL up front and then dialled without re-checking the address they connected to, so a name that answers with a public IP for the validation lookup and a private one for the dial got through. Both now do what `imageProxyTransport` and the notifier's `guardedTransport` already do: clone the shared proxy transport and install `httpsec.NewDialContext` on the direct path, and hand back the shared transport untouched when an outbound proxy is configured, because the dial then targets the operator-trusted proxy rather than the upstream host.

* Prowlarr gets `PolicyLANLoopback`, the policy `internal/api/prowlarr.go` already validates against. The transport is built once behind a `sync.Once` so every client keeps sharing one connection pool: a syncer builds a client per run, and a pool per run is not a fair trade for the guard.
* Discovery hangs it off the existing `DiscoverPolicy` option, so a caller with no policy (the in-process tests against `httptest.NewServer`) keeps the default transport and today's behaviour.

Second half, in the same PR because it is the same file family and the same class of hardening: the image proxy no longer accepts `image/svg+xml`. SVG is a scripting document and `/api/v1/images` serves it same-origin with the app. The CSP's `script-src 'self'` plus nosniff keep it inert today, which is what makes this hardening and not a fix, and the point is precisely that it stops depending on a CSP nobody will remember to re-check. The rule is a shared helper applied on both the fetch path and the cache-hit path, so an SVG cached before this lands is not served for the rest of its 30-day TTL. Cover art from every provider is JPEG, PNG or WebP, so nothing legitimate is lost.

Closes #2353
Closes #2355

### Testing

* `go test -count=1 ./internal/api/ ./internal/prowlarr/ ./internal/auth/oidc/` all green.
* `TestImageProxy_SVGRejected` and `TestImageProxy_CacheHitSVGRejected` are the behaviour tests. With `allowedImageContentType` forced back to the old `image/` prefix rule they fail with `status = 200, want 502` and `refused svg left 1 cache entries behind`; they pass with the rule in place. `TestAllowedImageContentType` pins the parameter and casing handling.
* Transport coverage is `TestGuardedTransport_DialGuardWhenDirect` / `_UsesProxyTransportWhenProxied` (Prowlarr) and `TestDiscoverTransport_DialGuardWhenDirect` / `_NoDialGuardWhenProxied` / `_NilPolicyKeepsDefault` (discovery). These assert structure rather than a caught rebind, which no unit test can stage without controlling DNS. The existing `TestNewWithTimeout_UsesProxyTransport` asserted the Prowlarr client held `DefaultProxyTransport` itself, which is no longer true on the direct path; it is replaced by the proxied-path case plus `TestNewWithTimeout_SharesOneTransport` for the pool invariant.
* `go vet` and `golangci-lint run` clean on all three packages.

### Sequencing

Independent of the rest of the security sweep, and of the S4 migration PR. Next minor. Whoever picks up #2036 (link-local Prowlarr behind an opt-in) should land after this so the dial guard and the URL guard end up on the same policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
