### PR TITLE
perf(web): pause page polling while the tab is hidden (#2360)

### DIFF
--- a/web/src/components/usePolling.test.tsx
+++ b/web/src/components/usePolling.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render } from '@testing-library/react'
+import { useState } from 'react'
+import { usePolling } from './usePolling'
+
+// jsdom's document.hidden is derived from visibilityState, which is read-only,
+// so drive it through a redefined property and dispatch the real event.
+let hidden = false
+function setHidden(value: boolean) {
+  hidden = value
+  act(() => { document.dispatchEvent(new Event('visibilitychange')) })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  hidden = false
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function Harness({ fn, enabled = true }: { fn: () => void; enabled?: boolean }) {
+  usePolling(fn, 5000, enabled)
+  return null
+}
+
+describe('usePolling', () => {
+  it('does not call fn on mount, then calls it every interval', () => {
+    const fn = vi.fn()
+    render(<Harness fn={fn} />)
+    expect(fn).not.toHaveBeenCalled()
+
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(fn).toHaveBeenCalledTimes(1)
+    act(() => { vi.advanceTimersByTime(10000) })
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops while the tab is hidden and catches up when it comes back', () => {
+    const fn = vi.fn()
+    render(<Harness fn={fn} />)
+
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    setHidden(true)
+    act(() => { vi.advanceTimersByTime(60000) })
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // One immediate catch-up call, then the interval resumes.
+    setHidden(false)
+    expect(fn).toHaveBeenCalledTimes(2)
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not start at all when the tab is already hidden', () => {
+    hidden = true
+    const fn = vi.fn()
+    render(<Harness fn={fn} />)
+    act(() => { vi.advanceTimersByTime(20000) })
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  // The bug this hook exists for: WantedPage listed hover and grab state in the
+  // effect's deps, so every hover cleared the interval and restarted the 5 s
+  // window, and a busy user could go a long time without a refresh (#2360).
+  it('keeps one timer running when unrelated state changes', () => {
+    const fn = vi.fn()
+    let bump: () => void = () => {}
+
+    function Rerenderer() {
+      const [n, setN] = useState(0)
+      bump = () => setN(x => x + 1)
+      // A fresh closure every render, exactly like an inline arrow on a page.
+      usePolling(() => fn(n), 5000)
+      return null
+    }
+
+    render(<Rerenderer />)
+    act(() => { vi.advanceTimersByTime(4000) })
+    act(() => { bump() })
+    act(() => { bump() })
+    // Restarting the timer on each render would leave 1000ms still to run.
+    act(() => { vi.advanceTimersByTime(1000) })
+    expect(fn).toHaveBeenCalledTimes(1)
+    // And it calls the latest closure, not the one captured on mount.
+    expect(fn).toHaveBeenLastCalledWith(2)
+  })
+
+  it('runs nothing while disabled and starts once enabled', () => {
+    const fn = vi.fn()
+    const { rerender } = render(<Harness fn={fn} enabled={false} />)
+    act(() => { vi.advanceTimersByTime(20000) })
+    expect(fn).not.toHaveBeenCalled()
+
+    rerender(<Harness fn={fn} enabled />)
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the timer and the listener on unmount', () => {
+    const fn = vi.fn()
+    const remove = vi.spyOn(document, 'removeEventListener')
+    const { unmount } = render(<Harness fn={fn} />)
+    unmount()
+
+    act(() => { vi.advanceTimersByTime(20000) })
+    expect(fn).not.toHaveBeenCalled()
+    expect(remove).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    remove.mockRestore()
+  })
+})

--- a/web/src/components/usePolling.ts
+++ b/web/src/components/usePolling.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * usePolling runs `fn` every `intervalMs` while the tab is visible (#2360).
+ *
+ * Two things it does that a bare setInterval in an effect did not:
+ *
+ *  - It stops on `document.hidden` and restarts on `visibilitychange`, with one
+ *    catch-up call the moment the tab comes back, so a queue left open in a
+ *    background window overnight stops asking the server for news nobody is
+ *    reading. Everything here polls a self-hosted box, so the point is noise and
+ *    battery rather than cost.
+ *  - It keeps `fn` in a ref, so an inline arrow that closes over changing state
+ *    does not tear the timer down and restart the interval on every render. The
+ *    Wanted page restarted its 5 s window on every hover.
+ *
+ * `fn` is NOT called on mount. Pages do their first load in their own effect,
+ * where the loading state lives.
+ *
+ * Pass `enabled: false` to suspend polling entirely, e.g. behind a user-facing
+ * "auto refresh" toggle.
+ */
+export function usePolling(fn: () => void, intervalMs: number, enabled = true): void {
+  const saved = useRef(fn)
+  useEffect(() => { saved.current = fn })
+
+  useEffect(() => {
+    if (!enabled) return
+    let timer: ReturnType<typeof setInterval> | null = null
+    const tick = () => saved.current()
+    const start = () => { if (timer === null) timer = setInterval(tick, intervalMs) }
+    const stop = () => {
+      if (timer !== null) {
+        clearInterval(timer)
+        timer = null
+      }
+    }
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        stop()
+        return
+      }
+      // Catch up first, so coming back to the tab shows current data rather
+      // than data up to intervalMs stale.
+      tick()
+      start()
+    }
+
+    if (!document.hidden) start()
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      stop()
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [intervalMs, enabled])
+}

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, Book, PendingRelease, QueueItem } from '../api/client'
 import BookAuthorLink from '../components/BookAuthorLink'
 import ImportHints from '../components/ImportHints'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
+import { usePolling } from '../components/usePolling'
 import { summarizeError, ERROR_SUMMARY_LEN } from './queueError'
 import { btn, btnSize } from '../components/buttons'
 
@@ -30,36 +31,32 @@ export default function QueuePage() {
   const [bulkResult, setBulkResult] = useState<string | null>(null)
   const selectAllRef = useRef<HTMLInputElement>(null)
 
-  const load = () => {
+  // Guard against stale responses and set-state-after-unmount: `mounted` is
+  // checked before every setState and flipped on unmount, so a poll that
+  // resolves after a newer tick or after unmount is ignored. Mirrors
+  // AuthorsPage's poll guard.
+  const mounted = useRef(true)
+  useEffect(() => {
+    mounted.current = true
+    return () => { mounted.current = false }
+  }, [])
+
+  const load = useCallback(() => {
     Promise.all([
       api.listQueue(),
       api.listPending(),
     ]).then(([q, p]) => {
+      if (!mounted.current) return
       setQueue(q)
       setPending(p)
-    }).catch(console.error).finally(() => setLoading(false))
-  }
-
-  // Guard against stale responses and set-state-after-unmount: a `cancelled`
-  // flag captured in the effect is checked before every setState and flipped in
-  // cleanup, so a poll that resolves after a newer tick or after unmount is
-  // ignored. Mirrors AuthorsPage's poll guard.
-  useEffect(() => {
-    let cancelled = false
-    const run = () => {
-      Promise.all([
-        api.listQueue(),
-        api.listPending(),
-      ]).then(([q, p]) => {
-        if (cancelled) return
-        setQueue(q)
-        setPending(p)
-      }).catch(console.error).finally(() => { if (!cancelled) setLoading(false) })
-    }
-    run()
-    const interval = setInterval(run, 5000)
-    return () => { cancelled = true; clearInterval(interval) }
+    }).catch(console.error).finally(() => { if (mounted.current) setLoading(false) })
   }, [])
+
+  useEffect(() => { load() }, [load])
+
+  // Poll while the tab is visible. usePolling pauses on document.hidden, so a
+  // queue left open in a background window stops asking (#2360).
+  usePolling(load, 5000)
 
   useEffect(() => {
     document.title = 'Queue · Bindery'

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -6,6 +6,7 @@ import BulkActionBar from '../components/BulkActionBar'
 import ImportHints from '../components/ImportHints'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
+import { usePolling } from '../components/usePolling'
 import { safeHref } from '../util/safeHref'
 
 // Shared grid template so the header row and every list row line up exactly.
@@ -47,18 +48,26 @@ export default function WantedPage() {
     return () => { cancelled = true }
   }, [showExcluded])
 
+  // Set-state-after-unmount guard for the poll, which outlives any one effect.
+  const mounted = useRef(true)
+  useEffect(() => {
+    mounted.current = true
+    return () => { mounted.current = false }
+  }, [])
+
   // Poll the wanted list so background auto-grabs (and books leaving as they
   // import) show up without a manual reload (#1161). Mirrors QueuePage's 5s
-  // poll. Pauses while the user is mid-interaction — a results panel is open or
-  // a grab/search is running — so the list doesn't reshuffle under them.
-  useEffect(() => {
-    let cancelled = false
-    const interval = setInterval(() => {
-      if (showResults !== null || grabbingGuid !== null || searchingId !== null) return
-      api.listWanted({ includeExcluded: showExcluded }).then(b => { if (!cancelled) setBooks(b) }).catch(() => {})
-    }, 5000)
-    return () => { cancelled = true; clearInterval(interval) }
-  }, [showExcluded, showResults, grabbingGuid, searchingId])
+  // poll. Skips a tick while the user is mid-interaction, a results panel open
+  // or a grab/search running, so the list doesn't reshuffle under them.
+  //
+  // That interaction state used to sit in the effect's deps, which tore the
+  // timer down and restarted the 5s window on every hover; usePolling holds the
+  // callback in a ref, so the timer survives and only the tick is skipped
+  // (#2360). It also pauses entirely while the tab is hidden.
+  usePolling(() => {
+    if (showResults !== null || grabbingGuid !== null || searchingId !== null) return
+    api.listWanted({ includeExcluded: showExcluded }).then(b => { if (mounted.current) setBooks(b) }).catch(() => {})
+  }, 5000)
 
   useEffect(() => {
     if (!toast) return

--- a/web/src/pages/settings/LogsTab.tsx
+++ b/web/src/pages/settings/LogsTab.tsx
@@ -4,6 +4,7 @@ import { api, LogEntry, LogQuery } from '../../api/client'
 import SaveButton from './SaveButton'
 import Toggle from './Toggle'
 import { useSaveResult } from './useSaveResult'
+import { usePolling } from '../../components/usePolling'
 
 function formatBackupSize(bytes: number): string {
   if (!bytes || bytes <= 0) return '0 B'
@@ -137,12 +138,11 @@ export default function LogsTab() {
     api.listBackups().then(setBackups).catch(console.error)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-refresh logs every 5 s while the toggle is on.
-  useEffect(() => {
-    if (!logAutoRefresh) return
-    const id = setInterval(() => { fetchLogs(logPage) }, 5000)
-    return () => clearInterval(id)
-  }, [logAutoRefresh, logPage, logFilter, logComponent, logFrom, logTo, logSearch]) // eslint-disable-line react-hooks/exhaustive-deps
+  // Auto-refresh logs every 5 s while the toggle is on and the tab is visible
+  // (#2360). The filter state used to be listed as effect deps purely so the
+  // interval captured fresh values; usePolling holds the callback in a ref, so
+  // changing a filter no longer restarts the 5 s window.
+  usePolling(() => { fetchLogs(logPage) }, 5000, logAutoRefresh)
 
   return (
     <div>


### PR DESCRIPTION
Queue, Wanted and the Logs tab each polled on a fixed 5s `setInterval` that ran whether or not anyone was looking. `visibilitychange` appeared exactly once in the whole frontend (`AuthContext`) and none of the three used it, so a queue left open in a background window overnight made roughly 1400 requests an hour with nothing to show for them.

`usePolling(fn, intervalMs, enabled)` runs `fn` while `document.hidden` is false, stops when the tab goes away, and does one catch up call the moment it comes back so returning to the tab shows current data rather than data up to an interval stale.

It also holds the callback in a ref, which fixes the second half of the issue. `WantedPage` listed `showResults`, `grabbingGuid` and `searchingId` in its effect deps purely so the interval captured fresh values, so every hover cleared the timer and restarted the 5s window. The guard now skips a tick instead of restarting the clock. `LogsTab` listed its six filter states for the same reason and no longer needs to.

This is the cheap version of #1163 (push updates over SSE), not a replacement for it.

Closes #2360

## Tests

New `web/src/components/usePolling.test.tsx`, fake timers throughout: no call on mount then one per interval, nothing while hidden plus one catch up call on return, nothing at all when mounted into an already hidden tab, `enabled: false` suspends and re enables, and the timer and listener are cleared on unmount.

The one that pins the actual bug is `keeps one timer running when unrelated state changes`: it advances 4000ms, re renders twice, advances 1000ms and asserts exactly one call with the newest closure's value. The old dep list would have restarted the window and fired nothing.

```
cd web
npm run typecheck   # clean
npm run lint        # 0 errors, 6 pre-existing warnings
npm test            # 69 files, 664 tests, all passing
npm run build       # clean
```

## Sequencing

**Merge after #2377, #2382 and #2394**, all of which also touch `QueuePage.tsx`. Last of the four frontend PRs. Next minor, not patch release material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
