### PR TITLE
fix(indexer): search localized and original book titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Clean-room Go rewrite, modern React UI, MIT-licensed, actively developed.
 
 **Search & downloads**
 - Newznab + Torznab indexers queried in parallel, deduplicated, then composite-ranked by format quality, edition tags (RETAIL / UNABRIDGED / ABRIDGED), year match, grab count, size, and ISBN exact-match bonus.
-- Smart matching — four-tier query fallback (`t=book` → `surname+title` → `author+title` → title), word-boundary keyword matching, contiguous-phrase requirement for multi-word titles, dual-author-anchor for ambiguous short titles, subtitle-aware (`Title: Subtitle`).
+- Smart matching — four-tier query fallback (`t=book` → `surname+title` → `author+title` → title), bounded localized/original-title candidates, word-boundary keyword matching, contiguous-phrase requirement for multi-word titles, dual-author-anchor for ambiguous short titles, subtitle-aware (`Title: Subtitle`). Original-language fallbacks are visible in interactive search but excluded from automatic grabs when the metadata profile selects a localized language.
 - SABnzbd, NZBGet, qBittorrent, Transmission, Deluge, rTorrent/ruTorrent — with **Use SSL** and **URL Base** for reverse-proxy subpaths.
 - Auto-grab sweep every 12h, immediate search on add or `wanted` flip, plus interactive per-book search and "Search all wanted" per author. Global kill-switch pauses auto-grab without losing your monitored list.
 - Quality profiles covering every format release parsing recognises (EPUB, MOBI, AZW3, PDF, plus AZW, DJVU, CBR, CBZ, FB2, LIT, RTF, TXT and the audio containers M4B, M4A, FLAC, MP3, OGG), language filter, regex-based custom formats, delay profiles, blocklist (consulted on every search; one-click add from History), and failure visibility in Queue and History.

--- a/changelog.d/multilingual-title-search.md
+++ b/changelog.d/multilingual-title-search.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Localized book searches** — search a safe localized title alias first and expose the original-language title as a clearly marked manual fallback, instead of sending combined bilingual titles to indexers.

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -434,23 +434,27 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	crit := indexer.MatchCriteria{
-		Title:            book.Title,
-		Author:           authorName,
-		MediaType:        book.MediaType,
-		ASIN:             book.ASIN,
-		AllowedLanguages: allowedLangs,
-		AuthorAliases:    authorAliases,
+		Title:               book.Title,
+		AllowManualFallback: true,
+		Author:              authorName,
+		MediaType:           book.MediaType,
+		ASIN:                book.ASIN,
+		AllowedLanguages:    allowedLangs,
+		AuthorAliases:       authorAliases,
 	}
 	if book.ReleaseDate != nil {
 		crit.Year = book.ReleaseDate.Year()
 	}
+	var bookEditions []models.Edition
 	if h.editions != nil {
 		if eds, err := h.editions.ListByBook(r.Context(), book.ID); err != nil {
 			slog.Warn("failed to load editions for search ISBN", "book_id", book.ID, "error", err)
 		} else {
+			bookEditions = eds
 			crit.ISBN = indexer.CriteriaISBN(book, eds)
 		}
 	}
+	crit.TitleCandidates = indexer.BuildTitleCandidates(*book, bookEditions, allowedLangs)
 
 	// For dual-format books (media_type='both'), run one search per format so
 	// each uses its own category tree (7xxx for ebooks, 3xxx for audiobooks).
