### PR TITLE
docs(importer): say why normalizeTitle diverges from CanonicalDedupKey (#2356)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2323,6 +2323,27 @@ func (s *Scanner) SnapshotFinder() *LibrarySnapshot {
 // spell the same title differently: "Enders Game" vs "Ender's Game", "Die
 // Hoehle" vs "Die Höhle", "Der Prozess" vs "Der Prozeß" (#1646). It runs AFTER
 // the comma-suffix inversion, which needs the comma the fold would remove.
+//
+// Why this is not indexer.CanonicalDedupKey, despite the #1648 consolidation
+// that exists so these alphabets stop drifting: the article handling above is
+// deliberate and specific to filesystem names. Library layouts really do carry
+// inverted articles as folder and file names, "Darker Shade of Magic, A" being
+// the case PR #517 was opened for, and Calibre's own sort-title convention
+// produces them by default. CanonicalDedupKey does neither the inversion nor
+// the strip, and must not: it is stored verbatim in books.dedup_key and
+// compared with =, so every side of every comparison has to compute it the
+// same way.
+//
+// That is also the constraint on this function. The output of normalizeTitle
+// MUST NOT be compared against a stored dedup_key, or used to look one up.
+// Stripping the article guarantees a miss on any title that starts with one:
+// "The Fragile Threads of Power" keys as "the fragile threads of power" in the
+// database and normalizes to "fragile threads of power" here. Every caller
+// today (scanner.go titleMatch and the scanBook precompute, lookup.go's exact
+// title check) compares two in-memory strings that it normalized itself, which
+// is the only safe shape. Reach for indexer.CanonicalDedupKey or
+// indexer.MainTitleKey when the other side of the comparison came out of the
+// database.
 func normalizeTitle(s string) string {
 	s = strings.ToLower(strings.TrimSpace(s))
 	// Invert comma-suffix form: check ", an" before ", a" to avoid prefix collision.


### PR DESCRIPTION
`normalizeTitle` inverts comma-suffix article form and strips the leading article. `indexer.CanonicalDedupKey` does neither. #1648 consolidated the normalisation alphabets precisely so they stop drifting, and this one was left out of that on purpose, but nothing in the file said so.

The comment now records two things. Why the divergence is right: filesystem layouts genuinely carry inverted articles as folder names, which is what PR #517 was opened for, and Calibre's sort-title convention produces them by default. And the constraint that follows from it: the output must never be compared against a stored `dedup_key` or used to look one up, because the article strip guarantees a miss on any title that starts with one.

I checked that claim rather than asserting it:

```
"The Fragile Threads of Power"   norm="fragile threads of power"   key="the fragile threads of power"
"Fragile Threads of Power, The"  norm="fragile threads of power"   key="fragile threads of power the"
"A Darker Shade of Magic"        norm="darker shade of magic"      key="a darker shade of magic"
```

Every caller today (`titleMatch`, the `scanBook` precompute, `lookup.go`'s exact title check) compares two in-memory strings it normalized itself, which is the only safe shape. The comment makes that a requirement instead of a coincidence.

No behaviour change.

Closes #2356

### Tests

No new test, since there is no behaviour to pin. `go build ./...`, `go vet ./internal/importer/...`, `go test ./internal/importer/...` (ok, 24s), `golangci-lint run ./internal/importer/...` (0 issues).

### Sequencing

Any time. Documentation only, blocks nothing, blocked by nothing, touches no file any other open PR does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
