### PR TITLE
fix(api): 400 on a malformed id, and make the Tier-1 IDOR guard a helper (#2364)

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -407,27 +407,11 @@ func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+	author, ok := h.loadOwnedAuthor(w, r)
+	if !ok {
 		return
 	}
-
-	author, err := h.authors.GetByID(r.Context(), id)
-	if err != nil {
-		writeServerError(w, r, err)
-		return
-	}
-	if author == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1). Return 404 (not 403) on mismatch so
-	// non-owners cannot probe for the existence of another user's authors.
-	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
-		return
-	}
+	id := author.ID
 
 	// Attach books, owner-scoped (#1416): the embedded list must apply the
 	// same tenancy predicate as GET /book?authorId=, or a co-author book
@@ -469,22 +453,13 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 // picker (#810) so the edit modal can render a checkbox list scoped to this
 // author rather than the global /series collection.
 func (h *AuthorHandler) ListSeries(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+	// The ownership check has to run before we list series belonging to the
+	// author, hence the load here rather than a bare parseID.
+	author, ok := h.loadOwnedAuthor(w, r)
+	if !ok {
 		return
 	}
-	// Tier-1 cross-user IDOR guard (D1). Look the author up so the ownership
-	// check runs before we list series belonging to it.
-	author, err := h.authors.GetByID(r.Context(), id)
-	if err != nil {
-		writeServerError(w, r, err)
-		return
-	}
-	if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
-		return
-	}
+	id := author.ID
 	if h.series == nil {
 		writeJSON(w, http.StatusOK, []models.Series{})
 		return
@@ -1001,20 +976,8 @@ func (h *AuthorHandler) recordAuthorRelinkAlias(ctx context.Context, author *mod
 }
 
 func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
-		return
-	}
-
-	author, err := h.authors.GetByID(r.Context(), id)
-	if err != nil || author == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1).
-	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+	author, ok := h.loadOwnedAuthor(w, r)
+	if !ok {
 		return
 	}
 
@@ -1381,24 +1344,13 @@ func (h *AuthorHandler) RelinkCandidates(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+	// The load has to happen before any destructive work, so the ownership
+	// check runs first.
+	author, ok := h.loadOwnedAuthor(w, r)
+	if !ok {
 		return
 	}
-
-	// Tier-1 cross-user IDOR guard (D1). Look the author up so the ownership
-	// check can run before any destructive work; return 404 on mismatch or
-	// missing row so non-owners cannot probe for existence by status code.
-	author, err := h.authors.GetByID(r.Context(), id)
-	if err != nil {
-		writeServerError(w, r, err)
-		return
-	}
-	if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
-		return
-	}
+	id := author.ID
 
 	// Opt-in `?deleteFiles=true` sweeps every book's on-disk path after the
 	// DB delete. We must collect the paths *before* deleting the author —
@@ -1465,20 +1417,8 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AuthorHandler) Refresh(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
-		return
-	}
-
-	author, err := h.authors.GetByID(r.Context(), id)
-	if err != nil || author == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1).
-	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+	author, ok := h.loadOwnedAuthor(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
@@ -156,18 +154,8 @@ func (h *BookHandler) hydrateHardcoverEditions(ctx context.Context, book *models
 // narrator, duration, cover, and description on the record. Requires the
 // book to be media_type=audiobook with an ASIN already set.
 func (h *BookHandler) EnrichAudiobook(w http.ResponseWriter, r *http.Request) {
-	id, ok := parseID(w, r)
+	book, ok := h.loadOwnedBook(w, r)
 	if !ok {
-		return
-	}
-	book, err := h.books.GetByID(r.Context(), id)
-	if err != nil || book == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1). 404 (not 403) on mismatch.
-	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
 	if book.MediaType != models.MediaTypeAudiobook && book.MediaType != models.MediaTypeBoth {
@@ -366,24 +354,8 @@ func pageBooks(in []models.Book, limit, offset int) ([]models.Book, int) {
 }
 
 func (h *BookHandler) Get(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
-		return
-	}
-
-	book, err := h.books.GetByID(r.Context(), id)
-	if err != nil {
-		writeServerError(w, r, err)
-		return
-	}
-	if book == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1).
-	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+	book, ok := h.loadOwnedBook(w, r)
+	if !ok {
 		return
 	}
 	proxyBookImages(book)
@@ -419,20 +391,8 @@ func (h *BookHandler) attachBookIdentifiers(ctx context.Context, book *models.Bo
 }
 
 func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
-		return
-	}
-
-	book, err := h.books.GetByID(r.Context(), id)
-	if err != nil || book == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1).
-	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+	book, ok := h.loadOwnedBook(w, r)
+	if !ok {
 		return
 	}
 	oldStatus := book.Status
