### PR TITLE
fix(jobs): track the handler goroutines and honour the Go contract (#2371) (#2372)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -604,7 +604,8 @@ func main() {
 		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI).
 		WithEditionHydration(editionRepo).
 		WithRoots(libraryRoots).
-		WithLifetimeCtx(appCtx)
+		WithLifetimeCtx(appCtx).
+		WithJobs(bgJobs) // drain an in-flight author catalogue sync on shutdown (#2371)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).
 		WithSettings(settingsRepo).
@@ -642,7 +643,8 @@ func main() {
 	// download dirs) still gates the delete handlers.
 	importRoots := api.NewLibraryRoots(rootFolderRepo, cfg.LibraryDir, cfg.AudiobookDir, cfg.DownloadDir, cfg.AudiobookDownloadDir)
 	manualImportHandler := api.NewManualImportHandler(importScanner, downloadRepo, bookRepo).
-		WithRoots(importRoots)
+		WithRoots(importRoots).
+		WithJobs(bgJobs) // drain in-flight batch imports and reassigns on shutdown (#2371)
 	pendingHandler := api.NewPendingHandler(pendingReleaseRepo, queueHandler, downloadRepo, bookRepo)
 	reorganizeHandler := api.NewReorganizeHandler(importScanner)
 	importScanner.WithSettings(settingsRepo)

--- a/internal/abs/importer.go
+++ b/internal/abs/importer.go
@@ -19,6 +19,12 @@ import (
 
 var ErrAlreadyRunning = errors.New("abs import already running")
 
+// ErrShuttingDown is returned by Start when the import could not be launched
+// because the process is already draining its background jobs. The running flag
+// and progress snapshot are rolled back before it is returned, so a restarted
+// process starts clean. Matches hardcoverlistsyncer.ErrShuttingDown.
+var ErrShuttingDown = errors.New("server is shutting down")
+
 func NewImporter(
 	authors *db.AuthorRepo,
 	aliases *db.AuthorAliasRepo,
@@ -248,11 +254,31 @@ func (i *Importer) Start(ctx context.Context, cfg ImportConfig) error {
 	// nothing ever cancels. Fall back to an untracked goroutine otherwise so
 	// tests and non-wired callers keep the previous behaviour (#1458).
 	if i.jobs != nil {
-		i.jobs.Go("abs-import", func(ctx context.Context) { i.run(ctx, cfg) })
-	} else {
-		go i.run(ctx, cfg)
+		// Go is a documented no-op once the group has begun shutting down. The
+		// gate and the Running progress snapshot are published above, so a
+		// dropped launch has to be undone here or Progress() keeps describing
+		// an import that will never finish (#2372).
+		if !i.jobs.Go("abs-import", func(ctx context.Context) { i.run(ctx, cfg) }) {
+			i.abandonStart(ErrShuttingDown)
+			return ErrShuttingDown
+		}
+		return nil
 	}
+	go i.run(ctx, cfg)
 	return nil
+}
+
+// abandonStart rolls back the running flag and progress snapshot Start
+// published, for a background import that was never launched.
+func (i *Importer) abandonStart(err error) {
+	now := time.Now().UTC()
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.running = false
+	i.progress.Running = false
+	i.progress.FinishedAt = &now
+	i.progress.Error = err.Error()
+	i.progress.Message = "import not started"
 }
 
 func (i *Importer) Run(ctx context.Context, cfg ImportConfig) (*ImportStats, error) {

--- a/internal/abs/importer_shutdown_test.go
+++ b/internal/abs/importer_shutdown_test.go
@@ -1,0 +1,58 @@
+package abs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/jobs"
+)
+
+// TestStart_ShutDownGroupRollsBackProgress is the regression guard for #2372.
+//
+// Start publishes running=true and a Running progress snapshot before handing
+// the work to the jobs group. jobs.Group.Go is a documented no-op once the group
+// has begun shutting down, so ignoring its return left Progress() describing an
+// import that would never finish for the rest of the process's life.
+func TestStart_ShutDownGroupRollsBackProgress(t *testing.T) {
+	group := jobs.NewGroup(context.Background())
+	if names := group.Shutdown(time.Second); len(names) != 0 {
+		t.Fatalf("shutting down an idle group reported jobs still running: %v", names)
+	}
+
+	i := &Importer{}
+	i.WithJobs(group)
+
+	err := i.Start(context.Background(), ImportConfig{
+		SourceID: DefaultSourceID,
+		BaseURL:  "http://abs.example",
+		APIKey:   "k",
+		Enabled:  true,
+	})
+	if !errors.Is(err, ErrShuttingDown) {
+		t.Fatalf("Start on a shut-down group: got %v, want ErrShuttingDown", err)
+	}
+
+	progress := i.Progress()
+	if progress.Running {
+		t.Error("Progress still reports a running import that was never launched")
+	}
+	if progress.FinishedAt == nil {
+		t.Error("Progress has no FinishedAt, so the UI polls a run that never ends")
+	}
+	if progress.Error == "" {
+		t.Error("Progress carries no error, so nothing explains why the import did not run")
+	}
+
+	// The gate has to be released too, otherwise a later Start answers
+	// ErrAlreadyRunning forever.
+	if err := i.Start(context.Background(), ImportConfig{
+		SourceID: DefaultSourceID,
+		BaseURL:  "http://abs.example",
+		APIKey:   "k",
+		Enabled:  true,
+	}); errors.Is(err, ErrAlreadyRunning) {
+		t.Error("the running gate was not released; every later import is refused")
+	}
+}

--- a/internal/api/abs_import.go
+++ b/internal/api/abs_import.go
@@ -67,6 +67,12 @@ func (h *ABSImportHandler) Start(w http.ResponseWriter, r *http.Request) {
 	case errors.Is(err, abs.ErrAlreadyRunning):
 		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
 		return
+	case errors.Is(err, abs.ErrShuttingDown):
+		// The process is draining and refused to start new work. 503 rather
+		// than 400: nothing about the request is wrong, it just arrived too
+		// late. Same answer the Hardcover list sync gives (#2372).
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
 	case err != nil:
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return

--- a/internal/api/abs_import_test.go
+++ b/internal/api/abs_import_test.go
@@ -180,6 +180,30 @@ func TestABSImportHandler_StartAlreadyRunning(t *testing.T) {
 	}
 }
 
+// TestABSImportHandler_StartShuttingDown pins the answer for an import the jobs
+// group refused because the process is draining (#2372). 400 would blame the
+// request; nothing about it is wrong, it just arrived too late.
+func TestABSImportHandler_StartShuttingDown(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubABSImporter{startErr: abs.ErrShuttingDown}
+	h := NewABSImportHandler(stub, func(context.Context) ABSStoredConfig {
+		return ABSStoredConfig{
+			BaseURL:   "https://abs.example.com",
+			APIKey:    "secret",
+			Label:     "Shelf",
+			LibraryID: "lib-books",
+			Enabled:   true,
+		}
+	})
+
+	rec := httptest.NewRecorder()
+	h.Start(rec, httptest.NewRequest(http.MethodPost, "/api/v1/abs/import", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
 func TestABSImportHandler_Status(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vavallee/bindery/internal/concurrency"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/jobs"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/telemetry"
@@ -80,6 +81,11 @@ type AuthorHandler struct {
 	// context.Background() when not set; see #846 and recommendations.go.
 	lifetimeCtx context.Context
 
+	// jobs tracks the catalogue-sync goroutine so shutdown can drain it before
+	// the database closes (#1458, #2371). Optional: without it the sync runs as
+	// an untracked goroutine, which is what tests and non-wired callers get.
+	jobs *jobs.Group
+
 	// syncSummaries records what each catalogue sync added and dropped so the
 	// detail endpoint can report it instead of leaving the drops to a Debug
 	// log line nobody reads (#1889).
@@ -88,6 +94,17 @@ type AuthorHandler struct {
 
 func NewAuthorHandler(authors *db.AuthorRepo, aliases *db.AuthorAliasRepo, books *db.BookRepo, series *db.SeriesRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo, searcher BookSearcher) *AuthorHandler {
 	return &AuthorHandler{authors: authors, aliases: aliases, books: books, series: series, meta: meta, settings: settings, profiles: profiles, searcher: searcher}
+}
+
+// WithJobs registers the process-wide background-jobs group so the async
+// catalogue sync an author add kicks off is tracked and drained on shutdown
+// before the database closes, mirroring Scanner.WithJobs (#1458, #2371).
+// Without it the sync is a bare goroutine that a SIGTERM cuts off mid-write,
+// leaving the author with a partial catalogue and "database is closed" in the
+// log.
+func (h *AuthorHandler) WithJobs(g *jobs.Group) *AuthorHandler {
+	h.jobs = g
+	return h
 }
 
 // WithFinder attaches a LibraryFinder to the handler. When set, FetchAuthorBooks
@@ -691,7 +708,23 @@ func (h *AuthorHandler) fetchAuthorBooksAsync(author *models.Author, opts catalo
 		return
 	}
 	snapshot := *author
-	go h.fetchAuthorBooks(&snapshot, opts)
+	// With a jobs group wired the sync runs on the shutdown-scoped context, so
+	// SIGTERM cancels and drains it before the DB closes rather than cutting it
+	// off mid-write. Fall back to an untracked goroutine for tests and
+	// non-wired callers, the same shape StartScan uses (#1458, #2371).
+	if h.jobs != nil {
+		if !h.jobs.Go("author-catalogue-sync", func(ctx context.Context) {
+			h.fetchAuthorBooks(ctx, &snapshot, opts)
+		}) {
+			// Go is a documented no-op once the group is shutting down. Nothing
+			// to roll back here (no running flag is published), but the drop is
+			// worth a line: the author was created and its catalogue was not.
+			slog.Warn("author catalogue sync not started: server is shutting down",
+				"author", snapshot.Name, "foreignId", snapshot.ForeignID)
+		}
+		return
+	}
+	go h.fetchAuthorBooks(h.bgCtx(), &snapshot, opts)
 }
 
 func (h *AuthorHandler) fetchAuthorForCreate(ctx context.Context, foreignID, fallbackName string) (*models.Author, error) {
@@ -1721,7 +1754,7 @@ func mergeAuthorProfileFields(author, upstream *models.Author) bool {
 // must use RefreshAuthorBooks instead so the author's MonitorNewItems policy
 // applies to later-discovered works (issue #1348).
 func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool, mediaType string) {
-	h.fetchAuthorBooks(author, catalogueSyncOptions{autoSearch: autoSearch, mediaType: mediaType})
+	h.fetchAuthorBooks(h.bgCtx(), author, catalogueSyncOptions{autoSearch: autoSearch, mediaType: mediaType})
 }
 
 // RefreshAuthorBooks is the discovery variant of FetchAuthorBooks used by the
@@ -1731,7 +1764,7 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 // for them (authorAcceptsDiscoveredBooks) — a refresh must never grow the
 // library behind the user's back (issues #1348, #1815).
 func (h *AuthorHandler) RefreshAuthorBooks(author *models.Author, autoSearch bool, mediaType string) {
-	h.fetchAuthorBooks(author, catalogueSyncOptions{autoSearch: autoSearch, mediaType: mediaType, discovery: true})
+	h.fetchAuthorBooks(h.bgCtx(), author, catalogueSyncOptions{autoSearch: autoSearch, mediaType: mediaType, discovery: true})
 }
 
 // authorAcceptsDiscoveredBooks reports whether a refresh-path catalogue sync
@@ -1788,7 +1821,9 @@ func (h *AuthorHandler) authorAwaitsFirstCatalogue(ctx context.Context, author *
 	return populatedAt == nil
 }
 
-func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSyncOptions) {
+// ctx is the background context the sync runs on: the jobs group's
+// shutdown-scoped one when the async path launched it, h.bgCtx() otherwise.
+func (h *AuthorHandler) fetchAuthorBooks(ctx context.Context, author *models.Author, opts catalogueSyncOptions) {
 	autoSearch, mediaType, discovery := opts.autoSearch, opts.mediaType, opts.discovery
 	// singleWork: the caller picked one specific book and the direct insert
 	// couldn't produce it. This run exists only to create that one row, so it
@@ -1796,7 +1831,6 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, opts catalogueSy
 	// Calibre re-link, no sync summary — and it is exempt from the
 	// catalogue-sync heuristics that may veto a work (#1612).
 	singleWork := opts.onlyForeignID != ""
-	ctx := h.bgCtx()
 	slog.Info("fetching books for author", "author", author.Name, "foreignId", author.ForeignID)
 
 	// Calibre-imported authors carry a synthetic "calibre:author:N" foreign ID

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -6196,7 +6196,7 @@ func TestFetchAuthorBooks_AuthorDeletedDuringFetch_AbortsWithoutFKBurst(t *testi
 	}
 
 	logs := captureSlog(t)
-	h.fetchAuthorBooks(&snapshot, catalogueSyncOptions{mediaType: models.MediaTypeEbook, discovery: true})
+	h.fetchAuthorBooks(context.Background(), &snapshot, catalogueSyncOptions{mediaType: models.MediaTypeEbook, discovery: true})
 
 	if got := logs.String(); strings.Contains(got, "failed to create book") {
 		t.Errorf("sync against deleted author emitted per-book create failures:\n%s", got)

--- a/internal/api/grimmory_sync.go
+++ b/internal/api/grimmory_sync.go
@@ -65,6 +65,12 @@ func (h *GrimmorySyncHandler) Start(w http.ResponseWriter, r *http.Request) {
 	case errors.Is(err, grimmory.ErrSyncAlreadyRunning):
 		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
 		return
+	case errors.Is(err, grimmory.ErrShuttingDown):
+		// The process is draining and refused to start new work. 503 rather
+		// than 500: nothing is broken, the request just arrived too late. Same
+		// answer the Hardcover list sync gives (#2372).
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
 	case err != nil:
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 		return

--- a/internal/api/grimmory_sync_test.go
+++ b/internal/api/grimmory_sync_test.go
@@ -82,6 +82,20 @@ func TestGrimmorySyncStart_AlreadyRunningConflicts(t *testing.T) {
 	}
 }
 
+// TestGrimmorySyncStart_ShuttingDownReturns503 pins the answer for a sync the
+// jobs group refused because the process is draining (#2372). 500 would read as
+// a fault; nothing is broken, the request just arrived too late.
+func TestGrimmorySyncStart_ShuttingDownReturns503(t *testing.T) {
+	stub := &stubGrimmorySyncer{startErr: grimmory.ErrShuttingDown}
+	h := NewGrimmorySyncHandler(stub, readyGrimmoryCfg)
+
+	rec := httptest.NewRecorder()
+	h.Start(rec, httptest.NewRequest(http.MethodPost, "/api/v1/grimmory/sync", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
 func TestGrimmorySyncStatus(t *testing.T) {
 	stub := &stubGrimmorySyncer{progress: grimmory.SyncProgress{Running: true, Message: "pushing"}}
 	h := NewGrimmorySyncHandler(stub, readyGrimmoryCfg)

--- a/internal/api/handler_jobs_group_test.go
+++ b/internal/api/handler_jobs_group_test.go
@@ -136,6 +136,60 @@ func TestManualImportBatch_ShutDownGroupIsRefused(t *testing.T) {
 	}
 }
 
+// TestManualImportReassign_ShutDownGroupIsRefused pins the same answer for the
+// reassign endpoint (#2372). Reassign has already detached the file from the
+// source book by the time it launches the move, so answering 202 for a move
+// that never happens would leave the file attached to nothing.
+func TestManualImportReassign_ShutDownGroupIsRefused(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+
+	src := seedBook(t, authors, books, ctx)
+	target := &models.Book{
+		ForeignID: "mi-book-shutdown", AuthorID: src.AuthorID,
+		Title: "Correct Book", SortTitle: "correct book",
+		Status: "wanted", Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, target); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	epub := filepath.Join(t.TempDir(), "mismatched.epub")
+	writeTestFile(t, epub)
+	if err := books.AddBookFile(ctx, src.ID, models.MediaTypeEbook, epub); err != nil {
+		t.Fatalf("attach file to source: %v", err)
+	}
+
+	scanner := &stubManualImportScanner{}
+	group := jobs.NewGroup(context.Background())
+	group.Shutdown(time.Second)
+	h := NewManualImportHandler(scanner, db.NewDownloadRepo(database), books).WithJobs(group)
+
+	body, err := json.Marshal(map[string]any{
+		"path": epub, "targetBookId": target.ID, "format": models.MediaTypeEbook,
+	})
+	if err != nil {
+		t.Fatalf("marshal reassign: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	h.Reassign(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/reassign", bytes.NewReader(body)))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 while shutting down; body = %s", rec.Code, rec.Body.String())
+	}
+	scanner.importMu.Lock()
+	calls := scanner.importCalls
+	scanner.importMu.Unlock()
+	if calls != 0 {
+		t.Errorf("ImportFromPath ran %d times for a refused reassign", calls)
+	}
+}
+
 // TestFetchAuthorBooksAsync_RoutesThroughTheJobsGroup covers the author side of
 // #2371. A calibre-prefixed author on a single-work run returns immediately
 // inside fetchAuthorBooks, which keeps the assertion about the launch rather

--- a/internal/api/handler_jobs_group_test.go
+++ b/internal/api/handler_jobs_group_test.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/jobs"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// blockingImportScanner parks ImportFromPath until release is closed, so a test
+// can observe whether shutdown WAITS for the import or walks straight past it.
+type blockingImportScanner struct {
+	stubManualImportScanner
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingImportScanner) ImportFromPath(ctx context.Context, dl *models.Download, path, hint string) {
+	select {
+	case s.started <- struct{}{}:
+	default:
+	}
+	<-s.release
+	s.stubManualImportScanner.ImportFromPath(ctx, dl, path, hint)
+}
+
+// batchImportRequest seeds a book and a real file, and returns the request body
+// for a one-item batch import of it.
+func batchImportRequest(t *testing.T, authors *db.AuthorRepo, books *db.BookRepo, ctx context.Context) []byte {
+	t.Helper()
+	book := seedBook(t, authors, books, ctx)
+	path := filepath.Join(t.TempDir(), "good.epub")
+	writeTestFile(t, path)
+	body, err := json.Marshal([]map[string]any{
+		{"path": path, "bookId": book.ID, "format": models.MediaTypeEbook},
+	})
+	if err != nil {
+		t.Fatalf("marshal batch: %v", err)
+	}
+	return body
+}
+
+// TestManualImportBatch_ShutdownDrainsTheImport is the regression guard for
+// #2371 on the manual-import side. The batch fan-out used to be a bare
+// goroutine, so a SIGTERM mid-import closed the database under it. Routed
+// through the jobs group, Shutdown must block until it finishes.
+func TestManualImportBatch_ShutdownDrainsTheImport(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+
+	scanner := &blockingImportScanner{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	group := jobs.NewGroup(context.Background())
+	h := NewManualImportHandler(scanner, db.NewDownloadRepo(database), books).WithJobs(group)
+
+	rec := httptest.NewRecorder()
+	h.ImportBatch(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/batch",
+		bytes.NewReader(batchImportRequest(t, authors, books, ctx))))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case <-scanner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the batch import never started")
+	}
+
+	drained := make(chan []string, 1)
+	go func() { drained <- group.Shutdown(10 * time.Second) }()
+
+	select {
+	case names := <-drained:
+		t.Fatalf("Shutdown returned while the import was still running (stragglers: %v); the job is not tracked", names)
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked, which is the point.
+	}
+
+	close(scanner.release)
+	select {
+	case names := <-drained:
+		if len(names) != 0 {
+			t.Errorf("Shutdown reported jobs still running after release: %v", names)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Shutdown never returned after the import was released")
+	}
+}
+
+// TestManualImportBatch_ShutDownGroupIsRefused pins the other half of the Go
+// contract (#2372): once the group is draining, the handler must say so rather
+// than answer 202 for work that will never run.
+func TestManualImportBatch_ShutDownGroupIsRefused(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+
+	scanner := &stubManualImportScanner{}
+	group := jobs.NewGroup(context.Background())
+	group.Shutdown(time.Second)
+	h := NewManualImportHandler(scanner, db.NewDownloadRepo(database), books).WithJobs(group)
+
+	rec := httptest.NewRecorder()
+	h.ImportBatch(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/batch",
+		bytes.NewReader(batchImportRequest(t, authors, books, ctx))))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 while shutting down; body = %s", rec.Code, rec.Body.String())
+	}
+	scanner.importMu.Lock()
+	calls := scanner.importCalls
+	scanner.importMu.Unlock()
+	if calls != 0 {
+		t.Errorf("ImportFromPath ran %d times for a refused batch", calls)
+	}
+}
+
+// TestFetchAuthorBooksAsync_RoutesThroughTheJobsGroup covers the author side of
+// #2371. A calibre-prefixed author on a single-work run returns immediately
+// inside fetchAuthorBooks, which keeps the assertion about the launch rather
+// than about the sync's own work.
+func TestFetchAuthorBooksAsync_RoutesThroughTheJobsGroup(t *testing.T) {
+	author := &models.Author{ID: 1, Name: "Calibre Author", ForeignID: "calibre:author:1"}
+	opts := catalogueSyncOptions{onlyForeignID: "OL1W"}
+
+	t.Run("live group runs and drains it", func(t *testing.T) {
+		logs := captureSlog(t)
+		group := jobs.NewGroup(context.Background())
+		h := &AuthorHandler{}
+		h.WithJobs(group)
+
+		h.fetchAuthorBooksAsync(author, opts)
+		if names := group.Shutdown(10 * time.Second); len(names) != 0 {
+			t.Fatalf("Shutdown reported jobs still running: %v", names)
+		}
+		// Shutdown drained the job, so the sync's first log line is on record
+		// by the time Shutdown returned. A bare goroutine would race this.
+		if got := logs.String(); !strings.Contains(got, "fetching books for author") {
+			t.Errorf("catalogue sync did not run through the group; logs: %s", got)
+		}
+	})
+
+	t.Run("shut-down group drops it with a reason", func(t *testing.T) {
+		logs := captureSlog(t)
+		group := jobs.NewGroup(context.Background())
+		group.Shutdown(time.Second)
+		h := &AuthorHandler{}
+		h.WithJobs(group)
+
+		h.fetchAuthorBooksAsync(author, opts)
+		got := logs.String()
+		if strings.Contains(got, "fetching books for author") {
+			t.Errorf("catalogue sync ran on a shut-down group; logs: %s", got)
+		}
+		if !strings.Contains(got, "server is shutting down") {
+			t.Errorf("dropped catalogue sync left no trace; logs: %s", got)
+		}
+	})
+}

--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -34,13 +34,18 @@ func (h *LibraryHandler) WithSettings(sr *db.SettingsRepo) *LibraryHandler {
 // returns 202 Accepted. The scan runs asynchronously; clients can monitor
 // progress via the book list. If a scan is already in flight (manual or the
 // scheduled 6-hourly job) it returns 409 Conflict instead of starting a
-// second concurrent full walk (#1460).
+// second concurrent full walk (#1460). If the process is shutting down it
+// returns 503 rather than 202 for a scan that will never run (#2372).
 func (h *LibraryHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	// context.WithoutCancel so the scan goroutine isn't killed when the HTTP
 	// response is sent and the request context is cancelled.
 	err := h.scanner.StartScan(context.WithoutCancel(r.Context()))
 	if errors.Is(err, importer.ErrScanAlreadyRunning) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	}
+	if errors.Is(err, importer.ErrShuttingDown) {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusAccepted, map[string]string{"message": "library scan started"})

--- a/internal/api/library_test.go
+++ b/internal/api/library_test.go
@@ -93,6 +93,27 @@ func TestLibraryScan_AlreadyRunningReturns409(t *testing.T) {
 	}
 }
 
+// TestLibraryScan_ShuttingDownReturns503 pins the answer for a scan the jobs
+// group refused because the process is draining (#2372). 202 there would tell
+// the user a scan started when nothing did.
+func TestLibraryScan_ShuttingDownReturns503(t *testing.T) {
+	fake := &fakeScanner{err: importer.ErrShuttingDown}
+	h := &LibraryHandler{scanner: fake}
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, httptest.NewRequest(http.MethodPost, "/library/scan", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 while shutting down, got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if body["error"] == "" {
+		t.Error("expected non-empty error in response body")
+	}
+}
+
 func TestLibraryScan_Returns202(t *testing.T) {
 	h := newLibraryHandler(t)
 	rec := httptest.NewRecorder()

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
+	"github.com/vavallee/bindery/internal/jobs"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -35,10 +36,36 @@ type ManualImportHandler struct {
 	downloads *db.DownloadRepo
 	books     *db.BookRepo
 	roots     *LibraryRoots
+	// jobs tracks the batch-import and reassign goroutines so shutdown can
+	// drain them before the database closes (#1458, #2371). Optional: without
+	// it they run untracked, which is what tests and non-wired callers get.
+	jobs *jobs.Group
 }
 
 func NewManualImportHandler(scanner manualImportScanner, downloads *db.DownloadRepo, books *db.BookRepo) *ManualImportHandler {
 	return &ManualImportHandler{scanner: scanner, downloads: downloads, books: books}
+}
+
+// WithJobs registers the process-wide background-jobs group so the batch-import
+// fan-out and the reassign move are tracked and drained on shutdown before the
+// database closes, mirroring Scanner.WithJobs (#1458, #2371). Both move files
+// as well as writing rows, so a SIGTERM mid-flight leaves state on disk that
+// the DB does not describe.
+func (h *ManualImportHandler) WithJobs(g *jobs.Group) *ManualImportHandler {
+	h.jobs = g
+	return h
+}
+
+// goBackground runs fn as a tracked background job when a jobs group is wired,
+// and as a bare goroutine on fallbackCtx otherwise. It reports whether the work
+// was started: false means the group is already draining, which is the
+// documented Go contract callers must not ignore (#2372).
+func (h *ManualImportHandler) goBackground(name string, fallbackCtx context.Context, fn func(ctx context.Context)) bool {
+	if h.jobs != nil {
+		return h.jobs.Go(name, fn)
+	}
+	go fn(fallbackCtx)
+	return true
 }
 
 // WithRoots attaches the shared library-root containment checker. Both Lookup
@@ -218,10 +245,13 @@ func (h *ManualImportHandler) Reassign(w http.ResponseWriter, r *http.Request) {
 	// THIS import actually placed a new file for the target, rather than treating
 	// a pre-existing unrelated file as proof of a successful move (#1368).
 	preexisting := h.targetFilePaths(ctx, targetID)
-	go func() {
+	if !h.goBackground("manual-import-reassign", ctx, func(ctx context.Context) {
 		h.scanner.ImportFromPath(ctx, dl, path, req.Format)
 		h.removeStaleSource(ctx, path, targetID, preexisting)
-	}()
+	}) {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "server is shutting down"})
+		return
+	}
 	writeJSON(w, http.StatusAccepted, dl)
 }
 
@@ -561,8 +591,7 @@ func (h *ManualImportHandler) ImportBatch(w http.ResponseWriter, r *http.Request
 	}
 
 	if len(jobs) > 0 {
-		ctx := context.WithoutCancel(r.Context())
-		go func() {
+		started := h.goBackground("manual-batch-import", context.WithoutCancel(r.Context()), func(ctx context.Context) {
 			sem := make(chan struct{}, batchImportConcurrency)
 			var wg sync.WaitGroup
 			for _, j := range jobs {
@@ -575,7 +604,11 @@ func (h *ManualImportHandler) ImportBatch(w http.ResponseWriter, r *http.Request
 				}(j)
 			}
 			wg.Wait()
-		}()
+		})
+		if !started {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "server is shutting down"})
+			return
+		}
 	}
 
 	writeJSON(w, http.StatusAccepted, resp)

--- a/internal/downloader/health.go
+++ b/internal/downloader/health.go
@@ -154,7 +154,13 @@ func RefreshDownloadClientHealthAsync(parent context.Context, g *jobs.Group, sto
 			store.Set(client.ID, CheckDownloadClientHealth(ctx, &client, downloadDir, audiobookDownloadDir, globalRemap))
 		}
 		if g != nil {
-			g.Go("download-health-refresh", probe)
+			// Go is a documented no-op once the group has begun shutting down.
+			// The Checking placeholder is published above, so a dropped probe
+			// has to take it back down or the client shows "Checking download
+			// client paths" for the rest of the process's life (#2372).
+			if !g.Go("download-health-refresh", probe) {
+				store.Delete(client.ID)
+			}
 		} else {
 			go probe(parent)
 		}

--- a/internal/downloader/health_shutdown_test.go
+++ b/internal/downloader/health_shutdown_test.go
@@ -1,0 +1,38 @@
+package downloader
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/jobs"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestRefreshDownloadClientHealthAsync_ShutDownGroupClearsTheChecking placeholder
+// is the regression guard for #2372. The refresh writes a Checking placeholder
+// before handing each probe to the jobs group. jobs.Group.Go is a documented
+// no-op once the group has begun shutting down, so ignoring its return left the
+// client showing "Checking download client paths" with nothing on its way to
+// replace it.
+func TestRefreshDownloadClientHealthAsync_ShutDownGroupClearsTheChecking(t *testing.T) {
+	group := jobs.NewGroup(context.Background())
+	if names := group.Shutdown(time.Second); len(names) != 0 {
+		t.Fatalf("shutting down an idle group reported jobs still running: %v", names)
+	}
+
+	store := NewHealthStore()
+	clients := []models.DownloadClient{
+		{ID: 1, Name: "qb", Type: "qbittorrent", Host: "127.0.0.1", Port: 1, Enabled: true},
+		{ID: 2, Name: "off", Type: "qbittorrent", Host: "127.0.0.1", Port: 2, Enabled: false},
+	}
+
+	RefreshDownloadClientHealthAsync(context.Background(), group, store, clients, "", "", "")
+
+	if got := store.Get(1); got != nil {
+		t.Errorf("enabled client kept a %q placeholder for a probe that will never run: %+v", got.Status, got)
+	}
+	if got := store.Get(2); got != nil {
+		t.Errorf("disabled client should never have been touched, got %+v", got)
+	}
+}

--- a/internal/grimmory/pusher.go
+++ b/internal/grimmory/pusher.go
@@ -167,3 +167,9 @@ func (p *Pusher) pushTracked(ctx context.Context, cfg PushConfig, bookID int64, 
 // ErrSyncAlreadyRunning is returned when a bulk sync is started while a
 // previous one is still executing. Maps to 409 Conflict at the API layer.
 var ErrSyncAlreadyRunning = errors.New("grimmory sync already running")
+
+// ErrShuttingDown is returned by Start when the sync could not be launched
+// because the process is already draining its background jobs. The running flag
+// and progress snapshot are rolled back before it is returned, so a restarted
+// process starts clean. Matches hardcoverlistsyncer.ErrShuttingDown.
+var ErrShuttingDown = errors.New("server is shutting down")

--- a/internal/grimmory/syncer.go
+++ b/internal/grimmory/syncer.go
@@ -119,11 +119,31 @@ func (s *Syncer) Start(ctx context.Context, cfg PushConfig) error {
 	// before the DB closes, instead of the never-cancelled WithoutCancel(request)
 	// context. Fall back to an untracked goroutine for tests/non-wired callers.
 	if s.jobs != nil {
-		s.jobs.Go("grimmory-sync", func(ctx context.Context) { s.run(ctx, cfg) })
-	} else {
-		go s.run(ctx, cfg)
+		// Go is a documented no-op once the group has begun shutting down. The
+		// gate and the Running progress snapshot are published above, so a
+		// dropped launch has to be undone here or Progress() keeps describing a
+		// sync that will never finish (#2372).
+		if !s.jobs.Go("grimmory-sync", func(ctx context.Context) { s.run(ctx, cfg) }) {
+			s.abandonStart(ErrShuttingDown)
+			return ErrShuttingDown
+		}
+		return nil
 	}
+	go s.run(ctx, cfg)
 	return nil
+}
+
+// abandonStart rolls back the running flag and progress snapshot Start
+// published, for a background sync that was never launched.
+func (s *Syncer) abandonStart(err error) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.running = false
+	s.progress.Running = false
+	s.progress.FinishedAt = &now
+	s.progress.Message = "sync not started"
+	s.progress.Error = err.Error()
 }
 
 func (s *Syncer) run(ctx context.Context, cfg PushConfig) {

--- a/internal/grimmory/syncer_shutdown_test.go
+++ b/internal/grimmory/syncer_shutdown_test.go
@@ -1,0 +1,47 @@
+package grimmory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/jobs"
+)
+
+// TestStart_ShutDownGroupRollsBackProgress is the regression guard for #2372.
+//
+// Start publishes running=true and a Running progress snapshot before handing
+// the work to the jobs group. jobs.Group.Go is a documented no-op once the group
+// has begun shutting down, so ignoring its return left Progress() describing a
+// sync that would never finish for the rest of the process's life.
+func TestStart_ShutDownGroupRollsBackProgress(t *testing.T) {
+	group := jobs.NewGroup(context.Background())
+	if names := group.Shutdown(time.Second); len(names) != 0 {
+		t.Fatalf("shutting down an idle group reported jobs still running: %v", names)
+	}
+
+	s := NewSyncer(nil, nil).WithJobs(group)
+	cfg := PushConfig{Enabled: true, BaseURL: "http://grimmory.example", APIKey: "k"}
+
+	if err := s.Start(context.Background(), cfg); !errors.Is(err, ErrShuttingDown) {
+		t.Fatalf("Start on a shut-down group: got %v, want ErrShuttingDown", err)
+	}
+
+	progress := s.Progress()
+	if progress.Running {
+		t.Error("Progress still reports a running sync that was never launched")
+	}
+	if progress.FinishedAt == nil {
+		t.Error("Progress has no FinishedAt, so the UI polls a run that never ends")
+	}
+	if progress.Error == "" {
+		t.Error("Progress carries no error, so nothing explains why the sync did not run")
+	}
+
+	// The gate has to be released too, otherwise a later Start answers
+	// ErrSyncAlreadyRunning forever.
+	if err := s.Start(context.Background(), cfg); errors.Is(err, ErrSyncAlreadyRunning) {
+		t.Error("the running gate was not released; every later sync is refused")
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2588,6 +2588,12 @@ func authorTitleFromLayout(path string, roots ...string) (author, title string, 
 // ErrAlreadyRunning / Grimmory syncer's ErrSyncAlreadyRunning pattern.
 var ErrScanAlreadyRunning = errors.New("library scan already running")
 
+// ErrShuttingDown is returned by StartScan when the scan could not be launched
+// because the process is already draining its background jobs. The single-flight
+// gate is released before it is returned, so a restarted process starts clean.
+// Matches hardcoverlistsyncer.ErrShuttingDown.
+var ErrShuttingDown = errors.New("server is shutting down")
+
 // StartScan launches a library scan in the background and returns
 // immediately. If a scan is already in flight it returns
 // ErrScanAlreadyRunning so callers (the manual-scan endpoint) can surface a
@@ -2603,10 +2609,18 @@ func (s *Scanner) StartScan(ctx context.Context) error {
 	// never-cancelled WithoutCancel(request) context. Fall back to an untracked
 	// goroutine for tests/non-wired callers (#1458).
 	if s.jobs != nil {
-		s.jobs.Go("library-scan", func(ctx context.Context) {
+		// Go is a documented no-op once the group has begun shutting down, and
+		// the single-flight gate is already claimed above. Ignoring the return
+		// left scanRunning true for the rest of the process's life and answered
+		// the manual-scan endpoint with success for a scan that never ran
+		// (#2372).
+		if !s.jobs.Go("library-scan", func(ctx context.Context) {
 			defer s.scanRunning.Store(false)
 			s.scanLibrary(ctx)
-		})
+		}) {
+			s.scanRunning.Store(false)
+			return ErrShuttingDown
+		}
 	} else {
 		go func() {
 			defer s.scanRunning.Store(false)

--- a/internal/importer/scanner_jobs_shutdown_test.go
+++ b/internal/importer/scanner_jobs_shutdown_test.go
@@ -1,0 +1,72 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/jobs"
+)
+
+// TestStartScan_ShutDownGroupResetsTheGate is the regression guard for #2372.
+//
+// jobs.Group.Go is a documented no-op once the group has begun shutting down,
+// and StartScan claims the single-flight gate before calling it. Ignoring the
+// return left scanRunning true for the rest of the process's life and answered
+// the manual-scan endpoint with success for a scan that never ran.
+func TestStartScan_ShutDownGroupResetsTheGate(t *testing.T) {
+	s, settings, ctx := singleFlightFixture(t)
+
+	group := jobs.NewGroup(context.Background())
+	if names := group.Shutdown(time.Second); len(names) != 0 {
+		t.Fatalf("shutting down an idle group reported jobs still running: %v", names)
+	}
+	s.WithJobs(group)
+
+	err := s.StartScan(ctx)
+	if err == nil {
+		t.Fatal("StartScan reported success for a scan the shut-down jobs group refused to launch")
+	}
+	if !errors.Is(err, ErrShuttingDown) {
+		t.Errorf("StartScan error: got %v, want ErrShuttingDown", err)
+	}
+	if s.scanRunning.Load() {
+		t.Error("the single-flight gate is still held, so every later scan on this process is refused")
+	}
+	// Nothing ran, so nothing may have been recorded.
+	if setting, err := settings.Get(ctx, "library.lastScan"); err != nil {
+		t.Fatal(err)
+	} else if setting != nil {
+		t.Errorf("a refused scan wrote a lastScan result: %q", setting.Value)
+	}
+}
+
+// TestStartScan_LiveGroupStillRuns pins the other direction: a healthy group
+// launches the scan and the gate is released when it finishes.
+func TestStartScan_LiveGroupStillRuns(t *testing.T) {
+	s, settings, ctx := singleFlightFixture(t)
+
+	group := jobs.NewGroup(context.Background())
+	t.Cleanup(func() { group.Shutdown(5 * time.Second) })
+	s.WithJobs(group)
+
+	if err := s.StartScan(ctx); err != nil {
+		t.Fatalf("StartScan with a live group: %v", err)
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		setting, err := settings.Get(ctx, "library.lastScan")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if setting != nil && !s.scanRunning.Load() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("scan launched through the jobs group never completed")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}


### PR DESCRIPTION
Two halves of the same drain contract, in one PR because they touch the same call sites.

**Untracked goroutines (#2371).** `AuthorHandler` and `ManualImportHandler` now take a `WithJobs` setter mirroring `Scanner.WithJobs`, and `cmd/bindery/main.go` wires both next to the existing calls. The author catalogue sync, the manual batch import and the reassign move were bare goroutines on a context nothing cancelled and nothing waited for, so a redeploy mid-flight closed the database under them: a partial catalogue plus "database is closed" in the log, and for the import paths, files moved that the DB no longer describes. Non-wired callers and tests keep the bare-goroutine fallback, the same shape `StartScan` uses. `fetchAuthorBooks` takes its background context as a parameter now instead of reaching for `h.bgCtx()` internally, so the group's shutdown-scoped context actually reaches the work.

**Ignored `Go` returns (#2372).** The four callers that discarded the documented `false` return now undo what they published, copying `hardcoverlistsyncer/syncer.go:272-281`. `StartScan` releases the single-flight gate and returns a new `ErrShuttingDown` instead of reporting success for a scan that will never run and leaving `scanRunning` stuck true for the rest of the process's life. The ABS importer and the Grimmory syncer roll back their running flag and progress snapshot. The download-health refresh takes its `Checking` placeholder back down. The three endpoints answer 503, which is what the Hardcover list sync already did.

Closes #2371
Closes #2372

### Testing

- `TestManualImportBatch_ShutdownDrainsTheImport` (`internal/api/handler_jobs_group_test.go`) parks the import in a blocking stub and asserts `group.Shutdown` does not return until it is released. Before the change: `Shutdown returned while the import was still running (stragglers: []); the job is not tracked`.
- `TestManualImportBatch_ShutDownGroupIsRefused` asserts 503 and zero imports on a draining group. Before: `status = 202, want 503`.
- `TestFetchAuthorBooksAsync_RoutesThroughTheJobsGroup` covers both directions for the author sync. Before, neither subtest saw any log line at all because the sync never went through the group.
- `TestStartScan_ShutDownGroupResetsTheGate` (`internal/importer/scanner_jobs_shutdown_test.go`) asserts the error, the released gate, and that no `library.lastScan` was written; `TestStartScan_LiveGroupStillRuns` pins the healthy path.

Ran: `go build ./...`, `go vet ./internal/... ./cmd/...`, `go test` over `internal/api`, `internal/importer`, `internal/abs`, `internal/grimmory`, `internal/downloader`, `cmd/...` (all ok), `golangci-lint run` over the same set (0 issues).

### Sequencing

Tech debt, next minor. Merge after #2385, #2388 and #2397; the only overlap is `internal/api/queue.go` in #2397, which this does not touch, so it should be clean. Nothing depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
