### PR TITLE
refactor(metadata): route foreign IDs through the models classifier (#2352)

### DIFF
--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -1376,15 +1376,12 @@ func authorNameAutoMatches(a, b string) bool {
 	return match.Kind == textutil.AuthorMatchExact || match.Kind == textutil.AuthorMatchFuzzyAuto
 }
 
+// metadataProviderFromForeignID names the provider a book's foreign ID belongs
+// to, for stamping books.metadata_provider. It delegates to models rather than
+// repeating the switch: this copy had drifted to four branches and was missing
+// "calibre:" and "abs:", so a Calibre or Audiobookshelf sourced book was
+// stamped "openlibrary", disagreeing with the value migration 078 backfills
+// (#2352).
 func metadataProviderFromForeignID(foreignID string) string {
-	switch {
-	case strings.HasPrefix(foreignID, "gb:"):
-		return "googlebooks"
-	case strings.HasPrefix(foreignID, "hc:"):
-		return "hardcover"
-	case strings.HasPrefix(foreignID, "dnb:"):
-		return "dnb"
-	default:
-		return "openlibrary"
-	}
+	return models.BookProviderFromForeignID(foreignID)
 }

--- a/internal/api/books_metadata_provider_test.go
+++ b/internal/api/books_metadata_provider_test.go
@@ -62,3 +62,27 @@ func TestBookGet_ServesProviderAndIdentityMap(t *testing.T) {
 		t.Fatalf("identifiers = %+v, want the Hardcover id recorded", got.Identifiers)
 	}
 }
+
+// TestMetadataProviderFromForeignID is the #2352 regression guard for the
+// api-side copy of the prefix classifier. It had drifted to four branches, so
+// a Calibre or Audiobookshelf sourced book was stamped "openlibrary" and
+// disagreed with the value migration 078 backfills for the same id.
+func TestMetadataProviderFromForeignID(t *testing.T) {
+	cases := map[string]string{
+		"calibre:book:5":  "calibre",
+		"abs:book:abc":    "audiobookshelf",
+		"hc:way-of-kings": "hardcover",
+		"gb:zyTCAlFPjgYC": "googlebooks",
+		"dnb:118540238":   "dnb",
+		"OL27448W":        "openlibrary",
+		"":                "openlibrary",
+	}
+	for id, want := range cases {
+		if got := metadataProviderFromForeignID(id); got != want {
+			t.Errorf("metadataProviderFromForeignID(%q) = %q, want %q", id, got, want)
+		}
+		if got := models.BookProviderFromForeignID(id); got != want {
+			t.Errorf("models.BookProviderFromForeignID(%q) = %q, want %q", id, got, want)
+		}
+	}
+}