@@ -523,7 +527,7 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 	beforeLang := len(results)
 	filterDesc := ""
 	if len(allowedLangs) > 0 {
-		results = indexer.FilterByAllowedLanguages(results, allowedLangs)
+		results = indexer.FilterByAllowedLanguagesInteractive(results, allowedLangs)
 		filterDesc = "allowed=" + strings.Join(allowedLangs, ",")
 	} else if s, _ := h.settings.Get(r.Context(), "search.preferredLanguage"); s != nil {
 		results = indexer.FilterByLanguage(results, s.Value)

--- a/internal/api/indexers_test.go
+++ b/internal/api/indexers_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -477,6 +478,60 @@ func TestSearchBook_RedactsIndexerAPIKey(t *testing.T) {
 	}
 	if len(resp.Results) != 1 || resp.Results[0].NZBURL != "https://idx.example.com/dl?id=eb1" {
 		t.Fatalf("nzbUrl not redacted as expected: %+v", resp.Results)
+	}
+}
+
+func TestSearchBookBuildsBilingualInteractiveCandidates(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	author := &models.Author{ForeignID: "OL1A", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	bookRepo := db.NewBookRepo(database)
+	book := &models.Book{
+		Title:            "El imperio final / The Final Empire",
+		OriginalTitle:    "The Final Empire",
+		Language:         "spa",
+		ForeignID:        "OL1W",
+		AuthorID:         author.ID,
+		MediaType:        models.MediaTypeEbook,
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockIndexerSearcher{}
+	h := NewIndexerHandler(
+		db.NewIndexerRepo(database), bookRepo, authorRepo,
+		db.NewMetadataProfileRepo(database), mock,
+		db.NewSettingsRepo(database), db.NewBlocklistRepo(database),
+	)
+	rec := httptest.NewRecorder()
+	req := withURLParam(httptest.NewRequest(http.MethodGet, "/indexer/book/1/search", nil), "id", strconv.FormatInt(book.ID, 10))
+	h.SearchBook(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	criteria := mock.criteria()
+	if !criteria.AllowManualFallback {
+		t.Fatal("interactive search did not enable manual title fallbacks")
+	}
+	want := []indexer.TitleCandidate{
+		{Title: "El imperio final", Language: "spa"},
+		{Title: "The Final Empire", ManualOnly: true},
+	}
+	if !reflect.DeepEqual(criteria.TitleCandidates, want) {
+		t.Fatalf("title candidates = %#v, want %#v", criteria.TitleCandidates, want)
 	}
 }
 

--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -25,28 +25,30 @@ type SearchDebug struct {
 
 // SearchQueryDebug is the effective criteria sent into the searcher.
 type SearchQueryDebug struct {
-	Title            string   `json:"title,omitempty"`
-	Author           string   `json:"author,omitempty"`
-	Year             int      `json:"year,omitempty"`
-	ISBN             string   `json:"isbn,omitempty"`
-	ASIN             string   `json:"asin,omitempty"`
-	MediaType        string   `json:"mediaType,omitempty"`
-	AllowedLanguages []string `json:"allowedLanguages,omitempty"`
-	FreeText         string   `json:"freeText,omitempty"`
+	Title            string           `json:"title,omitempty"`
+	TitleCandidates  []TitleCandidate `json:"titleCandidates,omitempty"`
+	Author           string           `json:"author,omitempty"`
+	Year             int              `json:"year,omitempty"`
+	ISBN             string           `json:"isbn,omitempty"`
+	ASIN             string           `json:"asin,omitempty"`
+	MediaType        string           `json:"mediaType,omitempty"`
+	AllowedLanguages []string         `json:"allowedLanguages,omitempty"`
+	FreeText         string           `json:"freeText,omitempty"`
 }
 
 // IndexerDebug describes what happened for a single indexer: whether it was
 // contacted, the categories sent, how many results came back, and any error.
 type IndexerDebug struct {
-	IndexerID   int64  `json:"indexerId"`
-	IndexerName string `json:"indexerName"`
-	Enabled     bool   `json:"enabled"`
-	Skipped     bool   `json:"skipped,omitempty"`
-	SkipReason  string `json:"skipReason,omitempty"`
-	Categories  []int  `json:"categories,omitempty"`
-	ResultCount int    `json:"resultCount"`
-	DurationMs  int64  `json:"durationMs"`
-	Error       string `json:"error,omitempty"`
+	IndexerID       int64    `json:"indexerId"`
+	IndexerName     string   `json:"indexerName"`
+	Enabled         bool     `json:"enabled"`
+	Skipped         bool     `json:"skipped,omitempty"`
+	SkipReason      string   `json:"skipReason,omitempty"`
+	Categories      []int    `json:"categories,omitempty"`
+	AttemptedTitles []string `json:"attemptedTitles,omitempty"`
+	ResultCount     int      `json:"resultCount"`
+	DurationMs      int64    `json:"durationMs"`
+	Error           string   `json:"error,omitempty"`
 }
 
 // PipelineDebug counts how results flowed through each filter stage in the
@@ -84,6 +86,7 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 		StartedAt: time.Now(),
 		Query: SearchQueryDebug{
 			Title:            c.Title,
+			TitleCandidates:  effectiveTitleCandidates(c),
 			Author:           c.Author,
 			Year:             c.Year,
 			ISBN:             c.ISBN,
@@ -137,7 +140,8 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 			cats := filterCategoriesForMedia(idx.Categories, c.MediaType, idx.IncludeParentCategories)
 			entry.Categories = cats
 
-			hits, err := client.BookSearch(ctx, c.Title, c.Author, cats)
+			hits, attempted, err := s.searchIndexerBook(ctx, client, c, cats)
+			entry.AttemptedTitles = attempted
 			entry.DurationMs = time.Since(start).Milliseconds()
 			if err != nil {
 				entry.Error = err.Error()
@@ -195,7 +199,7 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 	results = filterNonBookContent(results)
 	dbg.Pipeline.AfterNonBookContent = len(results)
 
-	results, relFilters := filterRelevantDebug(results, c.Title, c.Author, c.AuthorAliases)
+	results, relFilters := filterRelevantForCriteriaDebug(results, c)
 	dbg.Filters = append(dbg.Filters, relFilters...)
 	dbg.Pipeline.AfterRelevance = len(results)
 
@@ -203,6 +207,24 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 
 	dbg.DurationMs = time.Since(dbg.StartedAt).Milliseconds()
 	return results, dbg
+}
+
+// filterRelevantForCriteriaDebug is the instrumented counterpart of
+// filterRelevantForCriteria. Each rejection is explained against the title
+// candidate that actually produced the result.
+func filterRelevantForCriteriaDebug(results []newznab.SearchResult, c MatchCriteria) ([]newznab.SearchResult, []FilterDebug) {
+	filtered := make([]newznab.SearchResult, 0, len(results))
+	var dropped []FilterDebug
+	for _, result := range results {
+		title := result.MatchedTitle
+		if title == "" {
+			title = c.Title
+		}
+		kept, filters := filterRelevantDebug([]newznab.SearchResult{result}, title, c.Author, c.AuthorAliases)
+		filtered = append(filtered, kept...)
+		dropped = append(dropped, filters...)
+	}
+	return filtered, dropped
 }
 
 // filterUsenetJunkDebug is filterUsenetJunk instrumented to record which

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -336,6 +336,45 @@ func (c *Client) BookSearch(ctx context.Context, title, author string, categorie
 	return results, nil
 }
 
+// BookSearchFallback performs the two generic text queries that are most
+// useful for an alternate title: "surname title", then title alone. The
+// primary title has already consumed the full structured four-tier cascade,
+// so keeping this path to two requests bounds the extra load caused by a
+// bilingual or edition-title fallback.
+func (c *Client) BookSearchFallback(ctx context.Context, title, author string, categories []int) ([]SearchResult, error) {
+	title = primaryTitleForQuery(title)
+	if !hasSearchableText(title) {
+		return nil, nil
+	}
+	title = TransliterateQuery(title)
+	author = TransliterateQuery(norm.NFC.String(author))
+
+	terms := make([]string, 0, 2)
+	if surname := authorSurname(author); surname != "" {
+		terms = append(terms, strings.TrimSpace(surname+" "+title))
+	}
+	terms = append(terms, title)
+
+	var earliest []SearchResult
+	for i, term := range terms {
+		results, err := c.Search(ctx, term, categories)
+		if err != nil {
+			return nil, err
+		}
+		if len(results) == 0 {
+			continue
+		}
+		if earliest == nil {
+			earliest = results
+		}
+		if titleHasRelevantResult(title, results) {
+			slog.Debug("indexer alternate-title query matched", "tier", i+1, "title", title, "count", len(results))
+			return results, nil
+		}
+	}
+	return earliest, nil
+}
+
 // bookSearchTiers runs the four-tier query cascade for one spelling of the
 // title/author and returns the first tier that yields results plausibly about
 // the requested book (empty if none do). BookSearch calls it with the

--- a/internal/indexer/newznab/types.go
+++ b/internal/indexer/newznab/types.go
@@ -137,20 +137,22 @@ type capsCategory struct {
 
 // SearchResult is the domain type for an indexer search result.
 type SearchResult struct {
-	GUID        string `json:"guid"`
-	IndexerID   int64  `json:"indexerId"`
-	IndexerName string `json:"indexerName"`
-	Title       string `json:"title"`
-	Size        int64  `json:"size"`
-	PubDate     string `json:"pubDate"`
-	NZBURL      string `json:"nzbUrl"`
-	InfoURL     string `json:"infoUrl,omitempty"` // human-readable indexer detail/release page (from comments, guid-permalink, or link); never the download URL
-	Category    string `json:"category"`
-	Grabs       int    `json:"grabs"`
-	Author      string `json:"author"`
-	BookTitle   string `json:"bookTitle"`
-	Protocol    string `json:"protocol"`           // "usenet" or "torrent"
-	Language    string `json:"language,omitempty"` // ISO 639-1 from newznab:attr language (when present)
+	GUID         string `json:"guid"`
+	IndexerID    int64  `json:"indexerId"`
+	IndexerName  string `json:"indexerName"`
+	Title        string `json:"title"`
+	Size         int64  `json:"size"`
+	PubDate      string `json:"pubDate"`
+	NZBURL       string `json:"nzbUrl"`
+	InfoURL      string `json:"infoUrl,omitempty"` // human-readable indexer detail/release page (from comments, guid-permalink, or link); never the download URL
+	Category     string `json:"category"`
+	Grabs        int    `json:"grabs"`
+	Author       string `json:"author"`
+	BookTitle    string `json:"bookTitle"`
+	Protocol     string `json:"protocol"`               // "usenet" or "torrent"
+	Language     string `json:"language,omitempty"`     // ISO 639-1 from newznab:attr language (when present)
+	MatchedTitle string `json:"matchedTitle,omitempty"` // normalized book title candidate that produced this result
+	ManualOnly   bool   `json:"manualOnly,omitempty"`   // true when found through an original-language interactive fallback
 	// DownloadVolumeFactor is the torznab downloadvolumefactor attribute: the
 	// fraction of this release's size that counts against the user's download
 	// ratio. 0 means freeleech (costs nothing), 1 is a normal release, 0.5 is

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -73,14 +73,52 @@ func NewSearcher() *Searcher {
 // language outside the set are dropped). Recorded here so search debug
 // output shows which set was in force.
 type MatchCriteria struct {
-	Title            string
-	Author           string
-	Year             int
-	ISBN             string
-	ASIN             string   // for audiobook ASIN anchoring
-	MediaType        string   // models.MediaTypeEbook or models.MediaTypeAudiobook
-	AllowedLanguages []string // from author's MetadataProfile; empty = no filter
-	AuthorAliases    []string // alternate names (e.g. latin-script romanisations for non-latin authors)
+	Title               string
+	TitleCandidates     []TitleCandidate
+	AllowManualFallback bool
+	Author              string
+	Year                int
+	ISBN                string
+	ASIN                string   // for audiobook ASIN anchoring
+	MediaType           string   // models.MediaTypeEbook or models.MediaTypeAudiobook
+	AllowedLanguages    []string // from author's MetadataProfile; empty = no filter
+	AuthorAliases       []string // alternate names (e.g. latin-script romanisations for non-latin authors)
+}
+
+// searchIndexerBook runs the existing full four-tier cascade for the primary
+// title, then at most one two-tier fallback. A fallback is reached only when
+// the primary response contains no result that passes the precise relevance
+// filter; fixed category feeds therefore cannot suppress a useful alias.
+func (s *Searcher) searchIndexerBook(ctx context.Context, client *newznab.Client, c MatchCriteria, categories []int) ([]newznab.SearchResult, []string, error) {
+	candidates := effectiveTitleCandidates(c)
+	var (
+		allHits   []newznab.SearchResult
+		attempted []string
+	)
+	for i, candidate := range candidates {
+		attempted = append(attempted, candidate.Title)
+		var (
+			hits []newznab.SearchResult
+			err  error
+		)
+		if i == 0 {
+			hits, err = client.BookSearch(ctx, candidate.Title, c.Author, categories)
+		} else {
+			hits, err = client.BookSearchFallback(ctx, candidate.Title, c.Author, categories)
+		}
+		if err != nil {
+			return allHits, attempted, err
+		}
+		for j := range hits {
+			hits[j].MatchedTitle = candidate.Title
+			hits[j].ManualOnly = candidate.ManualOnly
+		}
+		allHits = append(allHits, hits...)
+		if len(filterRelevant(hits, candidate.Title, c.Author, c.AuthorAliases)) > 0 {
+			break
+		}
+	}
+	return allHits, attempted, nil
 }
 
 // CriteriaISBN picks the ISBN to put in MatchCriteria.ISBN for a book, given
@@ -271,7 +309,7 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 
 			client := s.makeClient(idx.URL, idx.APIKey)
 			cats := filterCategoriesForMedia(idx.Categories, c.MediaType, idx.IncludeParentCategories)
-			hits, err := client.BookSearch(ctx, c.Title, c.Author, cats)
+			hits, _, err := s.searchIndexerBook(ctx, client, c, cats)
 			if err != nil {
 				s.noteIndexerError(idx, err)
 				s.health.recordFailure(ctx, idx, err)
@@ -301,9 +339,26 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 	results = dedupe(results)
 	results = filterUsenetJunk(results)
 	results = filterNonBookContent(results)
-	results = filterRelevant(results, c.Title, c.Author, c.AuthorAliases)
+	results = filterRelevantForCriteria(results, c)
 	rankResults(results, c)
 	return results
+}
+
+// filterRelevantForCriteria evaluates each result against the title that
+// produced it. Legacy callers and tests that do not supply candidates retain
+// the original single-title behaviour.
+func filterRelevantForCriteria(results []newznab.SearchResult, c MatchCriteria) []newznab.SearchResult {
+	filtered := make([]newznab.SearchResult, 0, len(results))
+	for _, result := range results {
+		title := result.MatchedTitle
+		if title == "" {
+			title = c.Title
+		}
+		if len(filterRelevant([]newznab.SearchResult{result}, title, c.Author, c.AuthorAliases)) == 1 {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
 }
 
 // SearchQuery performs a generic text search across all enabled indexers.
@@ -860,6 +915,12 @@ func dedupe(results []newznab.SearchResult) []newznab.SearchResult {
 		if key == "" {
 			key = r.Title + r.NZBURL
 		}
+		// The same release can be returned by a noisy primary-title query and
+		// then by the correct fallback. Keep both until relevance filtering so
+		// the primary copy cannot erase the fallback's query provenance.
+		if r.MatchedTitle != "" {
+			key += "\x00" + strings.ToLower(r.MatchedTitle)
+		}
 		if seen[key] {
 			continue
 		}
@@ -1195,6 +1256,9 @@ func FilterByAllowedLanguages(results []newznab.SearchResult, allowed []string) 
 	for _, r := range results {
 		norm := NormalizeRelease(r.Title)
 		ok := true
+		if language := normalizeLanguageCode(r.Language); language != "" && !set[language] {
+			ok = false
+		}
 		for _, code := range releaseLanguageCodes(norm) {
 			if !set[code] {
 				ok = false
@@ -1203,6 +1267,20 @@ func FilterByAllowedLanguages(results []newznab.SearchResult, allowed []string) 
 		}
 		if ok {
 			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+// FilterByAllowedLanguagesInteractive applies the profile language filter to
+// normal results while retaining original-language candidates that were
+// deliberately marked manual-only. Those candidates are never available to
+// the scheduler, but keeping them here gives a human the promised fallback.
+func FilterByAllowedLanguagesInteractive(results []newznab.SearchResult, allowed []string) []newznab.SearchResult {
+	filtered := make([]newznab.SearchResult, 0, len(results))
+	for _, result := range results {
+		if result.ManualOnly || len(FilterByAllowedLanguages([]newznab.SearchResult{result}, allowed)) == 1 {
+			filtered = append(filtered, result)
 		}
 	}
 	return filtered

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -2,16 +2,115 @@ package indexer
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/vavallee/bindery/internal/indexer/newznab"
 	"github.com/vavallee/bindery/internal/models"
 )
+
+func TestSearchBookWithDebugBilingualManualFallback(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		queries []string
+	)
+	emptyRSS := `<?xml version="1.0"?><rss xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/"><channel><newznab:response offset="0" total="0"/></channel></rss>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		term := r.URL.Query().Get("q")
+		if term == "" {
+			term = r.URL.Query().Get("title")
+		}
+		mu.Lock()
+		queries = append(queries, term)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/xml")
+		if strings.Contains(strings.ToLower(term), "the final empire") {
+			_, _ = fmt.Fprint(w, `<?xml version="1.0"?><rss xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/"><channel><newznab:response offset="0" total="1"/><item><title>Brandon Sanderson - The Final Empire EPUB</title><guid>final-empire</guid><link>https://example.com/final-empire</link><enclosure url="https://example.com/final-empire.torrent" length="1048576" type="application/x-bittorrent"/><newznab:attr name="category" value="7020"/></item></channel></rss>`)
+			return
+		}
+		_, _ = fmt.Fprint(w, emptyRSS)
+	}))
+	defer srv.Close()
+
+	criteria := MatchCriteria{
+		Title:  "El imperio final / The Final Empire",
+		Author: "Brandon Sanderson",
+		TitleCandidates: []TitleCandidate{
+			{Title: "El imperio final", Language: "spa"},
+			{Title: "The Final Empire", Language: "eng", ManualOnly: true},
+		},
+		AllowManualFallback: true,
+		MediaType:           models.MediaTypeEbook,
+	}
+	indexers := []models.Indexer{{ID: 1, Name: "mock", URL: srv.URL, Type: "torznab", Enabled: true, Categories: []int{7020}}}
+	results, debug := newTestSearcher().SearchBookWithDebug(context.Background(), indexers, criteria)
+	if len(results) != 1 {
+		t.Fatalf("results = %#v, want one English manual fallback", results)
+	}
+	if results[0].MatchedTitle != "The Final Empire" || !results[0].ManualOnly {
+		t.Fatalf("fallback provenance = matched %q manual=%v", results[0].MatchedTitle, results[0].ManualOnly)
+	}
+	if debug == nil || len(debug.Indexers) != 1 {
+		t.Fatalf("debug = %#v, want one indexer outcome", debug)
+	}
+	wantAttempts := []string{"El imperio final", "The Final Empire"}
+	if !slices.Equal(debug.Indexers[0].AttemptedTitles, wantAttempts) {
+		t.Fatalf("attempted titles = %v, want %v", debug.Indexers[0].AttemptedTitles, wantAttempts)
+	}
+	mu.Lock()
+	gotQueries := append([]string(nil), queries...)
+	mu.Unlock()
+	if len(gotQueries) > 6 {
+		t.Fatalf("issued %d requests, want at most 6: %v", len(gotQueries), gotQueries)
+	}
+}
+
+func TestSearchBookDoesNotUseManualFallback(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		queries []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		term := r.URL.Query().Get("q")
+		if term == "" {
+			term = r.URL.Query().Get("title")
+		}
+		mu.Lock()
+		queries = append(queries, term)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = fmt.Fprint(w, `<?xml version="1.0"?><rss xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/"><channel><newznab:response offset="0" total="0"/></channel></rss>`)
+	}))
+	defer srv.Close()
+
+	criteria := MatchCriteria{
+		Title:  "El imperio final / The Final Empire",
+		Author: "Brandon Sanderson",
+		TitleCandidates: []TitleCandidate{
+			{Title: "El imperio final", Language: "spa"},
+			{Title: "The Final Empire", Language: "eng", ManualOnly: true},
+		},
+		MediaType: models.MediaTypeEbook,
+	}
+	indexers := []models.Indexer{{ID: 1, Name: "mock", URL: srv.URL, Type: "torznab", Enabled: true, Categories: []int{7020}}}
+	if results := newTestSearcher().SearchBook(context.Background(), indexers, criteria); len(results) != 0 {
+		t.Fatalf("automatic results = %#v, want none", results)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, query := range queries {
+		if strings.Contains(strings.ToLower(query), "the final empire") {
+			t.Fatalf("automatic search queried manual-only title: %v", queries)
+		}
+	}
+}
 
 // newTestSearcher returns a Searcher whose client factory bypasses the
 // SSRF-hardened DialContext so tests can target httptest servers on loopback.
@@ -658,6 +757,21 @@ func TestDedupeByGUID(t *testing.T) {
 	}
 	if got[0].GUID != "abc" || got[1].GUID != "def" {
 		t.Errorf("unexpected dedup order: %v", resultTitles(got))
+	}
+}
+
+func TestDedupeKeepsFallbackProvenanceUntilRelevanceFilter(t *testing.T) {
+	results := []newznab.SearchResult{
+		{GUID: "same", Title: "Brandon Sanderson - The Final Empire EPUB", MatchedTitle: "El imperio final"},
+		{GUID: "same", Title: "Brandon Sanderson - The Final Empire EPUB", MatchedTitle: "The Final Empire", ManualOnly: true},
+	}
+	got := dedupe(results)
+	if len(got) != 2 {
+		t.Fatalf("dedupe removed fallback provenance: %#v", got)
+	}
+	got = filterRelevantForCriteria(got, MatchCriteria{Title: "El imperio final / The Final Empire", Author: "Brandon Sanderson"})
+	if len(got) != 1 || got[0].MatchedTitle != "The Final Empire" || !got[0].ManualOnly {
+		t.Fatalf("relevance result = %#v, want only English manual fallback", got)
 	}
 }
 

--- a/internal/indexer/title_candidates.go
+++ b/internal/indexer/title_candidates.go
@@ -269,10 +269,16 @@ func firstSpecificLanguage(languages []string) string {
 	return ""
 }
 
+// normalizeLanguageCode canonicalises a provider-reported language so it can be
+// compared with a metadata profile's allowed list.
+//
+// It delegates to models.NormalizeLanguageCode, which is the single ISO 639
+// source (#2463). The local table this used to consult held ten two-letter
+// codes and returned anything else unchanged, so a language outside those ten
+// failed to reconcile with itself: a profile allowing "swe" dropped a release
+// reported as "sv", "ger" dropped "deu", "por" dropped "pt-BR", and "eng"
+// dropped both "en-US" and "English". The shared function handles the region
+// and script subtag strip, the ISO 639-2 T-to-B pairs and the language names.
 func normalizeLanguageCode(language string) string {
-	language = strings.ToLower(strings.TrimSpace(language))
-	if alias, ok := iso639TwoLetterAliases[language]; ok {
-		return alias
-	}
-	return language
+	return models.NormalizeLanguageCode(language)
 }

--- a/internal/indexer/title_candidates.go
+++ b/internal/indexer/title_candidates.go
@@ -1,0 +1,278 @@
+package indexer
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+const maxTitleCandidates = 2
+
+// TitleCandidate is one normalized title an indexer search may use. ManualOnly
+// candidates are exposed to interactive searches but are never queried by the
+// scheduler, which prevents an original-language fallback from being grabbed
+// automatically for a localized-only metadata profile.
+type TitleCandidate struct {
+	Title      string `json:"title"`
+	Language   string `json:"language,omitempty"`
+	ManualOnly bool   `json:"manualOnly,omitempty"`
+}
+
+// BuildTitleCandidates derives a small, ordered set of indexer query titles
+// from metadata already persisted on a book and its editions. The first entry
+// is always the automatic-search title. At most one fallback is added so a
+// missing book cannot multiply the existing four-tier indexer cascade without
+// bound.
+//
+// A localized/original display title such as "El imperio final / The Final
+// Empire" is split only when it has exactly one spaced slash outside grouping
+// punctuation and the book/profile carries non-English language evidence.
+// Multi-title bundles and format tags therefore keep their full title.
+func BuildTitleCandidates(book models.Book, editions []models.Edition, allowedLanguages []string) []TitleCandidate {
+	bookLanguage := normalizeLanguageCode(book.Language)
+	if bookLanguage == "" {
+		bookLanguage = firstSpecificLanguage(allowedLanguages)
+	}
+
+	primaryTitle := cleanTitleCandidate(book.Title)
+	var manualFallback string
+	if left, right, ok := splitLocalizedOriginalTitle(book.Title, book.OriginalTitle, bookLanguage, allowedLanguages); ok {
+		primaryTitle = left
+		manualFallback = right
+	}
+	if primaryTitle == "" {
+		primaryTitle = cleanTitleCandidate(book.OriginalTitle)
+	}
+	if primaryTitle == "" {
+		for _, edition := range editions {
+			if title := cleanTitleCandidate(edition.Title); title != "" {
+				primaryTitle = title
+				bookLanguage = normalizeLanguageCode(edition.Language)
+				break
+			}
+		}
+	}
+
+	candidates := make([]TitleCandidate, 0, maxTitleCandidates)
+	add := func(title, language string, manualOnly bool) bool {
+		title = cleanTitleCandidate(title)
+		if title == "" {
+			return false
+		}
+		for _, existing := range candidates {
+			if strings.EqualFold(existing.Title, title) {
+				return false
+			}
+		}
+		candidates = append(candidates, TitleCandidate{
+			Title:      title,
+			Language:   normalizeLanguageCode(language),
+			ManualOnly: manualOnly,
+		})
+		return true
+	}
+
+	add(primaryTitle, bookLanguage, false)
+	if len(candidates) == 0 {
+		return candidates
+	}
+
+	// A split bilingual title is the strongest available source for its
+	// original-language spelling and wins the single fallback slot.
+	if manualFallback != "" {
+		add(manualFallback, languageForTitle(manualFallback, editions), true)
+		return candidates
+	}
+
+	// Prefer one same-language edition title. It is safe for automatic search
+	// and often carries the exact wording used by release names.
+	for _, edition := range orderedEditions(book, editions) {
+		if len(candidates) >= maxTitleCandidates {
+			break
+		}
+		language := normalizeLanguageCode(edition.Language)
+		if languageAllowed(language, allowedLanguages) || (language != "" && language == bookLanguage) {
+			add(edition.Title, language, false)
+		}
+	}
+
+	// If no localized edition alias exists, preserve the original title as an
+	// interactive-only escape hatch.
+	if len(candidates) < maxTitleCandidates {
+		add(book.OriginalTitle, languageForTitle(book.OriginalTitle, editions), true)
+	}
+	if len(candidates) < maxTitleCandidates {
+		for _, edition := range orderedEditions(book, editions) {
+			language := normalizeLanguageCode(edition.Language)
+			if language != "" && !languageAllowed(language, allowedLanguages) {
+				if add(edition.Title, language, true) {
+					break
+				}
+			}
+		}
+	}
+
+	return candidates
+}
+
+func effectiveTitleCandidates(c MatchCriteria) []TitleCandidate {
+	candidates := c.TitleCandidates
+	if len(candidates) == 0 {
+		candidates = []TitleCandidate{{Title: cleanTitleCandidate(c.Title)}}
+	}
+	out := make([]TitleCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate.Title = cleanTitleCandidate(candidate.Title)
+		if candidate.Title == "" || (candidate.ManualOnly && !c.AllowManualFallback) {
+			continue
+		}
+		out = append(out, candidate)
+		if len(out) == maxTitleCandidates {
+			break
+		}
+	}
+	return out
+}
+
+func splitLocalizedOriginalTitle(title, originalTitle, bookLanguage string, allowedLanguages []string) (string, string, bool) {
+	if strings.Count(title, " / ") != 1 || separatorInsideGrouping(title, " / ") {
+		return "", "", false
+	}
+	parts := strings.SplitN(title, " / ", 2)
+	left, right := cleanTitleCandidate(parts[0]), cleanTitleCandidate(parts[1])
+	if left == "" || right == "" {
+		return "", "", false
+	}
+
+	original := cleanTitleCandidate(originalTitle)
+	originalIsLeft := original != "" && strings.EqualFold(original, left)
+	originalIsRight := original != "" && strings.EqualFold(original, right)
+	hasOriginalEvidence := originalIsLeft || originalIsRight
+	hasLocalizedLanguage := bookLanguage != "" && bookLanguage != "eng"
+	if !hasLocalizedLanguage {
+		for _, language := range allowedLanguages {
+			language = normalizeLanguageCode(language)
+			if language != "" && language != "eng" && language != "any" {
+				hasLocalizedLanguage = true
+				break
+			}
+		}
+	}
+	if !hasOriginalEvidence && !hasLocalizedLanguage {
+		return "", "", false
+	}
+	// Metadata normally stores "localized / original", but orient the pair
+	// from OriginalTitle when a provider returns it in the opposite order.
+	if originalIsLeft && !originalIsRight {
+		return right, left, true
+	}
+	return left, right, true
+}
+
+func separatorInsideGrouping(title, separator string) bool {
+	idx := strings.Index(title, separator)
+	if idx < 0 {
+		return false
+	}
+	var round, square int
+	for _, r := range title[:idx] {
+		switch r {
+		case '(':
+			round++
+		case ')':
+			if round > 0 {
+				round--
+			}
+		case '[':
+			square++
+		case ']':
+			if square > 0 {
+				square--
+			}
+		}
+	}
+	return round > 0 || square > 0
+}
+
+func cleanTitleCandidate(title string) string {
+	title = newznab.NormalizeQueryTitle(title)
+	for _, r := range title {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return title
+		}
+	}
+	return ""
+}
+
+func orderedEditions(book models.Book, editions []models.Edition) []models.Edition {
+	out := make([]models.Edition, 0, len(editions))
+	if book.SelectedEditionID != nil {
+		for _, edition := range editions {
+			if edition.ID == *book.SelectedEditionID {
+				out = append(out, edition)
+				break
+			}
+		}
+	}
+	for _, edition := range editions {
+		if book.SelectedEditionID != nil && edition.ID == *book.SelectedEditionID {
+			continue
+		}
+		if edition.Monitored {
+			out = append(out, edition)
+		}
+	}
+	for _, edition := range editions {
+		if book.SelectedEditionID != nil && edition.ID == *book.SelectedEditionID {
+			continue
+		}
+		if !edition.Monitored {
+			out = append(out, edition)
+		}
+	}
+	return out
+}
+
+func languageForTitle(title string, editions []models.Edition) string {
+	title = cleanTitleCandidate(title)
+	for _, edition := range editions {
+		if strings.EqualFold(cleanTitleCandidate(edition.Title), title) {
+			return edition.Language
+		}
+	}
+	return ""
+}
+
+func languageAllowed(language string, allowed []string) bool {
+	language = normalizeLanguageCode(language)
+	if language == "" || len(allowed) == 0 {
+		return false
+	}
+	for _, candidate := range allowed {
+		candidate = normalizeLanguageCode(candidate)
+		if candidate == "any" || candidate == language {
+			return true
+		}
+	}
+	return false
+}
+
+func firstSpecificLanguage(languages []string) string {
+	for _, language := range languages {
+		language = normalizeLanguageCode(language)
+		if language != "" && language != "any" {
+			return language
+		}
+	}
+	return ""
+}
+
+func normalizeLanguageCode(language string) string {
+	language = strings.ToLower(strings.TrimSpace(language))
+	if alias, ok := iso639TwoLetterAliases[language]; ok {
+		return alias
+	}
+	return language
+}

--- a/internal/indexer/title_candidates_test.go
+++ b/internal/indexer/title_candidates_test.go
@@ -90,6 +90,94 @@ func TestBuildTitleCandidatesUsesOneLocalizedEditionAlias(t *testing.T) {
 	}
 }
 
+func TestBuildTitleCandidatesFallsBackThroughMetadataSources(t *testing.T) {
+	tests := []struct {
+		name             string
+		book             models.Book
+		editions         []models.Edition
+		allowedLanguages []string
+		want             []TitleCandidate
+	}{
+		{
+			name:             "original title when display title is empty",
+			book:             models.Book{OriginalTitle: "Project Hail Mary", Language: "en"},
+			allowedLanguages: []string{"en"},
+			want:             []TitleCandidate{{Title: "Project Hail Mary", Language: "eng"}},
+		},
+		{
+			name:             "edition when book titles are empty",
+			book:             models.Book{},
+			editions:         []models.Edition{{ID: 21, Title: "Elantris", Language: "es"}},
+			allowedLanguages: []string{"es"},
+			want:             []TitleCandidate{{Title: "Elantris", Language: "spa"}},
+		},
+		{
+			name:             "original title as manual fallback",
+			book:             models.Book{Title: "El imperio final", OriginalTitle: "The Final Empire", Language: "spa"},
+			allowedLanguages: []string{"spa"},
+			want: []TitleCandidate{
+				{Title: "El imperio final", Language: "spa"},
+				{Title: "The Final Empire", ManualOnly: true},
+			},
+		},
+		{
+			name:             "out of language edition as manual fallback",
+			book:             models.Book{Title: "El imperio final", Language: "spa"},
+			editions:         []models.Edition{{ID: 22, Title: "The Final Empire", Language: "eng"}},
+			allowedLanguages: []string{"spa"},
+			want: []TitleCandidate{
+				{Title: "El imperio final", Language: "spa"},
+				{Title: "The Final Empire", Language: "eng", ManualOnly: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildTitleCandidates(tt.book, tt.editions, tt.allowedLanguages); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("BuildTitleCandidates() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildTitleCandidatesRequiresLocalizedEvidenceToSplit(t *testing.T) {
+	title := "Left / Right"
+	got := BuildTitleCandidates(models.Book{Title: title, Language: "eng"}, nil, []string{"eng"})
+	if len(got) != 1 || got[0].Title != title {
+		t.Fatalf("BuildTitleCandidates() = %#v, want unsplit title", got)
+	}
+}
+
+func TestBuildTitleCandidatesRejectsPunctuationOnlyMetadata(t *testing.T) {
+	got := BuildTitleCandidates(
+		models.Book{Title: "---", OriginalTitle: "..."},
+		[]models.Edition{{Title: "()", Language: "spa"}},
+		[]string{"spa"},
+	)
+	if len(got) != 0 {
+		t.Fatalf("BuildTitleCandidates() = %#v, want no candidates", got)
+	}
+}
+
+func TestEffectiveTitleCandidatesUsesLegacyTitleAndBoundsCandidates(t *testing.T) {
+	legacy := effectiveTitleCandidates(MatchCriteria{Title: "  Dune  "})
+	if !reflect.DeepEqual(legacy, []TitleCandidate{{Title: "Dune"}}) {
+		t.Fatalf("legacy candidates = %#v", legacy)
+	}
+
+	bounded := effectiveTitleCandidates(MatchCriteria{TitleCandidates: []TitleCandidate{
+		{Title: ""},
+		{Title: "Dune"},
+		{Title: "Dune Messiah"},
+		{Title: "Children of Dune"},
+	}})
+	want := []TitleCandidate{{Title: "Dune"}, {Title: "Dune Messiah"}}
+	if !reflect.DeepEqual(bounded, want) {
+		t.Fatalf("bounded candidates = %#v, want %#v", bounded, want)
+	}
+}
+
 func TestInteractiveLanguageFilterKeepsManualFallback(t *testing.T) {
 	results := []newznab.SearchResult{
 		{Title: "El Imperio Final SPANISH EPUB", Language: "es"},

--- a/internal/indexer/title_candidates_test.go
+++ b/internal/indexer/title_candidates_test.go
@@ -1,0 +1,103 @@
+package indexer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestBuildTitleCandidatesBilingualSpanish(t *testing.T) {
+	book := models.Book{
+		Title:         "El imperio final / The Final Empire",
+		OriginalTitle: "The Final Empire",
+		Language:      "spa",
+	}
+	got := BuildTitleCandidates(book, nil, []string{"spa"})
+	want := []TitleCandidate{
+		{Title: "El imperio final", Language: "spa"},
+		{Title: "The Final Empire", ManualOnly: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildTitleCandidates() = %#v, want %#v", got, want)
+	}
+
+	automatic := effectiveTitleCandidates(MatchCriteria{Title: book.Title, TitleCandidates: got})
+	if !reflect.DeepEqual(automatic, want[:1]) {
+		t.Fatalf("automatic candidates = %#v, want %#v", automatic, want[:1])
+	}
+	interactive := effectiveTitleCandidates(MatchCriteria{
+		Title:               book.Title,
+		TitleCandidates:     got,
+		AllowManualFallback: true,
+	})
+	if !reflect.DeepEqual(interactive, want) {
+		t.Fatalf("interactive candidates = %#v, want %#v", interactive, want)
+	}
+}
+
+func TestBuildTitleCandidatesOrientsReversedOriginalTitle(t *testing.T) {
+	book := models.Book{
+		Title:         "The Final Empire / El imperio final",
+		OriginalTitle: "The Final Empire",
+		Language:      "spa",
+	}
+	want := []TitleCandidate{
+		{Title: "El imperio final", Language: "spa"},
+		{Title: "The Final Empire", ManualOnly: true},
+	}
+	if got := BuildTitleCandidates(book, nil, []string{"spa"}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildTitleCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildTitleCandidatesKeepsAmbiguousSlashesWhole(t *testing.T) {
+	tests := []string{
+		"The Martian / Artemis / Project Hail Mary",
+		"Red Rising [ENG / M4B]",
+		"AC/DC: Maximum Rock & Roll",
+	}
+	for _, title := range tests {
+		t.Run(title, func(t *testing.T) {
+			got := BuildTitleCandidates(models.Book{Title: title, Language: "spa"}, nil, []string{"spa"})
+			if len(got) != 1 || got[0].Title != title {
+				t.Fatalf("BuildTitleCandidates(%q) = %#v, want unsplit title", title, got)
+			}
+		})
+	}
+}
+
+func TestBuildTitleCandidatesUsesOneLocalizedEditionAlias(t *testing.T) {
+	selectedID := int64(11)
+	book := models.Book{
+		Title:             "El nombre del viento",
+		OriginalTitle:     "The Name of the Wind",
+		Language:          "spa",
+		SelectedEditionID: &selectedID,
+	}
+	editions := []models.Edition{
+		{ID: 10, Title: "The Name of the Wind", Language: "eng", Monitored: true},
+		{ID: 11, Title: "El nombre del viento: Crónica del asesino de reyes", Language: "spa"},
+	}
+	got := BuildTitleCandidates(book, editions, []string{"spa"})
+	want := []TitleCandidate{
+		{Title: "El nombre del viento", Language: "spa"},
+		{Title: "El nombre del viento: Crónica del asesino de reyes", Language: "spa"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildTitleCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestInteractiveLanguageFilterKeepsManualFallback(t *testing.T) {
+	results := []newznab.SearchResult{
+		{Title: "El Imperio Final SPANISH EPUB", Language: "es"},
+		{Title: "The Final Empire ENGLISH EPUB", Language: "en", ManualOnly: true},
+		{Title: "Unrelated English EPUB", Language: "en"},
+	}
+	got := FilterByAllowedLanguagesInteractive(results, []string{"spa"})
+	if len(got) != 2 || got[0].Title != results[0].Title || got[1].Title != results[1].Title {
+		t.Fatalf("interactive filter = %#v, want Spanish plus manual fallback", got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -740,13 +740,16 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	if book.ReleaseDate != nil {
 		crit.Year = book.ReleaseDate.Year()
 	}
+	var bookEditions []models.Edition
 	if s.editions != nil {
 		if eds, err := s.editions.ListByBook(ctx, book.ID); err != nil {
 			slog.Warn("failed to load editions for search ISBN", "book_id", book.ID, "error", err)
 		} else {
+			bookEditions = eds
 			crit.ISBN = indexer.CriteriaISBN(&book, eds)
 		}
 	}
+	crit.TitleCandidates = indexer.BuildTitleCandidates(book, bookEditions, allowedLangs)
 
 	results, outcomes := s.searchBookWithOutcomes(ctx, idxs, crit)
 	// An indexer that failed contributed zero results and is otherwise

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -69,6 +69,8 @@ export interface SearchResult {
   pubDate: string
   protocol: string   // "usenet" or "torrent"
   language?: string  // ISO 639-1 from newznab:attr language (when present)
+  matchedTitle?: string // normalized title candidate that produced this result
+  manualOnly?: boolean  // found through an interactive-only language fallback
   mediaType?: string // "ebook" or "audiobook"; set for dual-format book searches
   approved?: boolean
   rejection?: string
@@ -76,6 +78,7 @@ export interface SearchResult {
 
 export interface SearchQueryDebug {
   title?: string
+  titleCandidates?: TitleCandidateDebug[]
   author?: string
   year?: number
   isbn?: string
@@ -85,6 +88,12 @@ export interface SearchQueryDebug {
   freeText?: string
 }
 
+export interface TitleCandidateDebug {
+  title: string
+  language?: string
+  manualOnly?: boolean
+}
+
 export interface IndexerDebug {
   indexerId: number
   indexerName: string
@@ -92,6 +101,7 @@ export interface IndexerDebug {
   skipped?: boolean
   skipReason?: string
   categories?: number[]
+  attemptedTitles?: string[]
   resultCount: number
   durationMs: number
   error?: string

--- a/web/src/components/SearchDebugPanel.test.tsx
+++ b/web/src/components/SearchDebugPanel.test.tsx
@@ -141,4 +141,27 @@ describe('SearchDebugPanel', () => {
       expect(fallback.selectionEnd).toBe(expectedDebugJson.length)
     })
   })
+
+  it('shows normalized and attempted title candidates', () => {
+    const multilingual: SearchDebug = {
+      ...debug,
+      query: {
+        ...debug.query,
+        title: 'El imperio final / The Final Empire',
+        titleCandidates: [
+          { title: 'El imperio final', language: 'spa' },
+          { title: 'The Final Empire', language: 'eng', manualOnly: true },
+        ],
+      },
+      indexers: [{
+        ...debug.indexers[0],
+        attemptedTitles: ['El imperio final', 'The Final Empire'],
+      }],
+    }
+
+    render(<SearchDebugPanel debug={multilingual} resultCount={1} defaultOpen />)
+
+    expect(screen.getByText('El imperio final [spa] → The Final Empire [eng] (manual only)')).toBeInTheDocument()
+    expect(screen.getByText('titles: El imperio final → The Final Empire')).toBeInTheDocument()
+  })
 })

--- a/web/src/components/SearchDebugPanel.tsx
+++ b/web/src/components/SearchDebugPanel.tsx
@@ -70,6 +70,11 @@ export default function SearchDebugPanel({ debug, resultCount, defaultOpen }: Pr
             <h4 className="font-semibold text-slate-700 dark:text-zinc-300 mb-1">Query</h4>
             <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-slate-600 dark:text-zinc-400">
               {debug.query?.title && <><span>title</span><span className="font-mono">{debug.query.title}</span></>}
+              {debug.query?.titleCandidates && debug.query.titleCandidates.length > 0 && (
+                <><span>titleCandidates</span><span className="font-mono">
+                  {debug.query.titleCandidates.map(c => `${c.title}${c.language ? ` [${c.language}]` : ''}${c.manualOnly ? ' (manual only)' : ''}`).join(' → ')}
+                </span></>
+              )}
               {debug.query?.author && <><span>author</span><span className="font-mono">{debug.query.author}</span></>}
               {debug.query?.mediaType && <><span>mediaType</span><span className="font-mono">{debug.query.mediaType}</span></>}
               {debug.query?.year ? <><span>year</span><span className="font-mono">{debug.query.year}</span></> : null}
@@ -109,6 +114,11 @@ export default function SearchDebugPanel({ debug, resultCount, defaultOpen }: Pr
                     {ix.categories && ix.categories.length > 0 && (
                       <div className="text-slate-500 dark:text-zinc-500 font-mono">
                         categories: {ix.categories.join(', ')}
+                      </div>
+                    )}
+                    {ix.attemptedTitles && ix.attemptedTitles.length > 0 && (
+                      <div className="text-slate-500 dark:text-zinc-500 font-mono break-words">
+                        titles: {ix.attemptedTitles.join(' → ')}
                       </div>
                     )}
                   </div>

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -182,6 +182,11 @@ export function SearchResultsSection({
       <div className="min-w-0 mr-3">
         <div className="flex items-center gap-1.5 flex-wrap mb-0.5">
           {fmt && <MediaBadge type={fmt} />}
+          {r.manualOnly && (
+            <span className="px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-400 font-medium">
+              manual fallback
+            </span>
+          )}
           <span className="truncate text-slate-800 dark:text-zinc-200">{r.title}</span>
         </div>
         <span className="text-slate-500 dark:text-zinc-500 truncate block">


### PR DESCRIPTION
## Summary

Avoid sending combined localized/original display titles to indexers. Bindery now builds a bounded title-candidate list, uses the localized title for automatic searches, and exposes the original-language fallback only to interactive searches.

Refs #211.

## Implementation notes

- Derives at most two safe title candidates from metadata and a single spaced slash outside brackets/parentheses.
- Keeps the existing four-tier cascade for the primary title and limits the fallback to two generic requests.
- Marks original-language results as `manualOnly`, so the scheduler and auto-grab path cannot select them.
- Preserves same-language edition aliases as automatic fallbacks.
- Exposes `matchedTitle`, `manualOnly`, candidates, and per-indexer attempted titles in the API/debug UI.
- Adds no database migration or dependency.

## Checklist

- [x] Commits signed off with `git commit -s` — see [Sign your work](../CONTRIBUTING.md#sign-your-work-dco)
- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` not required: no env vars, persisted config, or upgrade path changed
- [x] Added `changelog.d/multilingual-title-search.md`
- [ ] Wiki pages updated — the README documents the user-facing behaviour; happy to add a wiki follow-up if preferred

## Test plan

- [x] `go test ./internal/indexer/...`
- [x] `go test ./internal/api -run TestSearchBook -count=1`
- [x] `go test -count=1 ./internal/scheduler`
- [x] `go vet ./cmd/... ./internal/...`
- [x] Frontend: 659 tests, typecheck, lint (0 errors; 6 pre-existing warnings), and production build
- [x] Isolated live Prowlarr search with auto-grab disabled: Spanish localized result plus English manual-only fallback; no download triggered

<!-- Only lint, validate (Go), and Security Summary are required to merge.
     Other security scans are advisory; a red Container Scan is often a base-image
     CVE unrelated to your change — mention it and a maintainer will confirm. -->