@@ -605,23 +565,14 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+	// The load has to happen before any destructive work, so the ownership
+	// check runs first. The `?deleteFiles=true` branch below re-fetches when
+	// it needs the legacy file columns; the extra lookup is cheap.
+	existing, ok := h.loadOwnedBook(w, r)
+	if !ok {
 		return
 	}
-	// Tier-1 cross-user IDOR guard (D1). Pre-fetch the book so the ownership
-	// check can run before any destructive work; 404 on mismatch or missing
-	// row so non-owners cannot probe for existence. The handler's existing
-	// `?deleteFiles=true` branch re-fetches when it needs the legacy file
-	// columns; the extra lookup is cheap and keeps the diff localised.
-	if existing, err := h.books.GetByID(r.Context(), id); err != nil {
-		writeServerError(w, r, err)
-		return
-	} else if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
+	id := existing.ID
 	// Opt-in `?deleteFiles=true` also removes every on-disk file tracked in
 	// book_files before dropping the record. Each path is first run through
 	// the library-root containment check (Wave 1 / Bundle B) so a tampered
@@ -679,20 +630,13 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // `?path=<tracked path>` switches to DEREGISTER mode: it drops that one
 // book_files row and touches nothing on disk. See deregisterBookFile (#1692).
 func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
-	id, ok := parseID(w, r)
+	// The load has to happen before any file enumeration or destructive work,
+	// so the ownership check runs first.
+	existing, ok := h.loadOwnedBook(w, r)
 	if !ok {
 		return
 	}
-
-	// Tier-1 cross-user IDOR guard (D1). Fetch the book up-front so the
-	// ownership check runs before any file enumeration or destructive work.
-	if existing, err := h.books.GetByID(r.Context(), id); err != nil {
-		writeServerError(w, r, err)
-		return
-	} else if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
+	id := existing.ID
 
 	if path := r.URL.Query().Get("path"); path != "" {
 		h.deregisterBookFile(w, r, id, path)
@@ -1092,18 +1036,8 @@ func (h *BookHandler) ListWanted(w http.ResponseWriter, r *http.Request) {
 // Returns 409 when the upstream record belongs to a different author unless
 // force=true is passed. Returns the updated book JSON on success.
 func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
-	id, ok := parseID(w, r)
+	book, ok := h.loadOwnedBook(w, r)
 	if !ok {
-		return
-	}
-	book, err := h.books.GetByID(r.Context(), id)
-	if err != nil || book == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1).
-	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
 
@@ -1267,20 +1201,11 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *BookHandler) ToggleExcluded(w http.ResponseWriter, r *http.Request) {
-	id, ok := parseID(w, r)
+	book, ok := h.loadOwnedBook(w, r)
 	if !ok {
 		return
 	}
-	book, err := h.books.GetByID(r.Context(), id)
-	if err != nil || book == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1).
-	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
+	id := book.ID
 
 	newVal := !book.Excluded
 	if err := h.books.SetExcluded(r.Context(), id, newVal); err != nil {

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -7,11 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
-
-	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader"
@@ -142,7 +139,10 @@ func (h *DownloadClientHandler) List(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *DownloadClientHandler) Get(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
 	client, err := h.clients.GetByID(r.Context(), id)
 	if err != nil || client == nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download client not found"})
@@ -190,7 +190,10 @@ func (h *DownloadClientHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *DownloadClientHandler) Update(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
 	existing, err := h.clients.GetByID(r.Context(), id)
 	if err != nil || existing == nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download client not found"})
@@ -350,7 +353,10 @@ func applyDownloadClientCredentials(c, existing *models.DownloadClient, raw map[
 }
 
 func (h *DownloadClientHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
 	if err := h.clients.Delete(r.Context(), id); err != nil {
 		writeServerError(w, r, err)
 		return
@@ -366,7 +372,10 @@ func (h *DownloadClientHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
 	client, err := h.clients.GetByID(r.Context(), id)
 	if err != nil || client == nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download client not found"})

--- a/internal/api/download_clients_test.go
+++ b/internal/api/download_clients_test.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
@@ -612,10 +610,7 @@ func TestDownloadClientHandlers_NonNumericID(t *testing.T) {
 			}
 
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(tc.method, "/downloadclient/abc", bytes.NewBufferString(`{}`))
-			rctx := chi.NewRouteContext()
-			rctx.URLParams.Add("id", "abc")
-			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			req := withURLParam(httptest.NewRequest(tc.method, "/downloadclient/abc", bytes.NewBufferString(`{}`)), "id", "abc")
 
 			tc.call(h, rec, req)
 

--- a/internal/api/download_clients_test.go
+++ b/internal/api/download_clients_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
@@ -578,5 +580,62 @@ func TestDownloadClientURL_IPv6(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("downloadClientURL(%q) = %q, want %q", tc.host, got, tc.want)
 		}
+	}
+}
+
+// TestDownloadClientHandlers_NonNumericID pins that a malformed {id} answers
+// 400 on every handler that takes one. All four used to run
+// `id, _ := strconv.ParseInt(...)`, so "abc" became id 0. Get/Update/Test then
+// reported "download client not found" for a request that never named a
+// client, and Delete was worse: it ran the repo delete, downloader.Evict(0) and
+// the health drop against id 0, then answered 204 No Content, so a typo in a
+// script reported success for a delete that deleted nothing (#2364).
+func TestDownloadClientHandlers_NonNumericID(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		method string
+		call   func(h *DownloadClientHandler, w http.ResponseWriter, r *http.Request)
+	}{
+		{"Get", http.MethodGet, (*DownloadClientHandler).Get},
+		{"Update", http.MethodPut, (*DownloadClientHandler).Update},
+		{"Delete", http.MethodDelete, (*DownloadClientHandler).Delete},
+		{"Test", http.MethodPost, (*DownloadClientHandler).Test},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, clients := downloadClientFixture(t)
+
+			// A real client at id 1, so a 404 here would mean the handler
+			// looked something up rather than rejecting the id.
+			existing := &models.DownloadClient{Name: "qbit", Type: "qbittorrent", Host: "127.0.0.1", Port: 8080, Category: "books"}
+			if err := clients.Create(context.Background(), existing); err != nil {
+				t.Fatalf("seed client: %v", err)
+			}
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, "/downloadclient/abc", bytes.NewBufferString(`{}`))
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", "abc")
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+			tc.call(h, rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for a non-numeric id, got %d: %s", rec.Code, rec.Body.String())
+			}
+			var out map[string]string
+			if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+				t.Fatalf("decode error body: %v", err)
+			}
+			if out["error"] != "invalid id" {
+				t.Errorf("error = %q, want %q", out["error"], "invalid id")
+			}
+
+			// The seeded client must still be there: a rejected id must not
+			// have reached the repo at all.
+			still, err := clients.GetByID(context.Background(), existing.ID)
+			if err != nil || still == nil {
+				t.Errorf("seeded client should survive a malformed-id request (err=%v)", err)
+			}
+		})
 	}
 }

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/textutil"
@@ -68,6 +69,60 @@ func parseID(w http.ResponseWriter, r *http.Request) (int64, bool) {
 		return 0, false
 	}
 	return id, true
