### PR TITLE
test(jobs): stop TestGroup_RunIsTrackedAndWaitedOn racing its own flag (#2404)

### DIFF
--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -202,7 +202,7 @@ func TestGroup_RunIsTrackedAndWaitedOn(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var sawGroupCtx atomic.Bool
-	var returned atomic.Bool
+	returned := make(chan struct{})
 
 	go func() {
 		g.Run("sync-job", func(ctx context.Context) {
@@ -210,7 +210,7 @@ func TestGroup_RunIsTrackedAndWaitedOn(t *testing.T) {
 			close(started)
 			<-release
 		})
-		returned.Store(true)
+		close(returned)
 	}()
 	<-started
 
@@ -229,7 +229,13 @@ func TestGroup_RunIsTrackedAndWaitedOn(t *testing.T) {
 	if still := g.Shutdown(2 * time.Second); len(still) != 0 {
 		t.Fatalf("job did not release its tracking slot: %v", still)
 	}
-	if !returned.Load() {
+	// Wait for the caller to come back out of Run rather than sampling a flag.
+	// Run releases its tracking token from a defer, so the Shutdown above can
+	// return before the goroutine is scheduled to record that Run returned;
+	// reading a bool here raced that scheduling and failed at random (#2404).
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
 		t.Error("Run did not return after its job finished")
 	}
 }


### PR DESCRIPTION
`TestGroup_RunIsTrackedAndWaitedOn` fails at random on the race shard. It turned up on the `validate (Go race)` jobs of a PR that touches nothing in `internal/jobs`, which is what gave it away.

The race is in the test. `Run` releases its tracking token from a `defer`, so the WaitGroup drains before control returns to the caller. The test set its flag in the spawned goroutine after `Run` returned, then read that flag on the main goroutine the moment `Shutdown` came back. Nothing orders those two, so the read can win:

```
--- FAIL: TestGroup_RunIsTrackedAndWaitedOn (0.10s)
    jobs_test.go:233: Run did not return after its job finished
```

`Group` itself is fine. Waiting on a channel closed after `Run` returns asserts the same property without racing the scheduler.

Closes #2404

## Testing

Standing a 20ms sleep in for the scheduler gap makes the diagnosis reproducible rather than assumed:

- old test plus that delay: fails with the exact CI message above
- new test plus the same delay: passes 20 out of 20

Also `go vet`, `golangci-lint run` (0 issues), and `go test -race -count=40 ./internal/jobs/` green.

## Sequencing

Independent of every other open PR and touches one test file, so it can go in whenever. Worth taking early: it fails a required check at random on any open PR, and there are 22 of them right now. Not release material on its own, no shipped code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
