### PR TITLE
docs: correct stale comments and two wrong CHANGELOG lines (#2338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2761,7 +2761,7 @@ media type for Hardcover import lists. The one schema change
 (`import_lists.media_type`) is additive and defaults to the previous behaviour.
 
 ### Added
-- **Per-list media type for Hardcover import lists** (#1296, #1314) — a synced book took its format from Hardcover's edition availability, so separate "Audiobooks" and "Ebooks" lists produced identical media types (most works report both editions). Each import list now has an Auto / Ebook / Audiobook / Both selector that pins the format its books are created as. Applied on create only: the syncer skips books that already exist, so a book on two single-format lists is never auto-promoted to Both and a manually-set media type survives re-sync.
+- **Per-list media type for Hardcover import lists** (#1314) — a synced book took its format from Hardcover's edition availability, so separate "Audiobooks" and "Ebooks" lists produced identical media types (most works report both editions). Each import list now has an Auto / Ebook / Audiobook / Both selector that pins the format its books are created as. Applied on create only: the syncer skips books that already exist, so a book on two single-format lists is never auto-promoted to Both and a manually-set media type survives re-sync.
 
 ### Fixed
 - **Authors list sorts A–Z / Z–A case-insensitively** (#1312) — `sort_name` is stored case-preserving, so the default BINARY collation sorted all uppercase ahead of all lowercase and pushed lowercase-article names ("de Balzac") past "Z", which read as a jumble. The sort now uses `COLLATE NOCASE`, backed by a matching index (migration 055). Sorting by "recent" was unaffected.
@@ -2903,7 +2903,7 @@ Coverage backfill with no production behavior change: indexer ranker scoring ter
 
 ### Added
 
-- **`{Genre}` file-naming token** — organise your library into top-level genre folders (e.g. `{Genre}/{Author}/{Title}`). Genres are sourced from Hardcover's curated taxonomy when Hardcover is enabled; without it the token falls back to OpenLibrary's noisier subject data. New books pick up genres immediately; **refresh an author** to backfill genres onto books imported before this release.
+- **`{Genre}` file-naming token** — organise your library into top-level genre folders (e.g. `{Genre}/{Author}/{Title}`). Genres are sourced from Hardcover's curated taxonomy when Hardcover is enabled; without it the token falls back to OpenLibrary's noisier subject data. New books pick up genres immediately; with Hardcover enabled, **refresh an author** to backfill genres onto books imported before this release. The backfill only fills in genres for books Hardcover matched, so an OpenLibrary-only install gets genres on new books but not on existing ones.
 - **`{Token:default}` fallback syntax in naming templates** — any token can specify a fallback used when it renders empty, mirroring Calibre's `ifempty(...)`. For example `{Genre:Unsorted}/{Author}/{Title}` routes un-tagged books to an `Unsorted/` folder instead of dropping the folder level.
 
 ### Changed

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -932,13 +932,13 @@ func removeBookPathScoped(p, format string, ownedByOther func(string) bool) erro
 			if ownedByOther != nil && ownedByOther(sibling) {
 				continue
 			}
-			if rmErr := os.Remove(sibling); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- parent + stem both from importer-sanitized DB row; #865 plans defense-in-depth root-check
+			if rmErr := os.Remove(sibling); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- parent + stem both from importer-sanitized DB row; the defense-in-depth root check shipped in #865 and gates every caller in safeRemoveBookPath (path_safety.go)
 				slog.Warn("book delete: failed to remove sibling file", "path", sibling, "error", rmErr)
 			}
 		}
 	} else {
 		// ReadDir failed — fall back to deleting only the target file.
-		if err := os.Remove(p); err != nil { // #nosec G304 G703 -- p is from book_files row written by importer's sanitizePath; #865 plans defense-in-depth root-check
+		if err := os.Remove(p); err != nil { // #nosec G304 G703 -- p is from book_files row written by importer's sanitizePath; the defense-in-depth root check shipped in #865 and gates every caller in safeRemoveBookPath (path_safety.go)
 			return err
 		}
 	}
@@ -946,7 +946,7 @@ func removeBookPathScoped(p, format string, ownedByOther func(string) bool) erro
 	// Clean up parent directory if it is now empty.
 	remaining, err := os.ReadDir(parent)
 	if err == nil && len(remaining) == 0 {
-		_ = os.Remove(parent) // #nosec G304 G703 -- parent = filepath.Dir of importer-sanitized DB row; #865 plans defense-in-depth root-check
+		_ = os.Remove(parent) // #nosec G304 G703 -- parent = filepath.Dir of importer-sanitized DB row; the defense-in-depth root check shipped in #865 and gates every caller in safeRemoveBookPath (path_safety.go)
 	}
 	return nil
 }
@@ -988,7 +988,7 @@ func removeBookDirScoped(dir, format string, ownedByOther func(string) bool) err
 			kept++
 			return nil
 		}
