### PR TITLE
refactor(web): confirm in-app instead of window.confirm (#2359)

### DIFF
--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -5,8 +5,13 @@ interface Props {
   title: string
   /** Explanatory body. A string, or arbitrary nodes for emphasis/markup. */
   body: React.ReactNode
-  /** Label for the checkbox the user must tick before confirming. */
-  acknowledgeLabel: string
+  /**
+   * Label for an "I understand" checkbox the user must tick before confirming.
+   * Omit it for routine confirmations: the checkbox is then not rendered and
+   * the confirm button is enabled straight away. Keep it for the irreversible
+   * ones (deleting files off disk, rotating a secret).
+   */
+  acknowledgeLabel?: string
   /** Confirm button text. */
   confirmLabel: string
   /** Confirm button text while the action is in flight. */
@@ -17,8 +22,14 @@ interface Props {
 }
 
 /**
- * A guarded confirmation modal: the confirm button stays disabled until the
- * user ticks an "I understand" checkbox. Built on the shared modal shell.
+ * A confirmation modal, used everywhere the app used to call window.confirm
+ * (#2359). Pass acknowledgeLabel to make it a guarded confirmation: the confirm
+ * button then stays disabled until the user ticks an "I understand" checkbox.
+ * Without it the button is live immediately, which is the right weight for a
+ * routine "delete this profile".
+ *
+ * Most callers reach this through useConfirmDialog rather than rendering it
+ * directly.
  */
 export default function ConfirmDialog({
   title,
@@ -32,6 +43,7 @@ export default function ConfirmDialog({
 }: Props) {
   const { t } = useTranslation()
   const [acknowledged, setAcknowledged] = useState(false)
+  const needsAcknowledgement = acknowledgeLabel !== undefined
 
   return (
     <div
@@ -39,24 +51,30 @@ export default function ConfirmDialog({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        data-testid="confirm-dialog"
         className="bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-lg w-full max-w-md shadow-2xl max-h-[90vh] flex flex-col"
         onClick={e => e.stopPropagation()}
       >
         <div className="p-4 border-b border-slate-200 dark:border-zinc-800">
-          <h3 className="text-lg font-semibold text-slate-800 dark:text-zinc-200">{title}</h3>
+          <h3 id="confirm-dialog-title" className="text-lg font-semibold text-slate-800 dark:text-zinc-200">{title}</h3>
         </div>
         <div className="p-4 flex-1 overflow-y-auto space-y-4">
           <div className="text-sm text-slate-600 dark:text-zinc-400 leading-relaxed">{body}</div>
-          <label className="flex items-start gap-2 text-sm text-slate-700 dark:text-zinc-300 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={acknowledged}
-              onChange={e => setAcknowledged(e.target.checked)}
-              disabled={confirming}
-              className="mt-0.5 rounded border-slate-300 dark:border-zinc-700 text-emerald-600 focus:ring-emerald-500"
-            />
-            <span>{acknowledgeLabel}</span>
-          </label>
+          {needsAcknowledgement && (
+            <label className="flex items-start gap-2 text-sm text-slate-700 dark:text-zinc-300 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={acknowledged}
+                onChange={e => setAcknowledged(e.target.checked)}
+                disabled={confirming}
+                className="mt-0.5 rounded border-slate-300 dark:border-zinc-700 text-emerald-600 focus:ring-emerald-500"
+              />
+              <span>{acknowledgeLabel}</span>
+            </label>
+          )}
         </div>
         <div className="p-4 border-t border-slate-200 dark:border-zinc-800 flex justify-end gap-2">
           <button
@@ -70,7 +88,7 @@ export default function ConfirmDialog({
           <button
             type="button"
             onClick={onConfirm}
-            disabled={!acknowledged || confirming}
+            disabled={(needsAcknowledgement && !acknowledged) || confirming}
             className="px-3 py-1.5 text-sm font-medium rounded bg-red-600 hover:bg-red-500 text-white disabled:opacity-50"
           >
             {confirming ? confirmingLabel ?? confirmLabel : confirmLabel}

--- a/web/src/components/MergeAuthorsModal.tsx
+++ b/web/src/components/MergeAuthorsModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from './useConfirmDialog'
 import { api, Author } from '../api/client'
 
 interface Props {
@@ -18,6 +19,7 @@ interface Props {
 // committing.
 export default function MergeAuthorsModal({ authors, initialTargetId, onClose, onMerged }: Props) {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [targetId, setTargetId] = useState<number | ''>(initialTargetId ?? '')
   const [sourceId, setSourceId] = useState<number | ''>('')
   const [sourceBookCount, setSourceBookCount] = useState<number | null>(null)
@@ -48,11 +50,16 @@ export default function MergeAuthorsModal({ authors, initialTargetId, onClose, o
 
   const submit = async () => {
     if (!canSubmit || !source || !target) return
-    const msg = `Merge "${source.authorName}" into "${target.authorName}"?\n\n` +
-      `• ${sourceBookCount ?? '?'} book(s) will be reparented.\n` +
-      `• "${source.authorName}" will be kept as an alias of "${target.authorName}".\n` +
-      `• This cannot be undone.`
-    if (!confirm(msg)) return
+    if (!await confirm({
+      title: t('mergeAuthorsModal.title'),
+      body: t('mergeAuthorsModal.confirmBody', {
+        source: source.authorName,
+        target: target.authorName,
+        count: sourceBookCount ?? 0,
+      }),
+      confirmLabel: t('mergeAuthorsModal.mergeButton'),
+      acknowledgeLabel: t('mergeAuthorsModal.confirmAcknowledge'),
+    })) return
     setBusy(true)
     setError(null)
     try {
@@ -68,6 +75,7 @@ export default function MergeAuthorsModal({ authors, initialTargetId, onClose, o
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      {confirmDialog}
       <div
         className="bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-lg w-full max-w-lg shadow-2xl"
         onClick={e => e.stopPropagation()}

--- a/web/src/components/useConfirmDialog.test.tsx
+++ b/web/src/components/useConfirmDialog.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { useConfirmDialog, type ConfirmOptions } from './useConfirmDialog'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key),
+  }),
+}))
+
+function Harness({ options, onResult }: { options: ConfirmOptions; onResult: (v: boolean) => void }) {
+  const { confirm, confirmDialog } = useConfirmDialog()
+  return (
+    <div>
+      {confirmDialog}
+      <button onClick={async () => onResult(await confirm(options))}>Ask</button>
+    </div>
+  )
+}
+
+const dialog = () => screen.getByTestId('confirm-dialog')
+const confirmButton = () => {
+  const buttons = within(dialog()).getAllByRole('button')
+  return buttons[buttons.length - 1] as HTMLButtonElement
+}
+const cancelButton = () => {
+  const buttons = within(dialog()).getAllByRole('button')
+  return buttons[buttons.length - 2] as HTMLButtonElement
+}
+
+describe('useConfirmDialog', () => {
+  it('renders nothing until something asks', () => {
+    render(<Harness options={{ title: 'T', body: 'B' }} onResult={vi.fn()} />)
+    expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument()
+  })
+
+  it('resolves true when confirmed and shows the message on screen', async () => {
+    const onResult = vi.fn()
+    render(<Harness options={{ title: 'Delete it?', body: 'This cannot be undone.' }} onResult={onResult} />)
+
+    fireEvent.click(screen.getByText('Ask'))
+    expect(await screen.findByText('Delete it?')).toBeInTheDocument()
+    expect(screen.getByText('This cannot be undone.')).toBeInTheDocument()
+
+    await act(async () => { fireEvent.click(confirmButton()) })
+    expect(onResult).toHaveBeenCalledWith(true)
+    await waitFor(() => expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument())
+  })
+
+  it('resolves false when cancelled', async () => {
+    const onResult = vi.fn()
+    render(<Harness options={{ title: 'T', body: 'B' }} onResult={onResult} />)
+
+    fireEvent.click(screen.getByText('Ask'))
+    await screen.findByTestId('confirm-dialog')
+    await act(async () => { fireEvent.click(cancelButton()) })
+
+    expect(onResult).toHaveBeenCalledWith(false)
+    await waitFor(() => expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument())
+  })
+
+  // The checkbox gate used to be mandatory, which is too heavy for a routine
+  // "delete this profile" (#2359). It is now opt-in per prompt.
+  it('has no acknowledge checkbox and a live confirm button by default', async () => {
+    render(<Harness options={{ title: 'T', body: 'B' }} onResult={vi.fn()} />)
+    fireEvent.click(screen.getByText('Ask'))
+    await screen.findByTestId('confirm-dialog')
+
+    expect(within(dialog()).queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(confirmButton()).not.toBeDisabled()
+  })
+
+  it('gates the confirm button behind the acknowledge box when one is asked for', async () => {
+    const onResult = vi.fn()
+    render(
+      <Harness
+        options={{ title: 'T', body: 'B', acknowledgeLabel: 'I understand.' }}
+        onResult={onResult}
+      />,
+    )
+    fireEvent.click(screen.getByText('Ask'))
+    await screen.findByTestId('confirm-dialog')
+
+    expect(confirmButton()).toBeDisabled()
+    fireEvent.click(within(dialog()).getByRole('checkbox'))
+    expect(confirmButton()).not.toBeDisabled()
+
+    await act(async () => { fireEvent.click(confirmButton()) })
+    expect(onResult).toHaveBeenCalledWith(true)
+  })
+
+  // window.confirm could not be asked twice at once either; the point is that
+  // the second caller gets an answer instead of awaiting a promise forever.
+  it('declines a second prompt while one is open', async () => {
+    const onResult = vi.fn()
+    render(<Harness options={{ title: 'T', body: 'B' }} onResult={onResult} />)
+
+    fireEvent.click(screen.getByText('Ask'))
+    await screen.findByTestId('confirm-dialog')
+    await act(async () => { fireEvent.click(screen.getByText('Ask')) })
+
+    expect(onResult).toHaveBeenCalledWith(false)
+    expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/useConfirmDialog.tsx
+++ b/web/src/components/useConfirmDialog.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import ConfirmDialog from './ConfirmDialog'
+
+export interface ConfirmOptions {
+  /** Heading. Say what is about to happen. */
+  title: string
+  /** Explanatory body. A plain string keeps its line breaks. */
+  body: React.ReactNode
+  /** Confirm button text. Defaults to common.confirm. */
+  confirmLabel?: string
+  /**
+   * Set this to require an "I understand" tick before the confirm button
+   * enables. Reserve it for the irreversible actions.
+   */
+  acknowledgeLabel?: string
+}
+
+/**
+ * useConfirmDialog is the in-app replacement for window.confirm (#2359). It
+ * returns an awaitable `confirm` plus the element to render, so a call site
+ * keeps the shape it already had:
+ *
+ *   const { confirm, confirmDialog } = useConfirmDialog()
+ *   ...
+ *   if (!await confirm({ title, body })) return
+ *   ...
+ *   return <>{confirmDialog}...</>
+ *
+ * Only one prompt can be open at a time, which is what window.confirm gave us
+ * as well. Unmounting with a prompt open leaves its promise unsettled, same as
+ * navigating away from a native dialog.
+ */
+export function useConfirmDialog(): {
+  confirm: (options: ConfirmOptions) => Promise<boolean>
+  confirmDialog: React.ReactNode
+} {
+  const { t } = useTranslation()
+  const [pending, setPending] = useState<ConfirmOptions | null>(null)
+  const resolveRef = useRef<((value: boolean) => void) | null>(null)
+
+  const confirm = useCallback((options: ConfirmOptions) => new Promise<boolean>(resolve => {
+    // A second prompt while one is open would strand the first promise, so
+    // decline it rather than leaving a caller awaiting forever.
+    if (resolveRef.current) {
+      resolve(false)
+      return
+    }
+    resolveRef.current = resolve
+    setPending(options)
+  }), [])
+
+  const settle = useCallback((value: boolean) => {
+    const resolve = resolveRef.current
+    resolveRef.current = null
+    setPending(null)
+    resolve?.(value)
+  }, [])
+
+  const confirmDialog = pending ? (
+    <ConfirmDialog
+      title={pending.title}
+      // whitespace-pre-line keeps the blank lines and bullet lists the messages
+      // carried over from window.confirm, which rendered \n itself.
+      body={typeof pending.body === 'string'
+        ? <p className="whitespace-pre-line">{pending.body}</p>
+        : pending.body}
+      acknowledgeLabel={pending.acknowledgeLabel}
+      confirmLabel={pending.confirmLabel ?? t('common.confirm', 'Confirm')}
+      onConfirm={() => settle(true)}
+      onClose={() => settle(false)}
+    />
+  ) : null
+
+  return { confirm, confirmDialog }
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -43,7 +43,9 @@
     "clipboardTextLabel": "Text to copy",
     "saved": "Saved ✓",
     "saveError": "Error",
-    "more": "More"
+    "more": "More",
+    "confirm": "Confirm",
+    "confirmTitle": "Are you sure?"
   },
   "monitorMode": {
     "all": "All books",
@@ -293,7 +295,11 @@
       "status_imported": "Imported",
       "status_skipped": "Skipped",
       "status_excluded": "Excluded"
-    }
+    },
+    "deleteConfirm": "Delete {{author}} and all {{count}} book(s)?",
+    "deleteWithFilesConfirm": "Delete {{author}}, all {{count}} book(s), AND {{withFiles}} file(s) or folder(s) on disk?\n\nThis cannot be undone.",
+    "deleteTitle": "Delete author",
+    "deleteFilesAcknowledge": "I understand the files on disk will be deleted."
   },
   "catalogueReconciliation": {
     "title": "Reconcile catalogue",
@@ -453,6 +459,10 @@
     "removeDeleteFilesHint": "Deletes the data in the download client. For torrents this also stops seeding. Leave unchecked to keep the files.",
     "removeConfirm": "Remove",
     "removeCancel": "Cancel"
+  },
+  "series": {
+    "deleteConfirm": "Delete \"{{title}}\" from Series? Linked books will stay in your library.",
+    "deleteTitle": "Remove series"
   },
   "importHints": {
     "heading": "Already have files on disk?",
@@ -739,7 +749,9 @@
       "download": "Download",
       "downloadHint": "Download the entries matching the current filters as a text file",
       "downloadNote": "Download saves the entries matching the filters the table is showing as a plain-text file you can attach to a bug report. Large exports are capped; the file says so in its footer when that happens.",
-      "page": "Page {{page}}"
+      "page": "Page {{page}}",
+      "deleteBackupConfirm": "Delete backup {{filename}}?",
+      "deleteBackupTitle": "Delete backup"
     },
     "general": {
       "appearance": "Appearance",
@@ -873,7 +885,12 @@
       "hardcoverSync": "Hardcover list sync",
       "hardcoverSyncIntervalLabel": "Hardcover list sync interval",
       "hardcoverSyncIntervalHint": "How often Bindery re-syncs your enabled Hardcover import lists. Lower it if you curate a Hardcover list as your main way of adding books. Use Sync now on the Import tab for an immediate run.",
-      "restartRequired": "Takes effect after the next Bindery restart."
+      "restartRequired": "Takes effect after the next Bindery restart.",
+      "regenerateApiKeyConfirm": "Regenerate the API key? Existing integrations using the old key will stop working.",
+      "regenerateApiKeyTitle": "Regenerate API key",
+      "rotateSessionSecretConfirm": "Rotate the session signing secret? Existing logins keep working during a rotation window via the previous secret; a second rotation closes that window.",
+      "rotateSessionSecretTitle": "Rotate session secret",
+      "rotateSessionSecretAcknowledge": "I understand a second rotation will sign everyone out."
     },
     "import": {
       "csvHeading": "CSV of author names",
@@ -1074,7 +1091,9 @@
     "removeLabel": "Remove",
     "mergeButton": "Merge",
     "merging": "Merging...",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "confirmBody": "Merge \"{{source}}\" into \"{{target}}\"?\n\n• {{count}} book(s) will be reparented.\n• \"{{source}}\" will be kept as an alias of \"{{target}}\".\n• This cannot be undone.",
+    "confirmAcknowledge": "I understand this cannot be undone."
   },
   "pagination": {
     "previous": "Previous",

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -6,6 +6,7 @@ import AuthorDetailPage from './AuthorDetailPage'
 import { api } from '../api/client'
 import type { Author, Book } from '../api/client'
 import '../i18n'
+import { acceptConfirm, cancelConfirm, confirmDialog } from '../test-utils'
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -386,7 +387,6 @@ describe('AuthorDetailPage', () => {
 
   it('removes an author alias after confirmation', async () => {
     vi.mocked(api.deleteAuthorAlias).mockResolvedValue()
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     renderAuthorDetailPage([], 'grid', {
       aliases: [{ id: 7, authorId: 42, name: 'Robert Jordan', createdAt: '2026-01-01T00:00:00Z' }],
     })
@@ -394,28 +394,31 @@ describe('AuthorDetailPage', () => {
     await screen.findByText('Robert Jordan')
     fireEvent.click(screen.getByRole('button', { name: 'Remove alias Robert Jordan' }))
 
+    // In-app modal since #2359, so the message is on screen rather than passed
+    // to window.confirm.
+    expect(await screen.findByText('Remove alias "Robert Jordan" from Brandon Sanderson?')).toBeInTheDocument()
+    await acceptConfirm()
+
     await waitFor(() => {
       expect(api.deleteAuthorAlias).toHaveBeenCalledWith(42, 7)
     })
     await waitFor(() => {
       expect(screen.queryByText('Robert Jordan')).not.toBeInTheDocument()
     })
-    expect(confirmSpy).toHaveBeenCalledWith('Remove alias "Robert Jordan" from Brandon Sanderson?')
-    confirmSpy.mockRestore()
   })
 
   it('keeps an author alias when removal is cancelled', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
     renderAuthorDetailPage([], 'grid', {
       aliases: [{ id: 8, authorId: 42, name: 'Pen Name', createdAt: '2026-01-01T00:00:00Z' }],
     })
 
     await screen.findByText('Pen Name')
     fireEvent.click(screen.getByRole('button', { name: 'Remove alias Pen Name' }))
+    await cancelConfirm()
 
+    await waitFor(() => expect(confirmDialog()).not.toBeInTheDocument())
     expect(api.deleteAuthorAlias).not.toHaveBeenCalled()
     expect(screen.getByText('Pen Name')).toBeInTheDocument()
-    confirmSpy.mockRestore()
   })
 
   it('keeps table metadata visible and repeats it in compact title rows', async () => {
@@ -509,15 +512,13 @@ describe('AuthorDetailPage', () => {
     fireEvent.click(within(row1).getByRole('checkbox'))
     fireEvent.click(within(row2).getByRole('checkbox'))
 
-    // Confirm dialog for exclude — auto-accept.
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const excludeBtn = await screen.findByRole('button', { name: 'Exclude' })
     fireEvent.click(excludeBtn)
+    await acceptConfirm()
 
     await waitFor(() => {
       expect(api.bulkActionBooks).toHaveBeenCalledWith([101, 102], 'exclude', undefined)
     })
-    confirmSpy.mockRestore()
   })
 
   // #2066: the author page's book list had no media-type bulk action at all,

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../components/useConfirmDialog'
 import { api, Author, AuthorAlias, Book, BookBulkAction, MediaType, Series } from '../api/client'
 import ViewToggle from '../components/ViewToggle'
 import { bookStatusBadge } from '../components/bookStatus'
@@ -69,6 +70,7 @@ export default function AuthorDetailPage() {
   const navigate = useNavigate()
   const location = useLocation()
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const authorId = Number(id)
 
   const [author, setAuthor] = useState<Author | null>(null)
@@ -261,10 +263,15 @@ export default function AuthorDetailPage() {
   const handleDelete = async () => {
     if (!author) return
     const withFiles = books.filter(b => b.filePath)
-    const msg = withFiles.length > 0
-      ? `Delete ${author.authorName}, all ${books.length} book(s), AND ${withFiles.length} file(s)/folder(s) on disk?\n\nThis cannot be undone.`
-      : `Delete ${author.authorName} and all ${books.length} book(s)?`
-    if (!confirm(msg)) return
+    if (!await confirm({
+      title: t('authorDetail.deleteTitle'),
+      body: withFiles.length > 0
+        ? t('authorDetail.deleteWithFilesConfirm', { author: author.authorName, count: books.length, withFiles: withFiles.length })
+        : t('authorDetail.deleteConfirm', { author: author.authorName, count: books.length }),
+      confirmLabel: t('common.delete'),
+      // Deleting files off disk is irreversible, so that variant is gated.
+      acknowledgeLabel: withFiles.length > 0 ? t('authorDetail.deleteFilesAcknowledge') : undefined,
+    })) return
     try {
       await api.deleteAuthor(author.id, withFiles.length > 0)
       navigate('/')
@@ -275,7 +282,11 @@ export default function AuthorDetailPage() {
 
   const handleDeleteAlias = async (alias: AuthorAlias) => {
     if (!author) return
-    if (!confirm(t('authorDetail.aliases.removeConfirm', { name: alias.name, author: author.authorName }))) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('authorDetail.aliases.removeConfirm', { name: alias.name, author: author.authorName }),
+      confirmLabel: t('common.remove'),
+    })) return
     setError(null)
     try {
       await api.deleteAuthorAlias(author.id, alias.id)
@@ -319,7 +330,7 @@ export default function AuthorDetailPage() {
   // so the user knows partial success happened without burying it.
   const runBulk = async (action: BookBulkAction, actionLabel: string, confirmMsg?: string, mediaType?: MediaType) => {
     if (selected.size === 0) return
-    if (confirmMsg && !confirm(confirmMsg)) return
+    if (confirmMsg && !await confirm({ title: t('common.confirmTitle'), body: confirmMsg })) return
     setBulkBusy(true)
     setError(null)
     try {
@@ -667,6 +678,7 @@ export default function AuthorDetailPage() {
   return (
     // One width shared with BookDetailPage — see the note there.
     <div className={`max-w-7xl ${selected.size > 0 ? 'pb-20' : ''}`}>
+      {confirmDialog}
       <div className="mb-4 flex items-center gap-3 text-sm">
         <button onClick={() => navigate(-1)} className="text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">← Back</button>
       </div>

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../components/useConfirmDialog'
 import { api, Author, AuthorBulkMonitorMode, MediaType, MonitorNewItems, AuthorRefreshStatus } from '../api/client'
 import AddAuthorModal from '../components/AddAuthorModal'
 import AddBookModal from '../components/AddBookModal'
@@ -28,6 +29,7 @@ type MonitoredFilter = '' | 'monitored' | 'unmonitored'
 
 export default function AuthorsPage() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const navigate = useNavigate()
   const [authors, setAuthors] = useState<Author[]>([])
   const [total, setTotal] = useState(0)
@@ -131,7 +133,11 @@ export default function AuthorsPage() {
 
   const handleRefreshAll = async () => {
     if (refreshing) return
-    if (!confirm(t('authors.refreshAllConfirm'))) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('authors.refreshAllConfirm'),
+      confirmLabel: t('common.refresh'),
+    })) return
     setRefreshing(true)
     setRefreshStatus(null)
     try {
@@ -157,7 +163,13 @@ export default function AuthorsPage() {
     const msg = withFiles > 0
       ? t('authors.deleteWithFilesConfirm', { total, withFiles })
       : t('authors.deleteConfirm')
-    if (!confirm(msg)) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: msg,
+      confirmLabel: t('common.delete'),
+      // Deleting files off disk is irreversible, so that variant is gated.
+      acknowledgeLabel: withFiles > 0 ? t('authorDetail.deleteFilesAcknowledge') : undefined,
+    })) return
     await api.deleteAuthor(id, withFiles > 0)
     load()
   }
@@ -205,7 +217,11 @@ export default function AuthorsPage() {
 
   const runBulk = async (action: Parameters<typeof api.bulkActionAuthors>[1]) => {
     if (selectedIds.size === 0) return
-    if (action === 'delete' && !confirm(t('authors.bulkDeleteConfirm', { count: selectedIds.size }))) return
+    if (action === 'delete' && !await confirm({
+      title: t('common.confirmTitle'),
+      body: t('authors.bulkDeleteConfirm', { count: selectedIds.size }),
+      confirmLabel: t('common.delete'),
+    })) return
     setBulkBusy(true)
     try {
       await api.bulkActionAuthors([...selectedIds], action)
@@ -225,7 +241,7 @@ export default function AuthorsPage() {
       mediaType: t(`mediaType.${mediaType}`, mediaType),
       defaultValue: `Set the media type for every book of {{count}} selected authors to {{mediaType}}? This rewrites existing book rows and may re-evaluate wanted/missing status.`,
     })
-    if (!confirm(confirmMsg)) return
+    if (!await confirm({ title: t('common.confirmTitle'), body: confirmMsg })) return
     setBulkBusy(true)
     try {
       await api.bulkActionAuthors([...selectedIds], 'set_media_type', mediaType)
@@ -321,6 +337,7 @@ export default function AuthorsPage() {
 
   return (
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
+      {confirmDialog}
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">{t('authors.title')}</h2>
         <div className="flex items-center gap-2 flex-wrap justify-end">

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../components/useConfirmDialog'
 import ViewToggle from '../components/ViewToggle'
 import { bookStatusBadge } from '../components/bookStatus'
 import BookStatusLegend from '../components/BookStatusLegend'
@@ -32,6 +33,7 @@ const statusLabelKeys: Record<string, string> = {
 
 export default function BooksPage() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [books, setBooks] = useState<Book[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
@@ -117,7 +119,11 @@ export default function BooksPage() {
 
   const runBulk = async (action: Parameters<typeof api.bulkActionBooks>[1], mediaType?: MediaType) => {
     if (selectedIds.size === 0) return
-    if (action === 'delete' && !confirm(t('books.deleteConfirm', { count: selectedIds.size }))) return
+    if (action === 'delete' && !await confirm({
+      title: t('common.confirmTitle'),
+      body: t('books.deleteConfirm', { count: selectedIds.size }),
+      confirmLabel: t('common.delete'),
+    })) return
     setBulkBusy(true)
     try {
       await api.bulkActionBooks([...selectedIds], action, mediaType)
@@ -176,6 +182,7 @@ export default function BooksPage() {
 
   return (
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
+      {confirmDialog}
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">{t('books.title')}</h2>
         <div className="flex items-center gap-3">

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router'
 import QueuePage, { MatchBookControl } from './QueuePage'
 import { summarizeError, ERROR_SUMMARY_LEN } from './queueError'
 import { api } from '../api/client'
+import { acceptConfirm } from '../test-utils'
 import type { Download, PendingRelease, QueueItem } from '../api/client'
 
 vi.mock('../api/client', async importOriginal => {
@@ -257,16 +258,14 @@ describe('QueuePage', () => {
       makeQueueItem({ id: 2, title: 'Bad A', status: 'importFailed', errorMessage: 'x' }),
       makeQueueItem({ id: 3, title: 'Bad B', status: 'failed', errorMessage: 'y' }),
     ])
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-
     renderQueuePage()
     fireEvent.click(await screen.findByRole('button', { name: 'Clear all failed' }))
+    await acceptConfirm()
 
     await waitFor(() => expect(api.deleteFromQueue).toHaveBeenCalledWith(2, false))
     expect(api.deleteFromQueue).toHaveBeenCalledWith(3, false)
     // The healthy downloading item must NOT be cleared.
     expect(api.deleteFromQueue).not.toHaveBeenCalledWith(1, false)
-    confirmSpy.mockRestore()
   })
 
   it('bulk-removes arbitrarily selected items and unmonitors their books by default', async () => {
@@ -277,7 +276,6 @@ describe('QueuePage', () => {
         makeQueueItem({ id: 3, title: 'Keep', status: 'downloading' }),
       ])
       .mockResolvedValueOnce([])
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     renderQueuePage()
 
@@ -287,11 +285,11 @@ describe('QueuePage', () => {
     fireEvent.click(within(b.closest('div')!.parentElement!).getByRole('checkbox'))
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove selected' }))
+    await acceptConfirm()
 
     // unmonitorBooks defaults ON (undo a mass import); deleteFiles defaults OFF.
     // The unselected "Keep" item is not touched.
     await waitFor(() => expect(api.bulkDeleteQueue).toHaveBeenCalledWith([1, 2], { deleteFiles: false, unmonitorBooks: true }))
-    confirmSpy.mockRestore()
   })
 
   it('select-all covers the whole queue and can also delete downloaded files', async () => {
@@ -299,7 +297,6 @@ describe('QueuePage', () => {
       makeQueueItem({ id: 1, title: 'A', status: 'downloading' }),
       makeQueueItem({ id: 2, title: 'B', status: 'downloading' }),
     ])
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     renderQueuePage()
 
@@ -307,9 +304,9 @@ describe('QueuePage', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }))
     fireEvent.click(screen.getByRole('checkbox', { name: 'Delete downloaded files' }))
     fireEvent.click(screen.getByRole('button', { name: 'Remove selected' }))
+    await acceptConfirm()
 
     await waitFor(() => expect(api.bulkDeleteQueue).toHaveBeenCalledWith([1, 2], { deleteFiles: true, unmonitorBooks: true }))
-    confirmSpy.mockRestore()
   })
 
   it('retries an import-failed queue item and reloads the queue', async () => {

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../components/useConfirmDialog'
 import { api, Book, PendingRelease, QueueItem } from '../api/client'
 import BookAuthorLink from '../components/BookAuthorLink'
 import ImportHints from '../components/ImportHints'
@@ -10,6 +11,7 @@ import { btn, btnSize } from '../components/buttons'
 
 export default function QueuePage() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [queue, setQueue] = useState<QueueItem[]>([])
   const [pending, setPending] = useState<PendingRelease[]>([])
   const [loading, setLoading] = useState(true)
@@ -231,7 +233,12 @@ export default function QueuePage() {
   // per-item endpoints (no new API). Retry only applies to importFailed.
   const [bulkBusy, setBulkBusy] = useState(false)
   const clearAllFailed = async () => {
-    if (failedItems.length === 0 || !confirm(t('queue.clearAllConfirm', { count: failedItems.length, defaultValue: 'Remove {{count}} failed item(s) from the queue?' }))) return
+    if (failedItems.length === 0) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('queue.clearAllConfirm', { count: failedItems.length, defaultValue: 'Remove {{count}} failed item(s) from the queue?' }),
+      confirmLabel: t('common.remove'),
+    })) return
     setBulkBusy(true)
     try {
       await Promise.all(failedItems.map(it => api.deleteFromQueue(it.id, false).catch(() => {})))
@@ -257,7 +264,11 @@ export default function QueuePage() {
   // immediately re-grab them — the recovery path for an accidental mass import.
   const removeSelected = async () => {
     if (selectedIds.size === 0) return
-    if (!confirm(t('queue.removeSelectedConfirm', { count: selectedIds.size, defaultValue: 'Remove {{count}} item(s) from the queue?' }))) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('queue.removeSelectedConfirm', { count: selectedIds.size, defaultValue: 'Remove {{count}} item(s) from the queue?' }),
+      confirmLabel: t('common.remove'),
+    })) return
     setBulkBusy(true)
     setBulkResult(null)
     try {
@@ -317,6 +328,7 @@ export default function QueuePage() {
 
   return (
     <div>
+      {confirmDialog}
       <h2 className="text-2xl font-bold mb-6">{t('queue.title')}</h2>
 
       {loading ? (

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -4,6 +4,8 @@ import { MemoryRouter } from 'react-router'
 import SeriesPage from './SeriesPage'
 import { api } from '../api/client'
 import type { Series, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
+import '../i18n'
+import { acceptConfirm } from '../test-utils'
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -471,29 +473,28 @@ describe('SeriesPage', () => {
     vi.mocked(api.updateSeries).mockResolvedValue(renamed)
     vi.mocked(api.deleteSeries).mockResolvedValue(undefined)
     vi.mocked(api.deleteBook).mockResolvedValue(undefined)
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
-    try {
-      renderSeriesPage([initial])
+    renderSeriesPage([initial])
 
-      expect(await screen.findByRole('heading', { name: 'Old Series' })).toBeInTheDocument()
-      fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-      const dialog = await screen.findByRole('dialog', { name: 'Rename Series' })
-      fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'New Series' } })
-      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+    expect(await screen.findByRole('heading', { name: 'Old Series' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Rename Series' })
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'New Series' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
 
-      fireEvent.click(await screen.findByRole('heading', { name: 'New Series' }))
-      expect(await screen.findByRole('link', { name: /Existing Linked Book/ })).toHaveAttribute('href', '/book/201')
-      fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    fireEvent.click(await screen.findByRole('heading', { name: 'New Series' }))
+    expect(await screen.findByRole('link', { name: /Existing Linked Book/ })).toHaveAttribute('href', '/book/201')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
-      await waitFor(() => expect(api.deleteSeries).toHaveBeenCalledWith(20))
-      expect(api.deleteSeries).toHaveBeenCalledTimes(1)
-      expect(api.deleteBook).not.toHaveBeenCalled()
-      expect(confirmSpy).toHaveBeenCalledWith('Delete "New Series" from Series? Linked books will stay in your library.')
-      await waitFor(() => expect(screen.queryByRole('heading', { name: 'New Series' })).not.toBeInTheDocument())
-    } finally {
-      confirmSpy.mockRestore()
-    }
+    // In-app modal since #2359: the warning that linked books survive is on
+    // screen instead of inside a window.confirm string.
+    expect(await screen.findByText('Delete "New Series" from Series? Linked books will stay in your library.')).toBeInTheDocument()
+    await acceptConfirm()
+
+    await waitFor(() => expect(api.deleteSeries).toHaveBeenCalledWith(20))
+    expect(api.deleteSeries).toHaveBeenCalledTimes(1)
+    expect(api.deleteBook).not.toHaveBeenCalled()
+    await waitFor(() => expect(screen.queryByRole('heading', { name: 'New Series' })).not.toBeInTheDocument())
   })
 
   it('links an existing library book to an expanded series', async () => {

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router'
+import { useTranslation } from 'react-i18next'
 import { api, MediaType, Series, SeriesHardcoverDiff, SeriesHardcoverDiffBook, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
 import { hardcoverSeriesUrl } from '../util/metadataSource'
 import AddSeriesBookModal from '../components/AddSeriesBookModal'
@@ -7,8 +8,11 @@ import HardcoverSeriesLinkModal from '../components/HardcoverSeriesLinkModal'
 import SeriesNameModal from '../components/SeriesNameModal'
 import { btn, btnSize } from '../components/buttons'
 import Switch from '../components/Switch'
+import { useConfirmDialog } from '../components/useConfirmDialog'
 
 export default function SeriesPage() {
+  const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const location = useLocation()
   const [seriesList, setSeriesList] = useState<Series[]>([])
   const [loading, setLoading] = useState(true)
@@ -109,7 +113,11 @@ export default function SeriesPage() {
   }
 
   const deleteSeries = async (series: Series) => {
-    if (!confirm(`Delete "${series.title}" from Series? Linked books will stay in your library.`)) return
+    if (!await confirm({
+      title: t('series.deleteTitle'),
+      body: t('series.deleteConfirm', { title: series.title }),
+      confirmLabel: t('common.delete'),
+    })) return
     await api.deleteSeries(series.id)
     setSeriesList(prev => prev.filter(item => item.id !== series.id))
     setDiffs(prev => {
@@ -240,6 +248,7 @@ export default function SeriesPage() {
 
   return (
     <div>
+      {confirmDialog}
       <div className="flex items-center justify-between gap-3 flex-wrap mb-6">
         <h2 className="text-2xl font-bold">Series</h2>
         <div className="flex items-center gap-3">

--- a/web/src/pages/SettingsPage.absReview.test.tsx
+++ b/web/src/pages/SettingsPage.absReview.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import SettingsPage from './SettingsPage'
 import { api } from '../api/client'
 import type { ABSReviewItem, Author, Book } from '../api/client'
+import { acceptConfirm, cancelConfirm, confirmDialog } from '../test-utils'
 
 vi.mock('../settings/AuthSettings', () => ({ default: () => <div data-testid="auth-settings" /> }))
 vi.mock('../components/ThemeToggle', () => ({ default: () => <button type="button">Theme</button> }))
@@ -293,37 +294,30 @@ describe('SettingsPage ABS review search', () => {
     const itemB = makeReviewItem({ id: 2, itemId: 'item-2', latestRunId: 42 })
     const itemC = makeReviewItem({ id: 3, itemId: 'item-3', latestRunId: 99 })
     vi.mocked(api.dismissAbsReviewRun).mockResolvedValue({ dismissed: 2 })
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-    try {
-      await renderABSReview([itemA, itemB, itemC])
+    await renderABSReview([itemA, itemB, itemC])
 
-      const button = await screen.findAllByRole('button', { name: /Dismiss all from this run/ })
-      // Two groups (run 42 and run 99). Most-recent (99) renders first, so
-      // index 1 is the 42-group click target.
-      expect(button.length).toBe(2)
+    const button = await screen.findAllByRole('button', { name: /Dismiss all from this run/ })
+    // Two groups (run 42 and run 99). Most-recent (99) renders first, so
+    // index 1 is the 42-group click target.
+    expect(button.length).toBe(2)
 
-      fireEvent.click(button[1])
+    fireEvent.click(button[1])
+    await acceptConfirm()
 
-      await waitFor(() => {
-        expect(api.dismissAbsReviewRun).toHaveBeenCalledWith(42)
-      })
-      expect(confirmSpy).toHaveBeenCalled()
-    } finally {
-      confirmSpy.mockRestore()
-    }
+    await waitFor(() => {
+      expect(api.dismissAbsReviewRun).toHaveBeenCalledWith(42)
+    })
   })
 
   it('does nothing when the per-run dismiss confirmation is cancelled', async () => {
     const itemA = makeReviewItem({ id: 1, itemId: 'item-1', latestRunId: 42 })
     vi.mocked(api.dismissAbsReviewRun).mockResolvedValue({ dismissed: 1 })
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
-    try {
-      await renderABSReview([itemA])
-      const buttons = await screen.findAllByRole('button', { name: /Dismiss all from this run/ })
-      fireEvent.click(buttons[0])
-      expect(api.dismissAbsReviewRun).not.toHaveBeenCalled()
-    } finally {
-      confirmSpy.mockRestore()
-    }
+    await renderABSReview([itemA])
+    const buttons = await screen.findAllByRole('button', { name: /Dismiss all from this run/ })
+    fireEvent.click(buttons[0])
+    await cancelConfirm()
+
+    await waitFor(() => expect(confirmDialog()).not.toBeInTheDocument())
+    expect(api.dismissAbsReviewRun).not.toHaveBeenCalled()
   })
 })

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import SettingsPage from './SettingsPage'
+import { acceptConfirm } from '../test-utils'
 import { api, type ABSImportRun, type DownloadClient, type HardcoverList, type ImportList, type ImportListSyncProgress, type Indexer, type OidcProvider, type ProwlarrInstance, type RootFolder, type SystemStatus } from '../api/client'
 
 const mockAuthContext = vi.hoisted(() => ({
@@ -448,7 +449,7 @@ describe('SettingsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save Hardcover API token' }))
 
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('hardcover.api_token', 'hc-secret')
+    expect(api.setSetting).toHaveBeenCalledWith('hardcover.api_token', 'hc-secret')
     })
   })
 
@@ -460,17 +461,17 @@ describe('SettingsPage', () => {
     fireEvent.click(apiKeys.getByTitle('common.enable'))
 
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('hardcover.enhanced_series_enabled', 'true')
+    expect(api.setSetting).toHaveBeenCalledWith('hardcover.enhanced_series_enabled', 'true')
     })
   })
 
   it('tests the configured Hardcover token without exposing it', async () => {
     vi.mocked(api.status).mockResolvedValue({
-      version: 'dev',
-      commit: 'unknown',
-      buildDate: '',
-      enhancedHardcoverApi: true,
-      hardcoverTokenConfigured: true,
+    version: 'dev',
+    commit: 'unknown',
+    buildDate: '',
+    enhancedHardcoverApi: true,
+    hardcoverTokenConfigured: true,
     })
 
     renderSettings()
@@ -479,7 +480,7 @@ describe('SettingsPage', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Test Hardcover API' }))
 
     await waitFor(() => {
-      expect(api.testHardcover).toHaveBeenCalled()
+    expect(api.testHardcover).toHaveBeenCalled()
     })
     expect(await screen.findByText('Found 2 series; catalog "Dune" has 8 books')).toBeInTheDocument()
     expect(screen.queryByText('hc-secret')).not.toBeInTheDocument()
@@ -487,39 +488,39 @@ describe('SettingsPage', () => {
 
   it('adds global-token Hardcover lists disabled by default from the import picker', async () => {
     renderSettings({
-      status: {
-        version: 'dev',
-        commit: 'unknown',
-        buildDate: '',
-        enhancedHardcoverApi: false,
-        hardcoverTokenConfigured: true,
-      },
-      hardcoverLists: [makeHardcoverList({ name: 'Sci-Fi Backlog', slug: 'sci-fi-backlog', booksCount: 7 })],
+    status: {
+      version: 'dev',
+      commit: 'unknown',
+      buildDate: '',
+      enhancedHardcoverApi: false,
+      hardcoverTokenConfigured: true,
+    },
+    hardcoverLists: [makeHardcoverList({ name: 'Sci-Fi Backlog', slug: 'sci-fi-backlog', booksCount: 7 })],
     })
 
     await openImportTab()
     expect(await screen.findByText('Sci-Fi Backlog')).toBeInTheDocument()
     await waitFor(() => {
-      expect(api.hardcoverLists).toHaveBeenCalledWith(undefined)
+    expect(api.hardcoverLists).toHaveBeenCalledWith(undefined)
     })
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'settings.import.hardcoverImportList' }))
 
     await waitFor(() => {
-      expect(api.addImportList).toHaveBeenCalledWith(expect.objectContaining({
-        name: 'Sci-Fi Backlog',
-        type: 'hardcover',
-        url: 'sci-fi-backlog',
-        apiKey: '',
-        enabled: false,
-      }))
+    expect(api.addImportList).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Sci-Fi Backlog',
+      type: 'hardcover',
+      url: 'sci-fi-backlog',
+      apiKey: '',
+      enabled: false,
+    }))
     })
   })
 
   it('toggles a Hardcover list between downloading and cataloguing its books (#2124)', async () => {
     renderSettings({
-      importLists: [makeImportList({ id: 44, name: 'Want to Read', url: 'want-to-read', enabled: true, monitorNew: true })],
-      hardcoverLists: [makeHardcoverList()],
+    importLists: [makeImportList({ id: 44, name: 'Want to Read', url: 'want-to-read', enabled: true, monitorNew: true })],
+    hardcoverLists: [makeHardcoverList()],
     })
 
     await openImportTab()
@@ -528,7 +529,7 @@ describe('SettingsPage', () => {
 
     fireEvent.click(toggle)
     await waitFor(() => {
-      expect(api.updateImportList).toHaveBeenCalledWith(44, { monitorNew: false })
+    expect(api.updateImportList).toHaveBeenCalledWith(44, { monitorNew: false })
     })
     // The row reflects the saved value, so the next click sends true again.
     expect(await screen.findByRole('checkbox', { name: 'Download books from this list' })).not.toBeChecked()
@@ -536,8 +537,8 @@ describe('SettingsPage', () => {
 
   it('keeps per-list Hardcover override tokens write-only in the import picker', async () => {
     renderSettings({
-      importLists: [makeImportList({ id: 44, name: 'Want to Read', url: 'want-to-read', apiKeyConfigured: true, enabled: true })],
-      hardcoverLists: [makeHardcoverList()],
+    importLists: [makeImportList({ id: 44, name: 'Want to Read', url: 'want-to-read', apiKeyConfigured: true, enabled: true })],
+    hardcoverLists: [makeHardcoverList()],
     })
 
     await openImportTab()
@@ -549,20 +550,20 @@ describe('SettingsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear override' }))
     await waitFor(() => {
-      expect(api.updateImportList).toHaveBeenCalledWith(44, { clearApiKey: true })
+    expect(api.updateImportList).toHaveBeenCalledWith(44, { clearApiKey: true })
     })
   })
 
   it('starts a Hardcover sync in the background and shows it running (#1854)', async () => {
     renderSettings({
-      importLists: [makeImportList({ id: 44, name: 'Want to Read', url: 'want-to-read', enabled: true })],
-      hardcoverLists: [makeHardcoverList()],
-      syncStart: makeSyncProgress({
-        running: true,
-        listId: 44,
-        trigger: 'manual',
-        message: 'reading list from Hardcover…',
-      }),
+    importLists: [makeImportList({ id: 44, name: 'Want to Read', url: 'want-to-read', enabled: true })],
+    hardcoverLists: [makeHardcoverList()],
+    syncStart: makeSyncProgress({
+      running: true,
+      listId: 44,
+      trigger: 'manual',
+      message: 'reading list from Hardcover…',
+    }),
     })
 
     await openImportTab()
@@ -571,7 +572,7 @@ describe('SettingsPage', () => {
     // The request returns 202 immediately: the row switches to "Syncing…" and
     // the button locks, without the click awaiting the whole sync.
     await waitFor(() => {
-      expect(api.syncImportList).toHaveBeenCalledWith(44)
+    expect(api.syncImportList).toHaveBeenCalledWith(44)
     })
     const syncing = await screen.findByRole('button', { name: 'Syncing…' })
     expect(syncing).toBeDisabled()
@@ -580,15 +581,15 @@ describe('SettingsPage', () => {
 
   it('adopts a Hardcover sync already running when the tab mounts', async () => {
     renderSettings({
-      importLists: [makeImportList({ id: 44, name: 'Want to Read', url: 'want-to-read', enabled: true })],
-      hardcoverLists: [makeHardcoverList()],
-      syncStatus: makeSyncProgress({
-        running: true,
-        listId: 44,
-        trigger: 'scheduled',
-        message: 'importing 40 books from Want to Read…',
-        stats: { total: 40, processed: 12, imported: 9, skipped: 3, failed: 0 },
-      }),
+    importLists: [makeImportList({ id: 44, name: 'Want to Read', url: 'want-to-read', enabled: true })],
+    hardcoverLists: [makeHardcoverList()],
+    syncStatus: makeSyncProgress({
+      running: true,
+      listId: 44,
+      trigger: 'scheduled',
+      message: 'importing 40 books from Want to Read…',
+      stats: { total: 40, processed: 12, imported: 9, skipped: 3, failed: 0 },
+    }),
     })
 
     await openImportTab()
@@ -598,11 +599,11 @@ describe('SettingsPage', () => {
 
   it('keeps duplicate saved Hardcover lists with the same slug visible and actionable', async () => {
     renderSettings({
-      importLists: [
-        makeImportList({ id: 44, name: 'Global Want to Read', url: 'want-to-read', apiKeyConfigured: false, enabled: false }),
-        makeImportList({ id: 45, name: 'Override Want to Read', url: 'want-to-read', apiKeyConfigured: true, enabled: true }),
-      ],
-      hardcoverLists: [makeHardcoverList({ name: 'Remote Want to Read', slug: 'want-to-read', booksCount: 12 })],
+    importLists: [
+      makeImportList({ id: 44, name: 'Global Want to Read', url: 'want-to-read', apiKeyConfigured: false, enabled: false }),
+      makeImportList({ id: 45, name: 'Override Want to Read', url: 'want-to-read', apiKeyConfigured: true, enabled: true }),
+    ],
+    hardcoverLists: [makeHardcoverList({ name: 'Remote Want to Read', slug: 'want-to-read', booksCount: 12 })],
     })
 
     await openImportTab()
@@ -617,7 +618,7 @@ describe('SettingsPage', () => {
     fireEvent.click(within(globalRow as HTMLElement).getByRole('checkbox'))
 
     await waitFor(() => {
-      expect(api.updateImportList).toHaveBeenCalledWith(44, { enabled: true })
+    expect(api.updateImportList).toHaveBeenCalledWith(44, { enabled: true })
     })
   })
 
@@ -627,11 +628,11 @@ describe('SettingsPage', () => {
     // list, and clicking it creates a NEW import list carrying account bob —
     // not a toggle of Alice's row.
     renderSettings({
-      importLists: [
-        makeImportList({ id: 61, name: "Alice Want to Read", url: 'want-to-read', account: 'alice', apiKeyConfigured: true, enabled: true }),
-      ],
-      hardcoverLists: [makeHardcoverList({ name: 'Want to Read', slug: 'want-to-read', booksCount: 4 })],
-      hardcoverAccount: 'bob',
+    importLists: [
+      makeImportList({ id: 61, name: "Alice Want to Read", url: 'want-to-read', account: 'alice', apiKeyConfigured: true, enabled: true }),
+    ],
+    hardcoverLists: [makeHardcoverList({ name: 'Want to Read', slug: 'want-to-read', booksCount: 4 })],
+    hardcoverAccount: 'bob',
     })
 
     await openImportTab()
@@ -645,16 +646,16 @@ describe('SettingsPage', () => {
     fireEvent.click(within(remoteRow as HTMLElement).getByRole('checkbox'))
 
     await waitFor(() => {
-      expect(api.addImportList).toHaveBeenCalledWith(
-        expect.objectContaining({ url: 'want-to-read', account: 'bob' }),
-      )
+    expect(api.addImportList).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'want-to-read', account: 'bob' }),
+    )
     })
     expect(api.updateImportList).not.toHaveBeenCalled()
   })
 
   it('can load Hardcover list picker results from a per-list override token', async () => {
     renderSettings({
-      hardcoverLists: [makeHardcoverList({ id: 51, name: 'Other Account', slug: 'other-account', booksCount: 3 })],
+    hardcoverLists: [makeHardcoverList({ id: 51, name: 'Other Account', slug: 'other-account', booksCount: 3 })],
     })
 
     await openImportTab()
@@ -663,19 +664,19 @@ describe('SettingsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Load token lists' }))
 
     await waitFor(() => {
-      expect(api.hardcoverLists).toHaveBeenCalledWith('override-token')
+    expect(api.hardcoverLists).toHaveBeenCalledWith('override-token')
     })
   })
 
   it('persists import mode, naming templates, and preferred language', async () => {
     renderSettings({
-      settings: [
-        { key: 'import.mode', value: 'move' },
-        { key: 'naming.bookTemplate', value: '{OldBook}' },
-        { key: 'naming_template_audiobook', value: '{OldAudio}' },
-        { key: 'search.preferredLanguage', value: 'en' },
-        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
-      ],
+    settings: [
+      { key: 'import.mode', value: 'move' },
+      { key: 'naming.bookTemplate', value: '{OldBook}' },
+      { key: 'naming_template_audiobook', value: '{OldAudio}' },
+      { key: 'search.preferredLanguage', value: 'en' },
+      { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+    ],
     })
 
     expect(await screen.findByText('Import Mode')).toBeInTheDocument()
@@ -685,29 +686,29 @@ describe('SettingsPage', () => {
     await waitFor(() => expect(api.setSetting).toHaveBeenCalledWith('import.mode', 'copy'))
 
     fireEvent.change(fileNaming.getByPlaceholderText('{Author}/{Title} ({Year})/{Title} - {Author}.{ext}'), {
-      target: { value: '{Author}/{Title}/{Title}.{ext}' },
+    target: { value: '{Author}/{Title}/{Title}.{ext}' },
     })
     // Selected by test id, not index: once the first save lands the button
     // relabels to "Saved ✓" for two seconds, which shifts every index-based
     // lookup after it (#1668).
     fireEvent.click(fileNaming.getByTestId('naming-save-book'))
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('naming.bookTemplate', '{Author}/{Title}/{Title}.{ext}')
+    expect(api.setSetting).toHaveBeenCalledWith('naming.bookTemplate', '{Author}/{Title}/{Title}.{ext}')
     })
 
     fireEvent.change(fileNaming.getByPlaceholderText('{Author}/{Title} ({Year})'), {
-      target: { value: '{Author}/{Title}' },
+    target: { value: '{Author}/{Title}' },
     })
     fireEvent.click(fileNaming.getByTestId('naming-save-audiobook'))
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('naming_template_audiobook', '{Author}/{Title}')
+    expect(api.setSetting).toHaveBeenCalledWith('naming_template_audiobook', '{Author}/{Title}')
     })
 
     const downloads = sectionForHeading('settings.general.downloads')
     fireEvent.change(downloads.getByRole('combobox'), { target: { value: 'any' } })
     fireEvent.click(downloads.getByRole('button', { name: 'common.save' }))
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('search.preferredLanguage', 'any')
+    expect(api.setSetting).toHaveBeenCalledWith('search.preferredLanguage', 'any')
     })
   })
 
@@ -734,8 +735,8 @@ describe('SettingsPage', () => {
 
   it('refreshes library scan status', async () => {
     vi.mocked(api.libraryScanStatus)
-      .mockResolvedValueOnce({ ran_at: new Date(Date.now() - 10_000).toISOString(), files_found: 2, reconciled: 1, unmatched: 1 })
-      .mockResolvedValueOnce({ ran_at: new Date(Date.now() + 10_000).toISOString(), files_found: 9, reconciled: 5, unmatched: 4 })
+    .mockResolvedValueOnce({ ran_at: new Date(Date.now() - 10_000).toISOString(), files_found: 2, reconciled: 1, unmatched: 1 })
+    .mockResolvedValueOnce({ ran_at: new Date(Date.now() + 10_000).toISOString(), files_found: 9, reconciled: 5, unmatched: 4 })
 
     renderSettings()
 
@@ -754,14 +755,14 @@ describe('SettingsPage', () => {
 
   it('surfaces scanned paths and warns when no files were found', async () => {
     vi.mocked(api.libraryScanStatus).mockResolvedValue({
-      ran_at: new Date().toISOString(),
-      files_found: 0,
-      reconciled: 0,
-      unmatched: 0,
-      library_dir: '/books',
-      audiobook_dir: '',
-      scanned_paths: ['/books'],
-      no_files_found: true,
+    ran_at: new Date().toISOString(),
+    files_found: 0,
+    reconciled: 0,
+    unmatched: 0,
+    library_dir: '/books',
+    audiobook_dir: '',
+    scanned_paths: ['/books'],
+    no_files_found: true,
     })
 
     renderSettings()
@@ -776,13 +777,13 @@ describe('SettingsPage', () => {
 
   it('hints to populate catalogue when files found but none matched', async () => {
     vi.mocked(api.libraryScanStatus).mockResolvedValue({
-      ran_at: new Date().toISOString(),
-      files_found: 12,
-      reconciled: 0,
-      unmatched: 12,
-      library_dir: '/books',
-      scanned_paths: ['/books'],
-      no_files_found: false,
+    ran_at: new Date().toISOString(),
+    files_found: 12,
+    reconciled: 0,
+    unmatched: 12,
+    library_dir: '/books',
+    scanned_paths: ['/books'],
+    no_files_found: false,
     })
 
     renderSettings()
@@ -799,19 +800,19 @@ describe('SettingsPage', () => {
     // reports author_not_in_library, the hint must name the parsed author and
     // the old advice must not be shown.
     vi.mocked(api.libraryScanStatus).mockResolvedValue({
-      ran_at: new Date().toISOString(),
-      files_found: 1,
-      reconciled: 0,
-      unmatched: 1,
-      library_dir: '/books',
-      scanned_paths: ['/books'],
-      no_files_found: false,
-      unmatched_files: [{
-        path: '/books/Álvaro Enrigue/You Dreamed of Empires/You Dreamed of Empires.m4b',
-        parsed_title: 'You Dreamed of Empires',
-        parsed_author: 'Álvaro Enrigue, Natasha Wimmer - translator, Gabriel Porras',
-        reason: 'author_not_in_library',
-      }],
+    ran_at: new Date().toISOString(),
+    files_found: 1,
+    reconciled: 0,
+    unmatched: 1,
+    library_dir: '/books',
+    scanned_paths: ['/books'],
+    no_files_found: false,
+    unmatched_files: [{
+      path: '/books/Álvaro Enrigue/You Dreamed of Empires/You Dreamed of Empires.m4b',
+      parsed_title: 'You Dreamed of Empires',
+      parsed_author: 'Álvaro Enrigue, Natasha Wimmer - translator, Gabriel Porras',
+      reason: 'author_not_in_library',
+    }],
     })
 
     renderSettings()
@@ -828,19 +829,19 @@ describe('SettingsPage', () => {
     // proves nothing about the other 4000, so the specific "your authors don't
     // match" hint must fall back to the generic advice when the list is capped.
     vi.mocked(api.libraryScanStatus).mockResolvedValue({
-      ran_at: new Date().toISOString(),
-      files_found: 5000,
-      reconciled: 0,
-      unmatched: 5000,
-      library_dir: '/books',
-      scanned_paths: ['/books'],
-      no_files_found: false,
-      unmatched_files: [{
-        path: '/books/Becky Chambers/A Psalm for the Wild-Built.epub',
-        parsed_title: 'A Psalm for the Wild-Built',
-        parsed_author: 'Becky Chambers',
-        reason: 'author_not_in_library',
-      }],
+    ran_at: new Date().toISOString(),
+    files_found: 5000,
+    reconciled: 0,
+    unmatched: 5000,
+    library_dir: '/books',
+    scanned_paths: ['/books'],
+    no_files_found: false,
+    unmatched_files: [{
+      path: '/books/Becky Chambers/A Psalm for the Wild-Built.epub',
+      parsed_title: 'A Psalm for the Wild-Built',
+      parsed_author: 'Becky Chambers',
+      reason: 'author_not_in_library',
+    }],
     })
 
     renderSettings()
@@ -855,17 +856,17 @@ describe('SettingsPage', () => {
     // diagnosis must still produce it — the fix narrows the message, it doesn't
     // replace it.
     vi.mocked(api.libraryScanStatus).mockResolvedValue({
-      ran_at: new Date().toISOString(),
-      files_found: 2,
-      reconciled: 0,
-      unmatched: 2,
-      library_dir: '/books',
-      scanned_paths: ['/books'],
-      no_files_found: false,
-      unmatched_files: [
-        { path: '/books/Andy Weir/Project Hail Mary.epub', parsed_title: 'Project Hail Mary', parsed_author: 'Andy Weir', reason: 'no_candidate_books' },
-        { path: '/books/Andy Weir/The Martian.epub', parsed_title: 'The Martian', parsed_author: 'Andy Weir', reason: 'author_not_in_library' },
-      ],
+    ran_at: new Date().toISOString(),
+    files_found: 2,
+    reconciled: 0,
+    unmatched: 2,
+    library_dir: '/books',
+    scanned_paths: ['/books'],
+    no_files_found: false,
+    unmatched_files: [
+      { path: '/books/Andy Weir/Project Hail Mary.epub', parsed_title: 'Project Hail Mary', parsed_author: 'Andy Weir', reason: 'no_candidate_books' },
+      { path: '/books/Andy Weir/The Martian.epub', parsed_title: 'The Martian', parsed_author: 'Andy Weir', reason: 'author_not_in_library' },
+    ],
     })
 
     renderSettings()
@@ -880,11 +881,11 @@ describe('SettingsPage', () => {
     // the Root Folders tab. The link must switch tabs in place (soft nav) rather
     // than full-page-reload.
     renderSettings({
-      rootFolders: [makeRootFolder({ id: 7, path: '/mnt/books' })],
-      settings: [
-        { key: 'default.media_type', value: 'ebook' },
-        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
-      ],
+    rootFolders: [makeRootFolder({ id: 7, path: '/mnt/books' })],
+    settings: [
+      { key: 'default.media_type', value: 'ebook' },
+      { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+    ],
     })
 
     await screen.findByRole('heading', { name: 'settings.general.defaultLibraryLocation' })
@@ -903,11 +904,11 @@ describe('SettingsPage', () => {
   // the importer reads to place authors without an explicit root folder.
   it('persists the default root folder from the Root Folders tab', async () => {
     renderSettings({
-      rootFolders: [makeRootFolder({ id: 7, path: '/mnt/books' })],
-      settings: [
-        { key: 'library.defaultRootFolderId', value: '' },
-        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
-      ],
+    rootFolders: [makeRootFolder({ id: 7, path: '/mnt/books' })],
+    settings: [
+      { key: 'library.defaultRootFolderId', value: '' },
+      { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+    ],
     })
     vi.mocked(api.addRootFolder).mockResolvedValue(makeRootFolder({ id: 8, path: '/mnt/audiobooks' }))
 
@@ -919,7 +920,7 @@ describe('SettingsPage', () => {
 
     fireEvent.change(select, { target: { value: '7' } })
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '7')
+    expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '7')
     })
 
     // A newly added folder becomes selectable as the default.
@@ -929,7 +930,7 @@ describe('SettingsPage', () => {
 
     fireEvent.change(screen.getByLabelText('settings.rootfolders.defaultLabel'), { target: { value: '8' } })
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '8')
+    expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '8')
     })
     expect(screen.getByLabelText('settings.rootfolders.defaultLabel')).toHaveValue('8')
   })
@@ -940,11 +941,11 @@ describe('SettingsPage', () => {
     vi.mocked(api.deleteRootFolder).mockResolvedValue(undefined)
 
     renderSettings({
-      rootFolders: [a, b],
-      settings: [
-        { key: 'library.defaultRootFolderId', value: '7' },
-        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
-      ],
+    rootFolders: [a, b],
+    settings: [
+      { key: 'library.defaultRootFolderId', value: '7' },
+      { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+    ],
     })
 
     await openRootFoldersTab()
@@ -955,16 +956,16 @@ describe('SettingsPage', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'common.remove' })[0])
     await waitFor(() => expect(api.deleteRootFolder).toHaveBeenCalledWith(7))
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '')
+    expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '')
     })
   })
 
   it('persists author/metadata default choices from the Metadata tab', async () => {
     renderSettings({
-      settings: [
-        { key: 'default.media_type', value: 'ebook' },
-        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
-      ],
+    settings: [
+      { key: 'default.media_type', value: 'ebook' },
+      { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+    ],
     })
 
     await openMetadataTab()
@@ -974,25 +975,25 @@ describe('SettingsPage', () => {
     // [0] metadata provider, [1] default media type, [2] default monitor mode.
     fireEvent.change(selects[1], { target: { value: 'audiobook' } })
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('default.media_type', 'audiobook')
+    expect(api.setSetting).toHaveBeenCalledWith('default.media_type', 'audiobook')
     })
     fireEvent.change(selects[2], { target: { value: 'latest' } })
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('author.default_monitor_mode', 'latest')
+    expect(api.setSetting).toHaveBeenCalledWith('author.default_monitor_mode', 'latest')
     })
     fireEvent.change(authorDefaults.getByRole('spinbutton'), { target: { value: '3' } })
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('author.default_monitor_latest_count', '3')
+    expect(api.setSetting).toHaveBeenCalledWith('author.default_monitor_latest_count', '3')
     })
   })
 
   it('persists auto-grab and recommendations toggles', async () => {
     renderSettings({
-      settings: [
-        { key: 'autoGrab.enabled', value: 'true' },
-        { key: 'recommendations.enabled', value: 'false' },
-        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
-      ],
+    settings: [
+      { key: 'autoGrab.enabled', value: 'true' },
+      { key: 'recommendations.enabled', value: 'false' },
+      { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+    ],
     })
 
     // Auto-grab + recommendations moved to the Metadata tab's Library Defaults.
@@ -1007,19 +1008,19 @@ describe('SettingsPage', () => {
 
     fireEvent.click(autoGrabToggle)
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('autoGrab.enabled', 'false')
+    expect(api.setSetting).toHaveBeenCalledWith('autoGrab.enabled', 'false')
     })
 
     fireEvent.click(recommendationsToggle)
     await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('recommendations.enabled', 'true')
+    expect(api.setSetting).toHaveBeenCalledWith('recommendations.enabled', 'true')
     })
   })
 
   it('persists authentication mode changes and refreshes auth status', async () => {
     vi.mocked(api.authConfig)
-      .mockResolvedValueOnce({ mode: 'enabled', apiKey: 'api-secret', username: 'admin' })
-      .mockResolvedValue({ mode: 'local-only', apiKey: 'api-secret', username: 'admin' })
+    .mockResolvedValueOnce({ mode: 'enabled', apiKey: 'api-secret', username: 'admin' })
+    .mockResolvedValue({ mode: 'local-only', apiKey: 'api-secret', username: 'admin' })
     vi.mocked(api.authSetMode).mockResolvedValue({ mode: 'local-only' })
 
     renderSettings()
@@ -1036,33 +1037,30 @@ describe('SettingsPage', () => {
   it('shows, copies, and regenerates the security API key', async () => {
     vi.mocked(api.authConfig).mockResolvedValue({ mode: 'enabled', apiKey: 'api-secret', username: 'admin' })
     vi.mocked(api.authRegenerateApiKey).mockResolvedValue({ apiKey: 'rotated-secret' })
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
-    try {
-      renderSettings()
+    renderSettings()
 
-      await screen.findByRole('heading', { name: 'Security' })
-      const security = sectionForHeading('Security')
-      expect(security.queryByText('api-secret')).not.toBeInTheDocument()
+    await screen.findByRole('heading', { name: 'Security' })
+    const security = sectionForHeading('Security')
+    expect(security.queryByText('api-secret')).not.toBeInTheDocument()
 
-      fireEvent.click(security.getByRole('button', { name: 'Show' }))
-      expect(security.getByText('api-secret')).toBeInTheDocument()
-      fireEvent.click(security.getByRole('button', { name: 'Hide' }))
-      expect(security.queryByText('api-secret')).not.toBeInTheDocument()
+    fireEvent.click(security.getByRole('button', { name: 'Show' }))
+    expect(security.getByText('api-secret')).toBeInTheDocument()
+    fireEvent.click(security.getByRole('button', { name: 'Hide' }))
+    expect(security.queryByText('api-secret')).not.toBeInTheDocument()
 
-      fireEvent.click(security.getByRole('button', { name: 'Copy' }))
-      await waitFor(() => {
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('api-secret')
-      })
-      expect(await security.findByRole('button', { name: 'Copied' })).toBeInTheDocument()
+    fireEvent.click(security.getByRole('button', { name: 'Copy' }))
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('api-secret')
+    })
+    expect(await security.findByRole('button', { name: 'Copied' })).toBeInTheDocument()
 
-      fireEvent.click(security.getByRole('button', { name: 'Regenerate' }))
-      await waitFor(() => expect(api.authRegenerateApiKey).toHaveBeenCalled())
-      expect(confirmSpy).toHaveBeenCalledWith('Regenerate the API key? Existing integrations using the old key will stop working.')
-      expect(await security.findByText('rotated-secret')).toBeInTheDocument()
-    } finally {
-      confirmSpy.mockRestore()
-    }
+    fireEvent.click(security.getByRole('button', { name: 'Regenerate' }))
+    // In-app modal since #2359. The message is an i18n key here because this
+    // suite stubs t to return keys.
+    await acceptConfirm()
+    await waitFor(() => expect(api.authRegenerateApiKey).toHaveBeenCalled())
+    expect(await security.findByText('rotated-secret')).toBeInTheDocument()
   })
 
   it('shows manual copy fallback when security API key clipboard access is blocked', async () => {
@@ -1618,31 +1616,26 @@ describe('SettingsPage', () => {
 
   it('tests, syncs, and deletes an existing Prowlarr instance', async () => {
     const prowlarr = makeProwlarr({ id: 33, name: 'Library Prowlarr', lastSyncAt: '2026-05-06T12:00:00Z' })
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
-    try {
-      renderSettings({ prowlarr: [prowlarr], indexers: [makeIndexer({ id: 11, prowlarrInstanceId: 33 })] })
-      vi.mocked(api.syncProwlarr).mockResolvedValue({ added: 1, updated: 2, removed: 3 })
-      vi.mocked(api.listProwlarr).mockResolvedValue([{ ...prowlarr, lastSyncAt: '2026-05-06T13:00:00Z' }])
-      await openIndexersTab()
+    renderSettings({ prowlarr: [prowlarr], indexers: [makeIndexer({ id: 11, prowlarrInstanceId: 33 })] })
+    vi.mocked(api.syncProwlarr).mockResolvedValue({ added: 1, updated: 2, removed: 3 })
+    vi.mocked(api.listProwlarr).mockResolvedValue([{ ...prowlarr, lastSyncAt: '2026-05-06T13:00:00Z' }])
+    await openIndexersTab()
 
-      fireEvent.click(screen.getByRole('button', { name: 'settings.prowlarr.test' }))
-      await waitFor(() => expect(api.testProwlarr).toHaveBeenCalledWith(33))
-      expect(await screen.findByText('settings.prowlarr.connectedVersion')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'settings.prowlarr.test' }))
+    await waitFor(() => expect(api.testProwlarr).toHaveBeenCalledWith(33))
+    expect(await screen.findByText('settings.prowlarr.connectedVersion')).toBeInTheDocument()
 
-      fireEvent.click(screen.getByRole('button', { name: 'settings.prowlarr.syncNow' }))
-      await waitFor(() => expect(api.syncProwlarr).toHaveBeenCalledWith(33))
-      expect(await screen.findByText('settings.prowlarr.synced')).toBeInTheDocument()
-      await waitFor(() => expect(api.listIndexers).toHaveBeenCalledTimes(2))
-      await waitFor(() => expect(api.listProwlarr).toHaveBeenCalledTimes(2))
+    fireEvent.click(screen.getByRole('button', { name: 'settings.prowlarr.syncNow' }))
+    await waitFor(() => expect(api.syncProwlarr).toHaveBeenCalledWith(33))
+    expect(await screen.findByText('settings.prowlarr.synced')).toBeInTheDocument()
+    await waitFor(() => expect(api.listIndexers).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(api.listProwlarr).toHaveBeenCalledTimes(2))
 
-      fireEvent.click(screen.getByRole('button', { name: 'settings.prowlarr.delete' }))
-      await waitFor(() => expect(api.deleteProwlarr).toHaveBeenCalledWith(33))
-      expect(confirmSpy).toHaveBeenCalledWith('settings.prowlarr.confirmDelete')
-      await waitFor(() => expect(screen.queryByText('Library Prowlarr')).not.toBeInTheDocument())
-    } finally {
-      confirmSpy.mockRestore()
-    }
+    fireEvent.click(screen.getByRole('button', { name: 'settings.prowlarr.delete' }))
+    await acceptConfirm()
+    await waitFor(() => expect(api.deleteProwlarr).toHaveBeenCalledWith(33))
+    await waitFor(() => expect(screen.queryByText('Library Prowlarr')).not.toBeInTheDocument())
   })
 
   it('adds a SABnzbd download client with API key, SSL, URL Base, and category mapping', async () => {
@@ -1904,20 +1897,16 @@ describe('SettingsPage', () => {
   it('deletes a backup from the list', async () => {
     const backup = { name: 'bindery_20260513_120000.db', size: 1024 * 512, modTime: new Date().toISOString() }
     vi.mocked(api.listBackups).mockResolvedValue([backup])
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-    try {
-      renderSettings()
-      await openLogsTab()
+    renderSettings()
+    await openLogsTab()
 
-      expect(await screen.findByText(backup.name)).toBeInTheDocument()
+    expect(await screen.findByText(backup.name)).toBeInTheDocument()
 
-      const deleteBtn = screen.getByRole('button', { name: 'common.delete' })
-      fireEvent.click(deleteBtn)
+    const deleteBtn = screen.getByRole('button', { name: 'common.delete' })
+    fireEvent.click(deleteBtn)
+    await acceptConfirm()
 
-      await waitFor(() => expect(api.deleteBackup).toHaveBeenCalledWith(backup.name))
-      await waitFor(() => expect(screen.queryByText(backup.name)).not.toBeInTheDocument())
-    } finally {
-      confirmSpy.mockRestore()
-    }
+    await waitFor(() => expect(api.deleteBackup).toHaveBeenCalledWith(backup.name))
+    await waitFor(() => expect(screen.queryByText(backup.name)).not.toBeInTheDocument())
   })
 })

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../components/useConfirmDialog'
 import { api, ManagedUser, UserOwnedRows, UserDeletePlan } from '../api/client'
 import { ApiError } from '../api/core'
 import DeleteUserDialog from './DeleteUserDialog'
@@ -10,6 +11,7 @@ const btnCls = 'px-3 py-1.5 rounded text-sm font-medium transition-colors'
 
 export default function UsersPage() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const { isAdmin, status } = useAuth()
   const [users, setUsers] = useState<ManagedUser[]>([])
   const [loading, setLoading] = useState(true)
@@ -59,7 +61,11 @@ export default function UsersPage() {
   // straight away; one who owns library data comes back 409 with the counts,
   // and that opens the dialog rather than failing (#1899).
   async function handleDelete(u: ManagedUser) {
-    if (!confirm(t('users.deleteConfirm', { username: u.username }))) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('users.deleteConfirm', { username: u.username }),
+      confirmLabel: t('common.delete'),
+    })) return
     setError('')
     try {
       await api.deleteUser(u.id)
@@ -119,6 +125,7 @@ export default function UsersPage() {
 
   return (
     <div className="space-y-8 max-w-2xl">
+      {confirmDialog}
       <h1 className="text-2xl font-bold">{t('users.title')}</h1>
 
       {pendingDelete && (

--- a/web/src/pages/settings/ABSTab.tsx
+++ b/web/src/pages/settings/ABSTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../../components/useConfirmDialog'
 import { api, ABSConfig, ABSImportProgress, ABSImportRun, ABSLibrary, ABSMetadataConflict, ABSReviewItem, ABSRollbackAction, ABSRollbackResult, ABSTestResult, Author, Book } from '../../api/client'
 import ABSConflictPanel from '../../components/ABSAuthorConflictsPanel'
 import { inputCls } from './formStyles'
@@ -38,6 +39,7 @@ export default function ABSTab() {
 
 function AudiobookshelfSection() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [config, setConfig] = useState<ABSConfig | null>(null)
   const [draft, setDraft] = useState({ baseUrl: '', apiKey: '', label: 'Audiobookshelf', enabled: false, libraryIds: [] as string[], pathRemap: '' })
   const [libraries, setLibraries] = useState<ABSLibrary[]>([])
@@ -331,7 +333,10 @@ function AudiobookshelfSection() {
   }
 
   const dismissReviewRun = async (runId: number, count: number) => {
-    if (!confirm(t('settings.abs.review.dismissRunConfirm', { count, runId, defaultValue: 'Dismiss {{count}} review items from run #{{runId}}? This cannot be undone.' }))) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('settings.abs.review.dismissRunConfirm', { count, runId, defaultValue: 'Dismiss {{count}} review items from run #{{runId}}? This cannot be undone.' }),
+    })) return
     setDismissingRunId(runId)
     setReviewError(null)
     try {
@@ -518,6 +523,7 @@ function AudiobookshelfSection() {
 
   return (
     <section>
+      {confirmDialog}
       <div className="flex items-center justify-between mb-2 gap-4">
         <div>
           <h3 className="text-base font-semibold text-slate-800 dark:text-zinc-200">Audiobookshelf</h3>

--- a/web/src/pages/settings/BlocklistTab.tsx
+++ b/web/src/pages/settings/BlocklistTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../../components/useConfirmDialog'
 import { api, BlocklistEntry } from '../../api/client'
 import Pagination from '../../components/Pagination'
 import { usePagination } from '../../components/usePagination'
@@ -14,6 +15,7 @@ function formatBlocklistDate(s: string) {
 
 export default function BlocklistTab() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [entries, setEntries] = useState<BlocklistEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [selected, setSelected] = useState<Set<number>>(new Set())
@@ -34,7 +36,11 @@ export default function BlocklistTab() {
 
   const handleBulkDelete = async () => {
     if (selected.size === 0) return
-    if (!confirm(t('blocklist.deleteConfirm', { count: selected.size }))) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('blocklist.deleteConfirm', { count: selected.size }),
+      confirmLabel: t('common.delete'),
+    })) return
     setDeleting(true)
     try {
       await api.bulkDeleteBlocklist(Array.from(selected))
@@ -70,6 +76,7 @@ export default function BlocklistTab() {
 
   return (
     <div>
+      {confirmDialog}
       <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
         <h3 className="text-lg font-semibold">{t('blocklist.title')}</h3>
         <div className="flex items-center gap-3">

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../../components/useConfirmDialog'
 import { api, AuthConfig, AuthStatus, StorageDirStatus, StorageHealth } from '../../api/client'
 import AuthSettings from '../../settings/AuthSettings'
 import ThemeToggle from '../../components/ThemeToggle'
@@ -727,6 +728,7 @@ function StorageHealthBadge({ status, loading }: { status: StorageDirStatus | un
 
 function SecuritySection() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const { status, refresh, isAdmin } = useAuth()
   const [cfg, setCfg] = useState<AuthConfig | null>(null)
   const [showKey, setShowKey] = useState(false)
@@ -746,7 +748,10 @@ function SecuritySection() {
   useEffect(() => { loadCfg() }, [])
 
   const regenerate = async () => {
-    if (!confirm('Regenerate the API key? Existing integrations using the old key will stop working.')) return
+    if (!await confirm({
+      title: t('settings.general.regenerateApiKeyTitle'),
+      body: t('settings.general.regenerateApiKeyConfirm'),
+    })) return
     setRegenerating(true)
     try {
       const r = await api.authRegenerateApiKey()
@@ -760,7 +765,11 @@ function SecuritySection() {
   }
 
   const rotateSessionSecret = async () => {
-    if (!confirm('Rotate the session signing secret? Existing logins keep working during a rotation window via the previous secret; a second rotation closes that window.')) return
+    if (!await confirm({
+      title: t('settings.general.rotateSessionSecretTitle'),
+      body: t('settings.general.rotateSessionSecretConfirm'),
+      acknowledgeLabel: t('settings.general.rotateSessionSecretAcknowledge'),
+    })) return
     setRotatingSecret(true)
     try {
       await api.authRotateSessionSecret()
@@ -796,6 +805,7 @@ function SecuritySection() {
 
   return (
     <section>
+      {confirmDialog}
       <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">Security</h3>
       <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-5">
         {isAdmin && (<>

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../../components/useConfirmDialog'
 import { api, Indexer, IndexerTestResult, ProwlarrInstance } from '../../api/client'
 // client.ts re-exports types only, so the helper comes from its own module.
 import { indexerNeedsAttention } from '../../api/indexers'
@@ -132,6 +133,7 @@ interface Props {
 }
 
 export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, setProwlarrInstances }: Props) {
+  const { confirm, confirmDialog } = useConfirmDialog()
   const { t } = useTranslation()
   const [showAddProwlarr, setShowAddProwlarr] = useState(false)
   const [editingProwlarr, setEditingProwlarr] = useState<number | null>(null)
@@ -144,6 +146,7 @@ export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, 
 
   return (
     <div>
+      {confirmDialog}
       <div className="flex justify-between items-center mb-4">
         <h3 className="text-lg font-semibold">{t('settings.indexers.heading')}</h3>
         <button onClick={() => setShowAddIndexer(true)} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium">
@@ -341,7 +344,11 @@ export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, 
                   </button>
                   <button
                     onClick={async () => {
-                      if (!confirm(t('settings.prowlarr.confirmDelete', { name: p.name }))) return
+                      if (!await confirm({
+                        title: t('common.confirmTitle'),
+                        body: t('settings.prowlarr.confirmDelete', { name: p.name }),
+                        confirmLabel: t('common.delete'),
+                      })) return
                       await api.deleteProwlarr(p.id)
                       setProwlarrInstances(prev => prev.filter(i => i.id !== p.id))
                       api.listIndexers().then(setIndexers).catch(console.error)

--- a/web/src/pages/settings/LogsTab.tsx
+++ b/web/src/pages/settings/LogsTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../../components/useConfirmDialog'
 import { api, LogEntry, LogQuery } from '../../api/client'
 import SaveButton from './SaveButton'
 import Toggle from './Toggle'
@@ -37,6 +38,7 @@ function formatRelativeTime(iso: string): string {
 
 export default function LogsTab() {
   const { t, i18n } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [logEntries, setLogEntries] = useState<LogEntry[]>([])
   const [logLevel, setLogLevel] = useState<string>('info')
   const [logFilter, setLogFilter] = useState<string>('all')
@@ -114,7 +116,11 @@ export default function LogsTab() {
   }
 
   const handleDeleteBackup = async (filename: string) => {
-    if (!confirm(`Delete backup ${filename}?`)) return
+    if (!await confirm({
+      title: t('settings.logs.deleteBackupTitle'),
+      body: t('settings.logs.deleteBackupConfirm', { filename }),
+      confirmLabel: t('common.delete'),
+    })) return
     setDeletingBackup(filename)
     try {
       await api.deleteBackup(filename)
@@ -146,6 +152,7 @@ export default function LogsTab() {
 
   return (
     <div>
+      {confirmDialog}
       {/* Toolbar row 1: heading + level pills + runtime level + auto-refresh */}
       <div className="flex flex-wrap items-center gap-3 mb-3">
         <h3 className="text-lg font-semibold mr-auto">{t('settings.logs.heading')}</h3>

--- a/web/src/pages/settings/MetadataTab.tsx
+++ b/web/src/pages/settings/MetadataTab.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../../components/useConfirmDialog'
 import { api, AuthorMonitorMode, MetadataProfile } from '../../api/client'
 import { inputCls } from './formStyles'
 import { dangerLink } from '../../components/buttons'
@@ -51,6 +52,7 @@ function formatLanguageList(csv: string): string {
 
 export default function MetadataTab() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [profiles, setProfiles] = useState<MetadataProfile[]>([])
   const [editing, setEditing] = useState<MetadataProfile | null>(null)
   const [creating, setCreating] = useState(false)
@@ -75,6 +77,7 @@ export default function MetadataTab() {
 
   return (
     <div className="space-y-8">
+      {confirmDialog}
       {/* Library Defaults */}
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">Library Defaults</h3>
@@ -295,7 +298,11 @@ export default function MetadataTab() {
                       <button onClick={() => setEditing(p)} className="text-xs text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">{t('common.edit')}</button>
                       <button
                         onClick={async () => {
-                          if (!confirm(t('settings.metadata.deleteConfirm'))) return
+                          if (!await confirm({
+                            title: t('common.confirmTitle'),
+                            body: t('settings.metadata.deleteConfirm'),
+                            confirmLabel: t('common.delete'),
+                          })) return
                           await api.deleteMetadataProfile(p.id)
                           reload()
                         }}

--- a/web/src/pages/settings/QualityTab.tsx
+++ b/web/src/pages/settings/QualityTab.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useConfirmDialog } from '../../components/useConfirmDialog'
 import { api, QualityProfile } from '../../api/client'
 import { inputCls, labelCls } from './formStyles'
 import { dangerLink } from '../../components/buttons'
@@ -112,11 +113,16 @@ function ProfileRow({
   onDeleted: () => void
 }) {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [deleting, setDeleting] = useState(false)
   const [err, setErr] = useState<string | null>(null)
 
   const handleDelete = async () => {
-    if (!confirm(t('settings.quality.deleteConfirm', { name: profile.name }))) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('settings.quality.deleteConfirm', { name: profile.name }),
+      confirmLabel: t('common.delete'),
+    })) return
     setErr(null)
     setDeleting(true)
     try {
@@ -131,6 +137,7 @@ function ProfileRow({
 
   return (
     <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+      {confirmDialog}
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <h4 className="font-medium text-sm">{profile.name}</h4>

--- a/web/src/settings/AuthSettings.tsx
+++ b/web/src/settings/AuthSettings.tsx
@@ -3,11 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { api, BINDERY_BASE, OidcProvider, OidcProviderConfig } from '../api/client'
 import ClipboardManualFallback from '../components/ClipboardManualFallback'
 import { useClipboardCopy } from '../components/useClipboardCopy'
+import { useConfirmDialog } from '../components/useConfirmDialog'
 
 const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
 
 export default function AuthSettings() {
   const { t } = useTranslation()
+  const { confirm, confirmDialog } = useConfirmDialog()
   // GET returns public shape only (no client_secret). We track display list
   // separately from the full configs we accumulate during add operations.
   const [displayed, setDisplayed] = useState<OidcProvider[]>([])
@@ -27,7 +29,11 @@ export default function AuthSettings() {
     ids.map(id => fullConfigs.get(id) ?? { id, name: displayed.find(p => p.id === id)?.name ?? id, issuer: '', client_id: '', client_secret: '', scopes: [] })
 
   const remove = async (id: string) => {
-    if (!confirm(t('settings.oidc.removeConfirm'))) return
+    if (!await confirm({
+      title: t('common.confirmTitle'),
+      body: t('settings.oidc.removeConfirm'),
+      confirmLabel: t('common.remove'),
+    })) return
     setSaving(true)
     setError('')
     try {
@@ -64,6 +70,7 @@ export default function AuthSettings() {
 
   return (
     <section>
+      {confirmDialog}
       <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">
         {t('settings.oidc.heading')}
       </h3>

--- a/web/src/test-utils.tsx
+++ b/web/src/test-utils.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import type { ReactElement, ReactNode } from 'react'
 import type { RenderOptions } from '@testing-library/react'
@@ -27,4 +27,30 @@ export function makeAuthStatus(overrides: Partial<AuthStatus> = {}): AuthStatus 
     localAuthEnabled: true,
     ...overrides,
   }
+}
+
+// The app confirms through ConfirmDialog rather than window.confirm (#2359), so
+// a test that used to stub window.confirm clicks through the modal instead.
+// Buttons are addressed by position, not label, because several suites mock
+// react-i18next's `t` to return the key: Cancel is second to last, Confirm last.
+
+/** The open confirmation modal, or null when none is open. */
+export function confirmDialog(): HTMLElement | null {
+  return screen.queryByTestId('confirm-dialog')
+}
+
+/** Tick the acknowledge box if there is one, then confirm. */
+export async function acceptConfirm(): Promise<void> {
+  const dialog = await screen.findByTestId('confirm-dialog')
+  const acknowledge = within(dialog).queryByRole('checkbox')
+  if (acknowledge) fireEvent.click(acknowledge)
+  const buttons = within(dialog).getAllByRole('button')
+  fireEvent.click(buttons[buttons.length - 1])
+}
+
+/** Dismiss the confirmation modal without confirming. */
+export async function cancelConfirm(): Promise<void> {
+  const dialog = await screen.findByTestId('confirm-dialog')
+  const buttons = within(dialog).getAllByRole('button')
+  fireEvent.click(buttons[buttons.length - 2])
 }


### PR DESCRIPTION
22 raw `window.confirm` calls across 13 files, sitting next to a `ConfirmDialog` that only `BookDetailPage` used. They gave an unstyled native dialog with the origin in the title bar, and four of them hardcoded English that never reached i18n.

`useConfirmDialog` is the in-app replacement: an awaitable `confirm()` plus the element to render, so each call site keeps the shape it already had.

```ts
if (!await confirm({ title, body, confirmLabel })) return
```

`ConfirmDialog`'s acknowledge checkbox becomes optional. It is right for an irreversible file delete and too heavy for "delete backup X", so it is now opt in per prompt and kept for the three that earn it: deleting an author's files off disk, merging authors, and rotating the session signing secret. The dialog also gains `role="dialog"`, `aria-modal` and a labelled heading, which it did not have.

Six hardcoded English strings move into `en.json`: the two in `GeneralTab`, the series delete warning, the backup delete prompt, and the two author delete variants in `AuthorDetailPage` (the issue named four, these two are the same category and are on lines the change already touches). `en.json` only, so the other locales fall back to English rather than carrying filler. `SeriesPage` had no i18n at all and now does.

Closes #2359

## Tests

New `web/src/components/useConfirmDialog.test.tsx`: resolves true on confirm and false on cancel, renders the message on screen, has no checkbox and a live confirm button by default, gates the button behind the checkbox when one is asked for, and declines a second prompt while one is open rather than stranding its promise.

Ten existing tests stubbed `window.confirm` and now click through the modal, via `acceptConfirm` / `cancelConfirm` / `confirmDialog` added to `test-utils`. They address the dialog buttons by position rather than by label because several suites stub `t` to return keys. Two of them now assert the warning text is on screen, which the `window.confirm` versions could only check by inspecting the spy's argument.

```
cd web
npm run typecheck   # clean
npm run lint        # 0 errors, 6 pre-existing warnings
npm test            # 68 files, 664 tests, all passing
npm run build       # clean
```

## Sequencing

**Merge after #2377 and #2382**, both of which also touch `QueuePage.tsx`. Mechanical but wide (25 files), so worth landing on its own. Next minor, not patch release material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