--- a/internal/metadata/aggregator_foreign_id_classifier_test.go
+++ b/internal/metadata/aggregator_foreign_id_classifier_test.go
@@ -1,0 +1,83 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+)
+
+// TestProviderNameForForeignIDMatchesModels is the #2352 regression guard. This
+// classifier is one of nine copies of the same prefix routing and it had
+// drifted to four branches, so a Calibre or Audiobookshelf synthetic ID fell
+// through to the openlibrary default.
+func TestProviderNameForForeignIDMatchesModels(t *testing.T) {
+	cases := map[string]string{
+		"calibre:author:5": "calibre",
+		"abs:author:abc":   "audiobookshelf",
+		"hc:brandon":       "hardcover",
+		"gb:zyTCAlFPjgYC":  "googlebooks",
+		"dnb:118540238":    "dnb",
+		"OL26320A":         "openlibrary",
+		"":                 "openlibrary",
+	}
+	for id, want := range cases {
+		if got := providerNameForForeignID(id); got != want {
+			t.Errorf("providerNameForForeignID(%q) = %q, want %q", id, got, want)
+		}
+	}
+}
+
+// TestProviderForForeignIDRefusesImporterIDs pins the consequence of the fix:
+// no configured provider owns a synthetic importer prefix, so routing returns
+// nil instead of handing the ID to OpenLibrary, which 404s on it. Every caller
+// of providerForForeignID already handles nil.
+func TestProviderForForeignIDRefusesImporterIDs(t *testing.T) {
+	ol := &mockProvider{name: "openlibrary"}
+	hc := &mockProvider{name: "hardcover"}
+	agg := newTestAggregator(ol, hc)
+
+	for _, id := range []string{"calibre:author:5", "abs:author:abc"} {
+		if provider := agg.providerForForeignID(id); provider != nil {
+			t.Errorf("providerForForeignID(%q) routed to %q, want nil", id, providerName(provider))
+		}
+	}
+
+	// Real provider IDs and a bare OpenLibrary key are untouched.
+	if got := providerName(agg.providerForForeignID("OL26320A")); got != "openlibrary" {
+		t.Errorf("providerForForeignID(bare OL id) = %q, want openlibrary", got)
+	}
+	if got := providerName(agg.providerForForeignID("hc:brandon")); got != "hardcover" {
+		t.Errorf("providerForForeignID(hc: id) = %q, want hardcover", got)
+	}
+
+	// The user-facing consequence: GetAuthor answers (nil, nil) for a Calibre
+	// stub instead of spending a round trip that can only 404.
+	author, err := agg.GetAuthor(context.Background(), "calibre:author:5")
+	if err != nil || author != nil {
+		t.Errorf("GetAuthor(calibre stub) = (%v, %v), want (nil, nil)", author, err)
+	}
+}
+
+// TestSafeToBindUnchangedForProviderIDs pins that the classifier swap does not
+// move SafeToBind for any ID a provider search can actually return. Provider
+// search never yields a calibre: or abs: prefix, so those cases stay
+// theoretical, but they now classify as themselves rather than as openlibrary.
+func TestSafeToBindUnchangedForProviderIDs(t *testing.T) {
+	// Nothing failed: everything binds regardless of prefix.
+	clean := SearchOutcome{Primary: "openlibrary"}
+	for _, id := range []string{"hc:brandon", "gb:zyTCAlFPjgYC", "dnb:118540238", "OL26320A", "calibre:author:5"} {
+		if !clean.SafeToBind(id) {
+			t.Errorf("SafeToBind(%q) = false with no primary failure, want true", id)
+		}
+	}
+
+	// The primary failed, so only a match that came from the primary binds.
+	failed := SearchOutcome{Primary: "openlibrary", PrimaryFailed: true, FailedProviders: []string{"openlibrary"}}
+	if !failed.SafeToBind("OL26320A") {
+		t.Error("SafeToBind(bare OL id) = false, want true: the match came from the primary")
+	}
+	for _, id := range []string{"hc:brandon", "gb:zyTCAlFPjgYC", "dnb:118540238"} {
+		if failed.SafeToBind(id) {
+			t.Errorf("SafeToBind(%q) = true after a primary failure, want false", id)
+		}
+	}
+}

