### PR TITLE
perf(db): skip the startup backfills when the normaliser has not changed (#2346)

### DIFF
--- a/internal/db/backfill_revision_test.go
+++ b/internal/db/backfill_revision_test.go
@@ -1,0 +1,189 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// openFileDB opens the on-disk database at path and closes it at test end.
+// The revision markers only mean anything across process restarts, so these
+// tests need a file rather than OpenMemory.
+func openFileDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	database, err := Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	return database
+}
+
+func settingValue(t *testing.T, database *sql.DB, key string) (string, bool) {
+	t.Helper()
+	var v string
+	err := database.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&v)
+	if err == sql.ErrNoRows {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("read setting %s: %v", key, err)
+	}
+	return v, true
+}
+
+// TestBackfillBookDedupKeys_SkippedWhileRevisionMatches is the #2346 test.
+//
+// The backfill is observable through its own repair: park a deliberately wrong
+// dedup_key on a row and see whether the next startup rewrites it. With the
+// marker current it must not (that is the skipped scan); with the marker gone
+// it must (the backfill is still there and still idempotent).
+func TestBackfillBookDedupKeys_SkippedWhileRevisionMatches(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bindery.db")
+	ctx := context.Background()
+
+	database := openFileDB(t, path)
+	if got, ok := settingValue(t, database, backfillRevKeyDedup); !ok || got != strconv.Itoa(indexer.CanonicalDedupKeyRev) {
+		t.Fatalf("marker after first open = %q (present %v), want %d", got, ok, indexer.CanonicalDedupKeyRev)
+	}
+
+	authors := NewAuthorRepo(database)
+	books := NewBookRepo(database)
+	author := &models.Author{ForeignID: "OL-REV-A", Name: "Rev", SortName: "Rev"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL-REV-B", AuthorID: author.ID, Title: "The Canonical Title", Status: models.BookStatusWanted}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec("UPDATE books SET dedup_key = 'stale-on-purpose' WHERE id = ?", book.ID); err != nil {
+		t.Fatal(err)
+	}
+	database.Close()
+
+	// Second startup: the marker still matches, so the table is never scanned
+	// and the wrong key survives.
+	database = openFileDB(t, path)
+	var key string
+	if err := database.QueryRow("SELECT dedup_key FROM books WHERE id = ?", book.ID).Scan(&key); err != nil {
+		t.Fatal(err)
+	}
+	if key != "stale-on-purpose" {
+		t.Errorf("dedup_key = %q after a second open, want it untouched: the backfill re-ran despite a current revision marker", key)
+	}
+
+	// Dropping the marker is the documented way to force a recompute, and
+	// stands in for bumping CanonicalDedupKeyRev.
+	if _, err := database.Exec("DELETE FROM settings WHERE key = ?", backfillRevKeyDedup); err != nil {
+		t.Fatal(err)
+	}
+	database.Close()
+
+	database = openFileDB(t, path)
+	defer database.Close()
+	if err := database.QueryRow("SELECT dedup_key FROM books WHERE id = ?", book.ID).Scan(&key); err != nil {
+		t.Fatal(err)
+	}
+	if want := indexer.CanonicalDedupKey("The Canonical Title"); key != want {
+		t.Errorf("dedup_key = %q after the marker was dropped, want %q", key, want)
+	}
+	if got, ok := settingValue(t, database, backfillRevKeyDedup); !ok || got != strconv.Itoa(indexer.CanonicalDedupKeyRev) {
+		t.Errorf("marker after the repair run = %q (present %v), want %d", got, ok, indexer.CanonicalDedupKeyRev)
+	}
+}
+
+// TestBackfillAuthorSortKeys_SkippedWhileRevisionMatches is the same shape for
+// the authors table.
+func TestBackfillAuthorSortKeys_SkippedWhileRevisionMatches(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bindery.db")
+	ctx := context.Background()
+
+	database := openFileDB(t, path)
+	if got, ok := settingValue(t, database, backfillRevKeySortKeys); !ok || got != strconv.Itoa(authorSortKeyRev) {
+		t.Fatalf("marker after first open = %q (present %v), want %d", got, ok, authorSortKeyRev)
+	}
+
+	authors := NewAuthorRepo(database)
+	author := &models.Author{ForeignID: "OL-REV-A2", Name: "Östergaard, Åse", SortName: "Östergaard, Åse"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec("UPDATE authors SET sort_key = 'stale-on-purpose' WHERE id = ?", author.ID); err != nil {
+		t.Fatal(err)
+	}
+	database.Close()
+
+	database = openFileDB(t, path)
+	var key string
+	if err := database.QueryRow("SELECT sort_key FROM authors WHERE id = ?", author.ID).Scan(&key); err != nil {
+		t.Fatal(err)
+	}
+	if key != "stale-on-purpose" {
+		t.Errorf("sort_key = %q after a second open, want it untouched: the backfill re-ran despite a current revision marker", key)
+	}
+
+	if _, err := database.Exec("DELETE FROM settings WHERE key = ?", backfillRevKeySortKeys); err != nil {
+		t.Fatal(err)
+	}
+	database.Close()
+
+	database = openFileDB(t, path)
+	defer database.Close()
+	if err := database.QueryRow("SELECT sort_key FROM authors WHERE id = ?", author.ID).Scan(&key); err != nil {
+		t.Fatal(err)
+	}
+	if want := authorSortKey("Östergaard, Åse"); key != want {
+		t.Errorf("sort_key = %q after the marker was dropped, want %q", key, want)
+	}
+}
+
+// TestBackfillRevisionCurrent_FailsOpen pins the "a bad marker costs a scan,
+// never a stale key" rule.
+func TestBackfillRevisionCurrent_FailsOpen(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	const key = "backfill.test_rev"
+	if backfillRevisionCurrent(database, key, 1) {
+		t.Error("a missing marker must not count as current")
+	}
+
+	for _, stored := range []string{"", "  ", "banana", "1.5", "2"} {
+		markRaw(t, database, key, stored)
+		if backfillRevisionCurrent(database, key, 1) {
+			t.Errorf("stored marker %q must not count as revision 1", stored)
+		}
+	}
+
+	markBackfillRevision(database, key, 1)
+	if !backfillRevisionCurrent(database, key, 1) {
+		t.Error("a marker written at revision 1 must count as current")
+	}
+	if backfillRevisionCurrent(database, key, 2) {
+		t.Error("a marker at revision 1 must not satisfy revision 2")
+	}
+
+	// Whitespace around an otherwise valid value is tolerated.
+	markRaw(t, database, key, " 1 ")
+	if !backfillRevisionCurrent(database, key, 1) {
+		t.Error("a padded but valid marker must count as current")
+	}
+}
+
+func markRaw(t *testing.T, database *sql.DB, key, value string) {
+	t.Helper()
+	_, err := database.Exec(`
+		INSERT INTO settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(key) DO UPDATE SET value=excluded.value`, key, value)
+	if err != nil {
+		t.Fatalf("write raw marker %q: %v", value, err)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/vavallee/bindery/internal/indexer"
 
@@ -308,9 +309,11 @@ func migrate(database *sql.DB) error {
 	// Post-migration Go-side backfill. Migration 051's SQL backfill is a coarse
 	// approximation of indexer.CanonicalDedupKey (SQLite cannot run the Go
 	// normalizer); recompute the exact key for any row whose stored key is
-	// blank or no longer matches the canonical function (#940). Idempotent and
-	// cheap: a no-op once every row already holds the canonical key.
-	if err := backfillBookDedupKeys(database); err != nil {
+	// blank or no longer matches the canonical function (#940). Idempotent, but
+	// no longer free: it used to scan the whole books table on every boot just
+	// to conclude there was nothing to do, so it now runs only when the stored
+	// revision marker disagrees with the normalizer's own (#2346).
+	if err := runBackfillOnce(database, backfillRevKeyDedup, indexer.CanonicalDedupKeyRev, backfillBookDedupKeys); err != nil {
 		return fmt.Errorf("backfill book dedup keys: %w", err)
 	}
 
@@ -318,8 +321,9 @@ func migrate(database *sql.DB) error {
 	// column ships empty for existing rows. Populate it from sort_name with the
 	// Go folder (#1347). Idempotent: a no-op once every row holds its key, and it
 	// re-folds any row whose stored key drifts from authorSortKey (e.g. after a
-	// future change to the folding rules).
-	if err := backfillAuthorSortKeys(database); err != nil {
+	// change to the folding rules), which is what bumping authorSortKeyRev
+	// tells the marker gate to go and do.
+	if err := runBackfillOnce(database, backfillRevKeySortKeys, authorSortKeyRev, backfillAuthorSortKeys); err != nil {
 		return fmt.Errorf("backfill author sort keys: %w", err)
 	}
 
@@ -359,12 +363,85 @@ func ensureBooksExcludedColumn(database *sql.DB) error {
 	return nil
 }
 
+// Settings keys holding the normalizer revision each startup backfill last
+// ran at. See backfillRevisionCurrent.
+const (
+	backfillRevKeyDedup    = "backfill.dedup_key_rev"
+	backfillRevKeySortKeys = "backfill.sort_key_rev"
+)
+
+// backfillRevisionCurrent reports whether the stored marker for key already
+// equals want, i.e. whether the backfill that owns it can be skipped (#2346).
+//
+// It fails open on purpose: a missing row, an unreadable settings table, or a
+// value that does not parse all mean "run the backfill". The marker is a
+// shortcut, never a gate — a wrong answer here must cost a table scan, not
+// leave rows on a stale key. That is also why this is scoped to the exact
+// normalizer output it tracks rather than becoming a general "startup work
+// already done" flag: widening a startup check past what a change actually
+// touched is the shape of #1972, where migration 072's whole-database
+// foreign_key_check found pre-existing orphans and put instances in a restart
+// loop.
+//
+// A migration that rewrites books.title or authors.name / sort_name in bulk
+// must DELETE its marker row so the next boot recomputes; the derived key is
+// only as fresh as the column it comes from.
+func backfillRevisionCurrent(database *sql.DB, key string, want int) bool {
+	var raw string
+	if err := database.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&raw); err != nil {
+		return false
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(raw))
+	return err == nil && got == want
+}
+
+// markBackfillRevision records that the backfill owning key has just run at
+// revision rev. A write failure is logged and swallowed: the only consequence
+// is that the next boot repeats the scan, which is the behaviour that shipped
+// before the marker existed.
+func markBackfillRevision(database *sql.DB, key string, rev int) {
+	_, err := database.Exec(`
+		INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+		ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at`,
+		key, strconv.Itoa(rev), time.Now().UTC())
+	if err != nil {
+		slog.Warn("could not record backfill revision marker", "key", key, "revision", rev, "error", err)
+	}
+}
+
+// runBackfillOnce runs fn unless its revision marker says the current
+// normalizer revision has already been applied, and records the marker after a
+// successful run (#2346).
+//
+// The gate lives here rather than inside each backfill so the backfills stay
+// what they were: unconditional, idempotent, directly callable functions that
+// bring every row in line with the current normalizer. That is what their tests
+// exercise, and what dropping a marker row falls back to.
+func runBackfillOnce(database *sql.DB, key string, rev int, fn func(*sql.DB) error) error {
+	if backfillRevisionCurrent(database, key, rev) {
+		return nil
+	}
+	if err := fn(database); err != nil {
+		return err
+	}
+	// After the work, never before: a marker written ahead of a failed run
+	// would skip the retry on the next boot.
+	markBackfillRevision(database, key, rev)
+	return nil
+}
+
 // backfillAuthorSortKeys recomputes authors.sort_key for every row whose stored
 // value differs from authorSortKey(sort_name) — and likewise name_sort_key
-// against authorSortKey(name) (migration 079, #2102). It runs on every startup after
-// migrations so legacy rows created before migration 058 (which leaves sort_key
-// empty) get a correct accent-folded key, and a future change to the folder
-// re-canonicalizes existing rows on the next boot.
+// against authorSortKey(name) (migration 079, #2102). It exists so legacy rows
+// created before migration 058 (which leaves sort_key empty) get a correct
+// accent-folded key, and so a change to the folder re-canonicalizes existing
+// rows on the next boot.
+//
+// It is unconditional and idempotent: every call brings every row in line with
+// the current folder. What changed in #2346 is how often it is called —
+// migrate() now gates it on the backfill.sort_key_rev marker, so the scan runs
+// on a first boot, on the boot after authorSortKeyRev is bumped, and never
+// otherwise. Deleting the marker row is always a safe way to force a recompute.
 func backfillAuthorSortKeys(database *sql.DB) error {
 	type pending struct {
 		id      int64
@@ -427,8 +504,7 @@ func backfillAuthorSortKeys(database *sql.DB) error {
 }
 
 // backfillBookDedupKeys recomputes books.dedup_key for every row whose stored
-// value differs from indexer.CanonicalDedupKey(title). It runs on every startup
-// after migrations so that:
+// value differs from indexer.CanonicalDedupKey(title). It exists so that:
 //   - legacy rows created before migration 051 get a correct key (the SQL
 //     backfill only produced a coarse lowercase/subtitle approximation);
 //   - a future change to the canonical normalizer re-canonicalizes existing
@@ -455,6 +531,13 @@ func backfillAuthorSortKeys(database *sql.DB) error {
 //
 // Repairing libraries already duplicated by the old key is a separate piece of
 // work; the fix here stops new duplicates being created.
+//
+// It is unconditional and idempotent: every call brings every row in line with
+// the current normalizer. What changed in #2346 is how often it is called —
+// migrate() now gates it on the backfill.dedup_key_rev marker, so the scan runs
+// on a first boot, on the boot after indexer.CanonicalDedupKeyRev is bumped,
+// and never otherwise. Deleting the marker row is always a safe way to force a
+// recompute.
 func backfillBookDedupKeys(database *sql.DB) error {
 	type pending struct {
 		id  int64

--- a/internal/db/sortkey.go
+++ b/internal/db/sortkey.go
@@ -45,6 +45,18 @@ func authorSortKey(sortName string) string {
 	return folded
 }
 
+// authorSortKeyRev is the revision of the folder above. backfillAuthorSortKeys
+// records it after rewriting authors.sort_key and name_sort_key, and skips its
+// table scan while the stored value still matches, so the scan only runs on
+// the boot after this function's output changes (#2346).
+//
+// BUMP THIS whenever a change to authorSortKey, newAccentStripper or
+// textutil.FoldNonDecomposableLatin can produce a different key for the same
+// name. Missing a bump leaves existing rows folded by the old rules, which is
+// exactly the out-of-order Authors list #1347 was about. Bumping when nothing
+// changed costs one extra table scan, so when in doubt, bump.
+const authorSortKeyRev = 1
+
 // newAccentStripper builds a transformer that decomposes runes (NFD), removes
 // combining marks (Mn), then recomposes (NFC), folding precomposed accented
 // letters to their base. Constructed PER CALL: transform.Chain returns a

--- a/internal/indexer/dedup.go
+++ b/internal/indexer/dedup.go
@@ -133,6 +133,18 @@ func CanonicalDedupKey(title string) string {
 	return NormalizeTitleForDedup(StripBracketSuffixes(strings.TrimSpace(title)))
 }
 
+// CanonicalDedupKeyRev is the revision of the normalizer above. The startup
+// backfill in internal/db records it after rewriting books.dedup_key and skips
+// its table scan while the stored value still matches, so the scan only runs
+// on the boot after this function's output changes (#2346).
+//
+// BUMP THIS whenever a change to CanonicalDedupKey, NormalizeTitleForDedup or
+// StripBracketSuffixes can produce a different key for the same title. Missing
+// a bump leaves existing rows on the old key with nothing to correct them,
+// which is the asymmetry #940 and #2042 were both about. Bumping when nothing
+// changed costs one extra table scan, so when in doubt, bump.
+const CanonicalDedupKeyRev = 1
+
 // MainTitleKey is the canonical key of the title with any ": subtitle" tail
 // removed. It is the BLOCKING key: two rows for the same work always share it,
 // including when one side spells out a subtitle the other drops. It is


### PR DESCRIPTION
`backfillBookDedupKeys` and `backfillAuthorSortKeys` ran an unfiltered table scan on every boot. They exist so a change to the normaliser re-canonicalises existing rows on the next start, which means the scan only earns its keep on the boot right after that change. Every other boot it reads the whole books table and the whole authors table to conclude nothing needs writing. On a Pi with a large library that is the slow part of startup.

Each normaliser now carries a revision constant next to it (`indexer.CanonicalDedupKeyRev` beside `CanonicalDedupKey`, `authorSortKeyRev` beside `authorSortKey`), and `migrate` records it in a `settings` row (`backfill.dedup_key_rev`, `backfill.sort_key_rev`) after a successful run. The next boot compares the two and skips the scan while they match. Installs upgrading to this have no marker yet, so each backfill runs exactly once more and then settles.

Three things worth calling out:

- **The gate lives in the caller, not in the backfills.** They stay unconditional, idempotent and directly callable, which is what their existing tests exercise and what deleting a marker row falls back to. `runBackfillOnce` writes the marker only after a successful run, so a failed run is retried next boot.
- **The lookup fails open.** A missing row, an unreadable settings table, or a value that does not parse all mean "run the backfill". A wrong answer here costs a table scan, never a stale key.
- **It stays scoped to the exact normaliser output it tracks** rather than becoming a general "startup work done" flag, for the #1972 reason already written up next to `connectionPragmaDSN`. Documented next to the helper: a migration that rewrites `books.title` or `authors.name` / `sort_name` in bulk must delete its marker row, and both constants carry a BUMP THIS note.

Closes #2346

## Tests

New `internal/db/backfill_revision_test.go`. The backfill is observable through its own repair, so the tests park a deliberately wrong key on a row and check whether the next `Open` rewrites it:

- `TestBackfillBookDedupKeys_SkippedWhileRevisionMatches` and `TestBackfillAuthorSortKeys_SkippedWhileRevisionMatches` open a real file DB, assert the marker is written, stale a key, reopen and assert it survives (the skipped scan), then delete the marker, reopen and assert it is repaired. Both confirmed failing with the gate disabled: `dedup_key = "the canonical title" after a second open, want it untouched`.
- `TestBackfillRevisionCurrent_FailsOpen` pins the fail-open rule across a missing row, empty, whitespace, `banana`, `1.5` and a wrong number, plus the padded-but-valid case.

The pre-existing `TestBackfillBookDedupKeys`, `TestBackfillAuthorSortKeys` and the two `SurfacesReadError` / `SurfacesWriteError` tests are untouched and still call the backfills directly, which is the reason the gate is in the caller.

Ran:

```
go build ./...                                     ok
go vet ./internal/db/... ./internal/indexer/...     ok
go test ./... -count=1                             ok (whole tree)
golangci-lint run ./internal/db/... ./internal/indexer/...  0 issues
```

## Sequencing

Next minor. Independent of the other two PRs in this batch, no merge order constraint. Nothing depends on it.

Note: the Container Scan check fails on every PR in this batch regardless of content, so it is environmental here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
