### PR TITLE
refactor(migrate): one author-resolution helper for the CSV and Readarr importers (#2366)

### DIFF
--- a/internal/migrate/authors.go
+++ b/internal/migrate/authors.go
@@ -1,13 +1,87 @@
 package migrate
 
 import (
+	"context"
 	"errors"
+	"log/slog"
 	"strings"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
 )
 
 func isAuthorCreateConflict(err error) bool {
 	return strings.Contains(err.Error(), "UNIQUE constraint failed") ||
 		errors.Is(err, db.ErrAuthorIdentifierConflict)
+}
+
+// resolveAndCreateAuthor is the author-resolution step every bulk importer
+// runs: search the metadata providers for a name, take the top match, skip it
+// if the library already has that foreign id, fetch the full record, stamp the
+// monitor defaults, and create it. It records its own outcome on res, so the
+// caller only has to handle the created author.
+//
+// The CSV and Readarr importers carried byte-for-byte copies of this block,
+// which meant #2332 (the hardcoded provider stamp below) had to be fixed twice
+// and could be fixed half way. That is why it lives here now (#2366).
+//
+// source is the importer's name, used only in the "search failed" log line.
+// Returns nil when the name was skipped or failed; res already carries why.
+func resolveAndCreateAuthor(
+	ctx context.Context,
+	source, name string,
+	monitored bool,
+	authors *db.AuthorRepo,
+	settings *db.SettingsRepo,
+	agg *metadata.Aggregator,
+	res *Result,
+) *models.Author {
+	// Resolve via OpenLibrary. Top match wins.
+	matches, err := agg.SearchAuthors(ctx, name)
+	if err != nil {
+		slog.Warn(source+" import: search failed", "name", name, "error", err)
+		res.fail(name, "metadata lookup failed: "+err.Error())
+		return nil
+	}
+	if len(matches) == 0 {
+		res.fail(name, "no OpenLibrary match")
+		return nil
+	}
+	top := matches[0]
+
+	// Skip if already present.
+	if existing, _ := authors.GetByAnyForeignID(ctx, top.ForeignID); existing != nil {
+		res.Skipped++
+		return nil
+	}
+
+	// Fetch full metadata (description, image). Soft-fail if it errors: the
+	// search hit is already a usable author record.
+	full, ferr := agg.GetAuthor(ctx, top.ForeignID)
+	if ferr != nil || full == nil {
+		full = &top
+	}
+	full.Monitored = monitored
+	// #2332: this stamp is hardcoded and ignores which provider actually
+	// answered, so a provider timeout binds the author to the wrong one. Fix
+	// it here, on this one line, rather than in each importer.
+	full.MetadataProvider = "openlibrary"
+	// The source hands over a monitored flag but no monitor mode, so take the
+	// install-wide default rather than the column default "all" (#1666).
+	db.ApplyAuthorMonitorDefaults(ctx, settings, full)
+
+	if cerr := authors.Create(ctx, full); cerr != nil {
+		if isAuthorCreateConflict(cerr) {
+			if existing, _ := authors.GetByAnyForeignID(ctx, full.ForeignID); existing != nil {
+				res.Skipped++
+				return nil
+			}
+		}
+		res.fail(name, cerr.Error())
+		return nil
+	}
+	res.Added++
+	res.AddedNames = append(res.AddedNames, full.Name)
+	return full
 }

--- a/internal/migrate/csv.go
+++ b/internal/migrate/csv.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -146,47 +145,10 @@ func ImportCSVAuthors(
 			continue
 		}
 
-		// Resolve via OpenLibrary. Top match wins.
-		matches, err := agg.SearchAuthors(ctx, name)
-		if err != nil {
-			slog.Warn("csv import: search failed", "name", name, "error", err)
-			res.fail(name, "metadata lookup failed: "+err.Error())
+		full := resolveAndCreateAuthor(ctx, "csv", name, row.monitored, authors, settings, agg, res)
+		if full == nil {
 			continue
 		}
-		if len(matches) == 0 {
-			res.fail(name, "no OpenLibrary match")
-			continue
-		}
-		top := matches[0]
-
-		// Skip if already present.
-		existing, _ := authors.GetByAnyForeignID(ctx, top.ForeignID)
-		if existing != nil {
-			res.Skipped++
-			continue
-		}
-
-		// Fetch full metadata (description, image) — soft-fail if it errors.
-		full, ferr := agg.GetAuthor(ctx, top.ForeignID)
-		if ferr != nil || full == nil {
-			full = &top
-		}
-		full.Monitored = row.monitored
-		full.MetadataProvider = "openlibrary"
-		db.ApplyAuthorMonitorDefaults(ctx, settings, full)
-
-		if err := authors.Create(ctx, full); err != nil {
-			if isAuthorCreateConflict(err) {
-				if existing, _ := authors.GetByAnyForeignID(ctx, full.ForeignID); existing != nil {
-					res.Skipped++
-					continue
-				}
-			}
-			res.fail(name, err.Error())
-			continue
-		}
-		res.Added++
-		res.AddedNames = append(res.AddedNames, full.Name)
 		newlyAdded = append(newlyAdded, full)
 	}
 

--- a/internal/migrate/readarr.go
+++ b/internal/migrate/readarr.go
@@ -109,44 +109,10 @@ func importReadarrAuthors(ctx context.Context, src *sql.DB, repo *db.AuthorRepo,
 		}
 		res.Requested++
 
-		matches, serr := agg.SearchAuthors(ctx, name)
-		if serr != nil {
-			res.fail(name, "metadata lookup failed: "+serr.Error())
+		full := resolveAndCreateAuthor(ctx, "readarr", name, monitored, repo, settings, agg, res)
+		if full == nil {
 			continue
 		}
-		if len(matches) == 0 {
-			res.fail(name, "no OpenLibrary match")
-			continue
-		}
-		top := matches[0]
-
-		if existing, _ := repo.GetByAnyForeignID(ctx, top.ForeignID); existing != nil {
-			res.Skipped++
-			continue
-		}
-
-		full, ferr := agg.GetAuthor(ctx, top.ForeignID)
-		if ferr != nil || full == nil {
-			full = &top
-		}
-		full.Monitored = monitored
-		full.MetadataProvider = "openlibrary"
-		// Readarr hands over a monitored flag but no monitor mode, so take the
-		// install-wide default rather than the column default "all" (#1666).
-		db.ApplyAuthorMonitorDefaults(ctx, settings, full)
-
-		if cerr := repo.Create(ctx, full); cerr != nil {
-			if isAuthorCreateConflict(cerr) {
-				if existing, _ := repo.GetByAnyForeignID(ctx, full.ForeignID); existing != nil {
-					res.Skipped++
-					continue
-				}
-			}
-			res.fail(name, cerr.Error())
-			continue
-		}
-		res.Added++
-		res.AddedNames = append(res.AddedNames, full.Name)
 		newlyAdded = append(newlyAdded, full)
 	}
 	rowsErr := rows.Err()


### PR DESCRIPTION
`ImportCSVAuthors` and `importReadarrAuthors` carried the same 45 line block: search the aggregator, take the top match, skip an existing foreign id, fetch the full record with a soft fallback to the search hit, stamp `Monitored` and `metadata_provider`, apply the monitor defaults, then create with an `isAuthorCreateConflict` re-check. The only real difference was where the monitored flag came from. Now one `resolveAndCreateAuthor` in `internal/migrate/authors.go`, next to `isAuthorCreateConflict`.

The reason this is worth a PR rather than a shrug: **#2332 is filed against the code inside that block.** The hardcoded `full.MetadataProvider = "openlibrary"` ignores which provider actually answered, and the block skips the #2271 `SearchOutcome.SafeToBind` guard. Two copies meant #2332 had to be fixed twice and could be fixed half way, which is presumably how it ended up with two copies. There is now one line to change, and it carries a comment pointing at #2332 so the next person finds it.

#2332 itself is deliberately **not** fixed here. This is the vehicle, not the fix.

Behaviour is preserved with one exception: the readarr path now emits the same `"search failed"` WARN the csv path already did. The importer name is a parameter, so the csv log line is byte identical to before, and readarr gains a log for a failure it was already reporting to the user through `res.fail`.

Not touched: the indexer and download client loops further down `readarr.go` (`:233-244`, `:292-304`). #2380 adds `httpsec.ValidateOutboundURL` there; this PR's edit is only the author loop above them, so the two should not conflict.

Closes #2366

## Testing

Pure refactor, so no new test. The existing suite is what verifies it, and it covers every branch of the extracted helper on both paths:

- csv: `HappyPath`, `NoMatch`, `SearchError`, `SkipDuplicate`, `SkipDuplicateAlternateIdentifier`, `GetAuthorFallback`, `HonoursDefaultMonitorMode` (none / latest / unset)
- readarr: `HappyPath`, `SkipsDuplicateAlternateIdentifier`, `CatalogueFetchIsBoundedAndSurvivesCancellation`

```
go build ./...                          ok
go vet ./internal/migrate/              ok
go test ./internal/migrate/ -count=1    ok (2.9s), all pass unchanged
golangci-lint run ./internal/migrate/   0 issues
```

## Sequencing

Next minor. No user visible change.

**Should merge before any #2332 fix.** That is the whole point of doing it: #2332 first means fixing the same bug in two places.

Independent of #2363 and #2364. No conflict expected with #2380, which edits the indexer and client loops in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
