### PR TITLE
fix(http): cap six uncapped reads of third party responses (#2357)

### DIFF
--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -32,6 +32,28 @@ var categoryNameKey = regexp.MustCompile(`^Category\d+\.Name$`)
 // a category's other fields (DestDir) can be located by the same index.
 var categoryIndexKey = regexp.MustCompile(`^Category(\d+)\.`)
 
+// maxRPCResponseBytes caps an NZBGet JSON-RPC reply. history and listgroups
+// return the whole set in one document, the same shape that made a 1 MiB cap
+// on Transmission's torrent-get too small for a large session (#1524), so this
+// matches the 64 MiB the Transmission and rTorrent clients settled on
+// afterwards. Before this the success path read the body with no cap at all
+// (#2357).
+const maxRPCResponseBytes int64 = 64 << 20
+
+// readRPCBody reads an RPC response under maxRPCResponseBytes. Unlike a bare
+// io.LimitReader it reports an over-limit body as an explicit error rather
+// than a half-JSON document that fails to parse (#1524).
+func readRPCBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxRPCResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxRPCResponseBytes {
+		return nil, fmt.Errorf("NZBGet RPC response exceeded %d bytes — too many items to fetch in one request", maxRPCResponseBytes)
+	}
+	return body, nil
+}
+
 // Client interacts with the NZBGet JSON-RPC API.
 type Client struct {
 	baseURL   string
@@ -477,7 +499,7 @@ func (c *Client) call(ctx context.Context, method string, params []any, target a
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
-	raw, err := io.ReadAll(resp.Body)
+	raw, err := readRPCBody(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -59,6 +59,16 @@ var hashPollTimeout = 30 * time.Second
 // uploading it to qBittorrent.
 var maxTorrentFileBytes int64 = 50 << 20
 
+// maxAPIResponseBytes caps a qBittorrent WebUI API reply. /api/v2/torrents/info
+// returns every torrent in one document, the same shape that made a 1 MiB cap
+// on Transmission's torrent-get too small for a 5000 torrent session (#1524),
+// so this matches the 64 MiB the Transmission and rTorrent clients settled on
+// afterwards. Before this the success path read the body with no cap at all
+// (#2357). readLimited turns an over-limit reply into a clear error rather
+// than a truncated document that fails to parse. A var, like
+// maxTorrentFileBytes, so tests can lower it instead of allocating 64 MiB.
+var maxAPIResponseBytes int64 = 64 << 20
+
 // Client interacts with the qBittorrent WebUI API v2.
 // Authentication is cookie-based: Login() obtains a SID cookie which is
 // stored in the embedded http.Client's cookie jar and sent automatically on
@@ -592,7 +602,7 @@ func (c *Client) fetchTorrentContent(ctx context.Context, rawURL string) (*fetch
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("indexer returned HTTP %d", resp.StatusCode)
 		}
-		data, err := readLimited(resp.Body, maxTorrentFileBytes)
+		data, err := readLimited(resp.Body, maxTorrentFileBytes, "torrent response")
 		if err != nil {
 			return nil, err
 		}
@@ -612,13 +622,18 @@ func (c *Client) validateTorrentFetchURL(raw string) error {
 	return c.validateTorrentURL(raw)
 }
 
-func readLimited(r io.Reader, maxBytes int64) ([]byte, error) {
+// readLimited reads at most maxBytes from r. Unlike a bare io.LimitReader it
+// reports an over-limit body as an explicit error instead of handing back a
+// truncated document that fails to parse further down (the failure mode of
+// #1524). what names the thing being read so the error says which read blew
+// the cap.
+func readLimited(r io.Reader, maxBytes int64, what string) ([]byte, error) {
 	data, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
 	if err != nil {
 		return nil, err
 	}
 	if int64(len(data)) > maxBytes {
-		return nil, fmt.Errorf("torrent response exceeds %d bytes", maxBytes)
+		return nil, fmt.Errorf("%s exceeds %d bytes", what, maxBytes)
 	}
 	return data, nil
 }
@@ -857,7 +872,7 @@ func (c *Client) get(ctx context.Context, path string) ([]byte, error) {
 			body2, _ := io.ReadAll(io.LimitReader(resp2.Body, 512))
 			return nil, fmt.Errorf("HTTP %d: %s", resp2.StatusCode, string(body2))
 		}
-		return io.ReadAll(resp2.Body)
+		return readLimited(resp2.Body, maxAPIResponseBytes, "qBittorrent API response")
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -865,5 +880,5 @@ func (c *Client) get(ctx context.Context, path string) ([]byte, error) {
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
-	return io.ReadAll(resp.Body)
+	return readLimited(resp.Body, maxAPIResponseBytes, "qBittorrent API response")
 }

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -1020,6 +1020,37 @@ func TestAddTorrent_TorrentURL_RedirectToMagnetUsesURLForm(t *testing.T) {
 	}
 }
 
+// TestGetTorrents_OversizedAPIResponseIsRejected covers #2357. Client.get read
+// the success body with a bare io.ReadAll, so a qBittorrent that streamed
+// until the client timeout could make Bindery hold the whole reply. The cap is
+// lowered here rather than served 64 MiB; what matters is that going over
+// surfaces as a named error instead of a truncated document that fails to
+// unmarshal, which is how #1524 presented on the Transmission side.
+func TestGetTorrents_OversizedAPIResponseIsRejected(t *testing.T) {
+	orig := maxAPIResponseBytes
+	maxAPIResponseBytes = 32
+	t.Cleanup(func() { maxAPIResponseBytes = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte(`[{"hash":"` + strings.Repeat("a", 4096) + `"}]`))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	_, err := c.GetTorrents(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected an error for an over-limit qBittorrent API response")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected the cap to be named in the error, got: %v", err)
+	}
+}
+
 func TestAddTorrent_TorrentURL_OversizedResponseDoesNotCallQbitAdd(t *testing.T) {
 	orig := maxTorrentFileBytes
 	maxTorrentFileBytes = 8

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -100,6 +100,13 @@ var (
 	transportBuildCount atomic.Int64
 )
 
+// maxResponseBytes caps how much of an indexer response the client will read.
+// A Torznab feed is the largest thing on this path and 32 MiB is generous for
+// one; it was already the literal fetchXML used, and Probe's caps decode now
+// shares it rather than reading off the socket uncapped (#2357). A var so
+// tests can lower it instead of serving 32 MiB.
+var maxResponseBytes int64 = 32 << 20
+
 func sharedTransportInstance() *http.Transport {
 	sharedTransportOnce.Do(func() {
 		transportBuildCount.Add(1)
@@ -694,7 +701,11 @@ func (c *Client) Probe(ctx context.Context) ProbeResult {
 	}
 
 	var caps capsResponse
-	if err := xml.NewDecoder(resp.Body).Decode(&caps); err != nil {
+	// Capped like fetchXML below: a caps document is a few KiB in practice, so
+	// the same 32 MiB ceiling the feed path uses is generous here, and without
+	// it only the client timeout bounded what a hostile host could stream into
+	// the decoder (#2357).
+	if err := xml.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&caps); err != nil {
 		result.Error = fmt.Sprintf("parse caps: %v", err)
 		return result
 	}
@@ -840,7 +851,7 @@ func (c *Client) fetchXML(ctx context.Context, rawURL string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("read indexer response: %w", err)
 	}

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -679,6 +679,38 @@ func TestProbe_InvalidXML(t *testing.T) {
 	}
 }
 
+// TestProbe_OversizedCapsBodyIsCapped covers #2357. Probe decoded the caps
+// document straight off the socket, so only the client timeout bounded what a
+// hostile indexer could stream into the XML decoder while fetchXML on the same
+// client capped at 32 MiB. The cap is lowered here rather than served 32 MiB.
+// A truncated document is a parse error, which is the outcome the probe
+// already reports for a malformed caps body, so the caller sees "parse caps"
+// rather than a hang.
+func TestProbe_OversizedCapsBodyIsCapped(t *testing.T) {
+	orig := maxResponseBytes
+	maxResponseBytes = 64
+	t.Cleanup(func() { maxResponseBytes = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		// Valid XML, far past the cap. Uncapped this decodes cleanly.
+		_, _ = w.Write([]byte(`<caps><categories>` + strings.Repeat(`<category id="7020"/>`, 4096) + `</categories></caps>`))
+	}))
+	defer srv.Close()
+
+	c := testNew(srv.URL, "testkey")
+	result := c.Probe(context.Background())
+	if result.Error == "" {
+		t.Fatal("expected the over-limit caps body to fail rather than decode")
+	}
+	if !strings.Contains(result.Error, "parse caps") {
+		t.Errorf("expected a parse caps error, got %q", result.Error)
+	}
+	if result.Categories != 0 {
+		t.Errorf("expected no categories from a truncated document, got %d", result.Categories)
+	}
+}
+
 // TestProbe_NetworkError verifies that connection failures (server closed
 // before the call) populate Error and leave Status zero.
 func TestProbe_NetworkError(t *testing.T) {

--- a/internal/metadata/dnb/client.go
+++ b/internal/metadata/dnb/client.go
@@ -32,6 +32,13 @@ const (
 	sruBase      = "https://services.dnb.de/sru/dnb"
 	idPrefix     = "dnb:"
 	recordSchema = "MARC21-xml"
+	// maxResponseBytes caps the SRU document handed to the XML decoder. The
+	// request bounds itself with maximumRecords so a well-behaved response is
+	// far under this; the cap is there because the decode read straight off
+	// the socket with no limit, leaving only the 15 s client timeout to bound
+	// what a misbehaving host could make Bindery hold (#2357). Same ceiling as
+	// the newznab XML path.
+	maxResponseBytes = 32 << 20
 )
 
 // Client implements metadata.Provider for DNB via the public SRU endpoint.
@@ -246,7 +253,7 @@ func (c *Client) sruQuery(ctx context.Context, cql string, maxRecords int) ([]ma
 	}
 
 	var result sruResponse
-	if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := xml.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode SRU response: %w", err)
 	}
 

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -16,6 +16,30 @@ import (
 	"github.com/vavallee/bindery/internal/useragent"
 )
 
+// maxResponseBytes caps a Prowlarr API reply. GET /api/v1/indexer returns
+// every configured indexer with its full definition in one document, so the
+// cap has to be generous — the 1 MiB cap on Transmission's torrent-get was too
+// small for exactly this shape of response (#1524) — but it must exist: the
+// success path here read the body with no cap at all, so only the client
+// timeout bounded how much a misbehaving host could make Bindery hold (#2357).
+// 32 MiB matches the cap the newznab client uses on indexer feeds. A var so
+// tests can lower it instead of allocating 32 MiB.
+var maxResponseBytes int64 = 32 << 20
+
+// readCapped reads a Prowlarr response under maxResponseBytes. Unlike a bare
+// io.LimitReader it reports an over-limit body as an explicit error rather
+// than a truncated document that fails to decode (#1524).
+func readCapped(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxResponseBytes {
+		return nil, fmt.Errorf("prowlarr response exceeded %d bytes", maxResponseBytes)
+	}
+	return body, nil
+}
+
 // Client calls the Prowlarr HTTP API.
 type Client struct {
 	baseURL string
@@ -439,5 +463,5 @@ func (c *Client) get(ctx context.Context, path string) ([]byte, error) {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
-	return io.ReadAll(resp.Body)
+	return readCapped(resp.Body)
 }

--- a/internal/prowlarr/client_test.go
+++ b/internal/prowlarr/client_test.go
@@ -92,6 +92,62 @@ func TestFetchIndexers_HappyPath(t *testing.T) {
 	}
 }
 
+// TestGet_OversizedResponseIsRejected covers #2357. The success path used a
+// bare io.ReadAll, so a configured Prowlarr that streamed until the client
+// timeout could make Bindery hold the whole thing. The cap is lowered here
+// rather than served 32 MiB; what matters is that going over is an error and
+// not a silently truncated document.
+func TestGet_OversizedResponseIsRejected(t *testing.T) {
+	orig := maxResponseBytes
+	maxResponseBytes = 16
+	t.Cleanup(func() { maxResponseBytes = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":1,"name":"` + strings.Repeat("x", 4096) + `"}]`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "secret")
+	_, err := c.FetchIndexers(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for an over-limit Prowlarr response")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Errorf("expected the cap to be named in the error, got: %v", err)
+	}
+}
+
+// TestGet_ResponseAtTheCapStillDecodes is the boundary case: a body exactly at
+// the limit is valid, not an error. Reading maxResponseBytes+1 and comparing
+// on > is what makes that true.
+func TestGet_ResponseAtTheCapStillDecodes(t *testing.T) {
+	body := `[{"id":1,"name":"T","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`
+	orig := maxResponseBytes
+	maxResponseBytes = int64(len(body))
+	t.Cleanup(func() { maxResponseBytes = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/indexer" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "secret")
+	infos, err := c.FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("a body exactly at the cap must decode: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 indexer, got %d", len(infos))
+	}
+}
+
 func TestFetchIndexers_AppliesApplicationCategoryScopes(t *testing.T) {
 	indexerBody := `[
 		{


### PR DESCRIPTION
Four bare `io.ReadAll(resp.Body)` calls and two XML decodes read straight off the socket with no size limit, so only the client timeout bounded how much a configured host could make Bindery hold. Every one of them sits next to sibling code in the same file that already caps, so this is drift rather than a decision. Same defect #470 fixed for the Hardcover client, in the six places it missed.

| Site | Cap | Where the number comes from |
|---|---|---|
| `prowlarr/client.go` `Client.get` | 32 MiB | the newznab feed path's existing literal |
| `newznab/client.go` `Probe` caps decode | 32 MiB | `fetchXML` in the same file, now sharing one named constant |
| `dnb/client.go` `Search` SRU decode | 32 MiB | same, and the request already bounds itself with `maximumRecords` |
| `qbittorrent/client.go` `Client.get` (both the first attempt and the post re-login retry) | 64 MiB | `maxRPCResponseBytes` in the Transmission and rTorrent clients |
| `nzbget/client.go` `Client.call` | 64 MiB | same |

The last two fetch the whole torrent list and the whole history in one document, which is the shape that made a 1 MiB cap too small for Transmission on a 5000 torrent session (#1524). Capping too tightly is the actual risk here, so those two take the number the repo already settled on after that report rather than the 50 MiB their own files use for a single NZB or torrent file.

The three read paths that could plausibly reach their cap report going over as a named error rather than handing back a truncated document that fails to parse, which is how #1524 presented to the user. qbittorrent's existing `readLimited` grew a label parameter so the error says which read blew the cap instead of always saying "torrent response".

Closes #2357

## Tests

Three new tests, one per class of read. Each lowers the cap through the package var rather than serving tens of MiB, following the existing `TestAddTorrent_TorrentURL_OversizedResponseDoesNotCallQbitAdd`. All three fail on `main`, verified by reverting each fix in place:

| Test | Failure on main |
|---|---|
| `prowlarr.TestGet_OversizedResponseIsRejected` | no error at all, the whole body was read and decoded |
| `qbittorrent.TestGetTorrents_OversizedAPIResponseIsRejected` | `expected an error for an over-limit qBittorrent API response` |
| `newznab.TestProbe_OversizedCapsBodyIsCapped` | `expected the over-limit caps body to fail rather than decode` |

`prowlarr.TestGet_ResponseAtTheCapStillDecodes` pins the boundary: a body exactly at the limit is valid, which is what the read-one-extra-byte-and-compare-on-greater-than shape buys.

Ran:

```
go build ./...                                                            ok
go vet    <the five changed packages>                                     ok
go test   <the five changed packages>                                     ok (prowlarr 2.4s, qbittorrent 3.6s, nzbget 4.3s, newznab 2.4s, dnb 0.0s)
golangci-lint run <the five changed packages>                             0 issues
```

## Sequencing

Independent, and not patch release material on its own: reaching any of these needs a host the operator already configured and trusted. It can ride the next minor. Merge it after the S1/S2/S5 patch (#2384) only because that one is time sensitive, not because they conflict — the two PRs share no file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