+}
+
+// Tier-1 cross-user IDOR guard (D1). loadOwnedAuthor and loadOwnedBook below
+// are the one implementation of the parse, load, 404-on-missing,
+// 404-on-not-mine sequence that ~48 handlers used to carry inline. 404 rather
+// than 403 on an ownership mismatch is deliberate: a non-owner must not be
+// able to probe for the existence of another user's rows by status code.
+//
+// Keeping it in one function is the point. Pasted into every handler, the
+// guard holds only as long as everyone remembers to paste it, and a new
+// handler that forgets is a silent cross-user read that nothing in the build
+// or the linter notices (#2364).
+//
+// A store error is a 500, not a 404. Some of the converted sites collapsed
+// `err != nil || row == nil` into 404, which reports a database failure as a
+// missing row; a failure to read is not an answer about existence, and it is
+// not one a non-owner can distinguish either way.
+
+// loadOwnedAuthor reads the {id} URL param, loads the author, and enforces the
+// guard above. It returns (author, true) only when the caller may proceed; on
+// false the response has already been written.
+func (h *AuthorHandler) loadOwnedAuthor(w http.ResponseWriter, r *http.Request) (*models.Author, bool) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return nil, false
+	}
+	author, err := h.authors.GetByID(r.Context(), id)
+	if err != nil {
+		writeServerError(w, r, err)
+		return nil, false
+	}
+	if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return nil, false
+	}
+	return author, true
+}
+
+// loadOwnedBook is loadOwnedAuthor for books. Same contract, same reasoning.
+func (h *BookHandler) loadOwnedBook(w http.ResponseWriter, r *http.Request) (*models.Book, bool) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return nil, false
+	}
+	book, err := h.books.GetByID(r.Context(), id)
+	if err != nil {
+		writeServerError(w, r, err)
+		return nil, false
+	}
+	if book == nil || !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return nil, false
+	}
+	return book, true
 }
 
 func parseLimitOffset(r *http.Request, defaultLimit, maxLimit int) (int, int) {

--- a/internal/api/root_folders.go
+++ b/internal/api/root_folders.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
-	"strconv"
-
-	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
@@ -74,7 +71,10 @@ func (h *RootFolderHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *RootFolderHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
 	// Tier-1 cross-user IDOR guard (D1). Pre-fetch so non-owners cannot
 	// delete a root folder belonging to a different user, and cannot
 	// distinguish "exists but not mine" from "does not exist".

--- a/internal/api/root_folders_test.go
+++ b/internal/api/root_folders_test.go
@@ -2,11 +2,14 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
@@ -116,5 +119,32 @@ func TestRootFolderDelete(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&list)
 	if len(list) != 0 {
 		t.Errorf("expected empty list after delete, got %d", len(list))
+	}
+}
+
+// TestRootFolderDelete_NonNumericID pins that a malformed {id} answers 400 and
+// not 404. Delete used to run `id, _ := strconv.ParseInt(...)`, which turns
+// "abc" into id 0 and reports "root folder not found" for a request that never
+// named a root folder at all (#2364).
+func TestRootFolderDelete_NonNumericID(t *testing.T) {
+	h := rootFolderFixture(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/rootfolder/abc", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	h.Delete(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a non-numeric id, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if out["error"] != "invalid id" {
+		t.Errorf("error = %q, want %q", out["error"], "invalid id")
 	}
 }

--- a/internal/api/root_folders_test.go
+++ b/internal/api/root_folders_test.go
@@ -2,14 +2,11 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
-
-	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
@@ -130,10 +127,7 @@ func TestRootFolderDelete_NonNumericID(t *testing.T) {
 	h := rootFolderFixture(t)
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodDelete, "/rootfolder/abc", nil)
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("id", "abc")
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	req := withURLParam(httptest.NewRequest(http.MethodDelete, "/rootfolder/abc", nil), "id", "abc")
 
 	h.Delete(rec, req)
 


### PR DESCRIPTION
Two commits, both from #2364.

**1. Five handlers threw the id parse error away.** `download_clients.go` Get/Update/Delete/Test and `root_folders.go` Delete all ran `id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)`. `ParseInt` returns 0 on failure, so `GET /api/v1/downloadclient/abc` looked up id 0, found nothing, and answered `404 download client not found`, telling a client that sent a malformed id that the resource does not exist.

`DELETE` was worse. It ran the repo delete, `downloader.Evict(0)` and the health drop against id 0 and then answered `204 No Content`, so a typo in a script reported success for a delete that deleted nothing. All five now use `parseID`, the helper 26 other handlers already use.

**2. The Tier-1 IDOR guard is now a helper, not a pasted block.** The parse, load, 404-on-missing, 404-on-not-mine sequence was inline in roughly 48 handlers, 26 carrying a hand written `// Tier-1 cross-user IDOR guard (D1)` comment. That comment is the tell: the guard holds only as long as everyone remembers to paste it, and a handler that forgets is a cross user read that nothing in the build or the linter notices. Adds `loadOwnedAuthor` and `loadOwnedBook` to `helpers.go` with the D1 reasoning stated once, and converts the twelve sites in `authors.go` and `books.go` that follow exactly that shape.

**One behaviour change worth reviewing:** five of the converted sites collapsed `err != nil || row == nil` into a 404, so a database read failure was reported as a missing row. They now answer 500, matching the seven that already did. A failure to read is not an answer about existence, and it is not one a non-owner can distinguish either way. No ownership behaviour changes: 404 rather than 403 on a mismatch is preserved exactly.

Not converted: `RelinkUpstream` and `RelinkCandidates` load through `GetByIDForUser` rather than `GetByID`, so they are a different shape and are left alone. Also left alone deliberately, since other work in flight touches them: `fetchAuthorBooksAsync` and the ad hoc `calibre:` guards in `authors.go`.

Closes #2364

## Testing

Fail before, pass after:

- `TestDownloadClientHandlers_NonNumericID` (`internal/api/download_clients_test.go`), subtests Get/Update/Delete/Test. Before: `got 404` on three and `got 204` on Delete. It also asserts a seeded client survives, so a rejected id never reaches the repo.
- `TestRootFolderDelete_NonNumericID` (`internal/api/root_folders_test.go`). Before: `got 404`.

The helper conversion is covered by the existing tenancy suite in `internal/api/authorization_test.go`, which exercises the cross user 404, the admin bypass and the gate off case against `Get`, `Update` and `Delete` on both handlers. Those pass unchanged, which is what says the guard did not move.

```
go build ./...                       ok
go vet ./internal/api/               ok
go test ./internal/api/ -count=1     ok (146s)
golangci-lint run ./internal/api/... 0 issues
```

## Sequencing

Next minor. Part 1 is a correctness nit with no security angle, part 2 is hardening of a guard that is currently correct everywhere, so neither is patch material.

**Merge after the L8/L9 PR (untracked goroutines and the ignored `jobs.Group.Go` return) if that one is open**, since it also touches `internal/api/authors.go`. No dependency either way beyond the textual conflict.

Independent of #2363 (SortName) and #2366 (migrate author resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