--- a/internal/metadata/aggregator_providers.go
+++ b/internal/metadata/aggregator_providers.go
@@ -1,6 +1,10 @@
 package metadata
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/vavallee/bindery/internal/models"
+)
 
 func (a *Aggregator) providerForForeignID(foreignID string) Provider {
 	if a == nil {
@@ -35,18 +39,17 @@ func sameProvider(a, b Provider) bool {
 	return normalizedProviderName(providerName(a)) == normalizedProviderName(providerName(b))
 }
 
+// providerNameForForeignID classifies a foreign ID by its prefix. It delegates
+// to models rather than repeating the switch: this copy had drifted to four
+// branches and was missing "calibre:" and "abs:", so an importer's synthetic ID
+// fell through to the openlibrary default and providerForForeignID handed it to
+// the OpenLibrary client, which 404s on it (#2352).
+//
+// It routes author and book IDs both, which is fine: AuthorProviderFromForeignID
+// and BookProviderFromForeignID agree branch for branch, and the prefixes are a
+// single shared namespace precisely so one classifier can answer for either.
 func providerNameForForeignID(foreignID string) string {
-	foreignID = strings.TrimSpace(foreignID)
-	switch {
-	case strings.HasPrefix(foreignID, "gb:"):
-		return "googlebooks"
-	case strings.HasPrefix(foreignID, "hc:"):
-		return "hardcover"
-	case strings.HasPrefix(foreignID, "dnb:"):
-		return "dnb"
-	default:
-		return "openlibrary"
-	}
+	return models.AuthorProviderFromForeignID(foreignID)
 }
 
 func normalizedProviderName(name string) string {


### PR DESCRIPTION
Two of the nine copies of the foreign-ID prefix classifier had drifted to four branches and were missing `calibre:` and `abs:`, so an importer's synthetic ID fell through to the openlibrary default. Both now delegate to the `models` helper.

The metadata one is the load-bearing case. `providerForForeignID` routes on that name and falls back to the primary for "openlibrary", so `calibre:author:N` was handed to the OpenLibrary client, which 404s on it. It now returns nil, which all six call sites already handle. Two paths get better as a side effect: `canonicalPrimaryBookAuthorWorks` stops treating a Calibre author as an OpenLibrary one and skips a call that could only fail, and `GetPrimaryAuthorWorksSnapshot` returns "metadata provider is not available for this author" instead of a snapshot built from a 404. That one matters a little more than the rest, because the snapshot is the input to catalogue reconciliation's delete decision (#2247).

The api one is smaller: a Calibre or Audiobookshelf sourced book was stamped `openlibrary` in `books.metadata_provider`, disagreeing with what migration 078 backfills for the same id.

Closes #2352

### On the hand-written guards

The issue suggested deleting the ad-hoc `calibre:` prefix guards this drift caused. Having read each one, only one of them is actually redundant, and it is not in a file this PR touches:

* `internal/api/authors.go:1820` gates `relinkCalibreAuthor`, an early return with its own log line on the single-work path, and the skip of `refreshAuthorProfile`. Not routing. Kept.
* `internal/api/authors.go:2428` and `:3579` rewrite a Calibre stub's foreign id during dedup. Not routing. Kept.
* `internal/scheduler/scheduler.go:1172` genuinely does become redundant. The `updated == nil` check ten lines below it now catches the same case. Left in place so this PR stays out of `internal/scheduler`, which another change is touching. It can go in a follow-up, or be left alone since it costs one string compare and documents the intent.

The two guards the issue cited at `authors.go:191` and `:3131` do not exist. There is no `calibre:` check at either line on `main` or on `bb60d60e`.

### Tests

New `internal/metadata/aggregator_foreign_id_classifier_test.go` and one case appended to `internal/api/books_metadata_provider_test.go`. The classifier and routing cases fail on `main`:

```
providerNameForForeignID("calibre:author:5") = "openlibrary", want "calibre"
providerNameForForeignID("abs:author:abc") = "openlibrary", want "audiobookshelf"
providerForForeignID("calibre:author:5") routed to "openlibrary", want nil
metadataProviderFromForeignID("calibre:book:5") = "openlibrary", want "calibre"
```

`TestSafeToBindUnchangedForProviderIDs` passes before and after, and is there to pin that nothing moved for `hc:` / `gb:` / `dnb:` / a bare OpenLibrary key, which are the only prefixes a provider search can actually return.

Ran: `go build ./...`, `go vet ./internal/metadata/... ./internal/api/...`, `go test ./internal/metadata/... ./internal/api/... ./internal/abs/... ./internal/scheduler/...` (all ok), `golangci-lint run ./internal/metadata/... ./internal/api/...` (0 issues). The scheduler and abs suites are in there because both consume this routing.

### Sequencing

Next minor, not a patch. The symptom is real (404 noise on a Calibre imported library, a wrong `metadataProvider` on the book row) but low impact, and this changes routing several paths depend on. Touches `internal/api/books.go`, which no other open PR of mine does; #2379 touches `internal/api/series.go` and there is no ordering constraint between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