-		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- path is under an importer-sanitized DB row; #865 plans defense-in-depth root-check
+		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- path is under an importer-sanitized DB row; the defense-in-depth root check shipped in #865 and gates every caller in safeRemoveBookPath (path_safety.go)
 			slog.Warn("book delete: failed to remove file in book folder", "path", path, "error", rmErr)
 			kept++
 		}
@@ -1015,7 +1015,7 @@ func removeBookDirScoped(dir, format string, ownedByOther func(string) bool) err
 			kept++
 			return nil
 		}
-		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- path is under an importer-sanitized DB row; #865 plans defense-in-depth root-check
+		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- path is under an importer-sanitized DB row; the defense-in-depth root check shipped in #865 and gates every caller in safeRemoveBookPath (path_safety.go)
 			slog.Warn("book delete: failed to remove sidecar in book folder", "path", path, "error", rmErr)
 			kept++
 		}

--- a/internal/db/author_monitor_defaults.go
+++ b/internal/db/author_monitor_defaults.go
@@ -7,7 +7,7 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
-// Install-wide author monitor defaults, surfaced in Settings → Metadata as
+// Install-wide author monitor defaults, surfaced in Settings → Metadata Profiles as
 // "Default monitor mode" with the hint "Applied to newly added authors".
 //
 // The keys live here rather than in internal/api because the create paths that


### PR DESCRIPTION
Four factual corrections found in the same sweep. No behaviour change.

- **`internal/api/books.go`** five `#nosec` suppressions said "#865 plans defense-in-depth root-check". #865 closed on 2026-06-02 and the check it planned exists in `internal/api/path_safety.go`, so they now name `safeRemoveBookPath` instead of an open plan.
- **`internal/db/author_monitor_defaults.go`** said the setting is surfaced in "Settings → Metadata". The control is in `MetadataTab.tsx` and that tab's nav label (`settings.tabs.metadata`) is "Metadata Profiles". There is no tab called "Metadata".
- **CHANGELOG v1.19.0** promised "refresh an author to backfill genres onto books imported before this release" with no qualifier, two sentences after telling OpenLibrary-only users the token falls back to OpenLibrary subjects. The backfill is gated on Hardcover provenance at `internal/api/authors.go:2396`:

  ```go
  if b.HardcoverForeignID != "" && len(b.Genres) > 0 && !slices.Equal(existing.Genres, b.Genres) &&
      !existing.IsFieldLocked(models.BookFieldGenres) {
  ```

  The gate is deliberate (the comment above it says a refresh while Hardcover is unavailable must not downgrade clean genres back to OpenLibrary subjects), so the code is right and the sentence was wrong. Added the qualifier.
- **CHANGELOG v1.22.3** credited the per-list media type entry to `(#1296, #1314)`. `gh issue view 1296` is "Link to metadata sources", an unrelated closed enhancement. The work is PR #1314, whose body carries the actual request. Dropped #1296.

Editing settled CHANGELOG sections is normally off limits. These two are corrections to shipped entries, not new release notes.

Closes #2338

## Tests

Comments and docs only, so there is nothing to add. Ran the matrix anyway because `#nosec` text is load-bearing for gosec:

```
go build ./...                                       ok
go vet ./internal/api/... ./internal/db/...          ok
golangci-lint run ./internal/api/... ./internal/db/...   0 issues
```

## Sequencing

Independent, unblocks nothing, merge whenever. #2392 is the only other open PR touching `internal/api/books.go`; it rewrites the foreign-ID classifier around line 1380 and this one only edits `#nosec` comments between 935 and 1018, so there is no textual overlap either way round. Next minor, not patch material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
