### PR TITLE
fix(web): offer the relink metadata action for every author

### DIFF
--- a/web/src/components/AddAuthorModal.test.tsx
+++ b/web/src/components/AddAuthorModal.test.tsx
@@ -294,6 +294,50 @@ describe('AddAuthorModal — search error handling', () => {
     alertSpy.mockRestore()
   })
 
+  it('offers find metadata when the conflicting canonical author is already linked with a full record', async () => {
+    vi.mocked(api.searchAuthors).mockResolvedValue([
+      author({
+        id: 0,
+        foreignAuthorId: 'OL13200512A',
+        authorName: 'Emilia Jae',
+      }),
+    ])
+    const err = Object.assign(new Error('author already exists'), {
+      status: 409,
+      body: {
+        error: 'author already exists',
+        canonicalAuthorId: 60,
+        canonicalAuthor: author({
+          id: 60,
+          foreignAuthorId: 'OL13200512A',
+          authorName: 'Emilia Jae',
+          metadataProvider: 'openlibrary',
+          description: 'A bio',
+          imageUrl: 'https://example.com/emilia.jpg',
+          ratingsCount: 12,
+          averageRating: 4.1,
+        }),
+      },
+    })
+    vi.mocked(api.addAuthor).mockRejectedValue(err)
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'emilia jae' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+    await waitFor(() => expect(screen.getByText('Emilia Jae')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add author' }))
+
+    await waitFor(() => expect(screen.getByText('author already exists')).toBeInTheDocument())
+    expect(screen.getByRole('link', { name: 'Find metadata' })).toHaveAttribute('href', '/author/60?linkMetadata=1')
+    alertSpy.mockRestore()
+  })
+
   it('loads global monitor defaults and lets the backend apply them when unchanged', async () => {
     vi.mocked(api.getSetting).mockImplementation(async (key: string) => {
       if (key === 'default.media_type') return { key, value: 'ebook' }

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { api, AddAuthorRequest, Author, AuthorConflictBody, AuthorMonitorMode, MediaType, MetadataProfile, RootFolder } from '../api/client'
 import { splitAuthorSearchResults } from './addAuthorTitleGuard'
 import { useNeedsSetup } from './useNeedsSetup'
-import { authorProviderKey, canLinkAuthorMetadata, hasSparseMetadata } from '../util/authorMetadata'
+import { authorProviderKey } from '../util/authorMetadata'
 import { providerDisplayName } from '../util/metadataSource'
 
 interface Props {
@@ -200,7 +200,9 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
     }
   }
 
-  const showConflictFindMetadata = addConflict?.canonicalAuthorId && (canLinkAuthorMetadata(addConflict.canonicalAuthor) || hasSparseMetadata(addConflict.canonicalAuthor))
+  // A conflict always involves an existing author the user may want to point at
+  // a richer provider, regardless of how complete that record is.
+  const showConflictFindMetadata = !!addConflict?.canonicalAuthorId
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -334,6 +334,23 @@ describe('AuthorDetailPage', () => {
     }))
   })
 
+  it('shows find-better metadata for linked authors with a full record, not just sparse ones', async () => {
+    renderAuthorDetailPage([], 'grid', {
+      foreignAuthorId: 'OL13200512A',
+      authorName: 'Emilia Jae',
+      sortName: 'Jae, Emilia',
+      metadataProvider: 'openlibrary',
+      description: 'Fantasy author of the Shades of Magic series.',
+      imageUrl: 'https://example.com/emilia.jpg',
+      disambiguation: 'Fantasy author, not the botanist',
+      ratingsCount: 128,
+      averageRating: 4.4,
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: /More/ }))
+    expect(await screen.findByRole('menuitem', { name: 'Find better metadata' })).toBeInTheDocument()
+  })
+
   it('opens link metadata from the query string once and removes the trigger param', async () => {
     const locations: string[] = []
     renderAuthorDetailPage([], 'grid', {

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -11,7 +11,7 @@ import RenameFilesModal from '../components/RenameFilesModal'
 import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
 import MarkdownDescription from '../components/MarkdownDescription'
-import { canLinkAuthorMetadata, hasSparseMetadata } from '../util/authorMetadata'
+import { canLinkAuthorMetadata } from '../util/authorMetadata'
 import { metadataSourceLink } from '../util/metadataSource'
 import { btn, btnSize } from '../components/buttons'
 import Switch from '../components/Switch'
@@ -464,7 +464,10 @@ export default function AuthorDetailPage() {
   if (!author) return <div className="text-slate-600 dark:text-zinc-500">Author not found</div>
 
   const searchableWantedCount = books.filter(b => b.status === 'wanted' && b.monitored && !b.excluded).length
-  const showMetadataLinkAction = canLinkAuthorMetadata(author) || hasSparseMetadata(author)
+  // Relinking is valid for every author — the backend accepts any record and the
+  // candidate search deliberately does not merge same-person records — so the
+  // action is always offered. The record's fullness only picks the wording below.
+  const showMetadataLinkAction = true
   const metadataLinkLabel = canLinkAuthorMetadata(author)
     ? t('authorMetadataLink.actionLink', 'Link metadata')
     : t('authorMetadataLink.actionFindBetter', 'Find better metadata')

--- a/web/src/util/authorMetadata.test.ts
+++ b/web/src/util/authorMetadata.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { Author } from '../api/client'
-import { canLinkAuthorMetadata, hasSparseMetadata } from './authorMetadata'
+import { canLinkAuthorMetadata } from './authorMetadata'
 
 const author = (over: Partial<Author>): Author => ({ id: 1, name: 'X', ...over }) as Author
 
@@ -17,19 +17,5 @@ describe('canLinkAuthorMetadata', () => {
   })
   it('defaults to true for a nil author', () => {
     expect(canLinkAuthorMetadata(undefined)).toBe(true)
-  })
-})
-
-describe('hasSparseMetadata', () => {
-  it('is true only when description, image, disambiguation, and ratings are all empty', () => {
-    expect(hasSparseMetadata(author({}))).toBe(true)
-    expect(hasSparseMetadata(author({ description: 'A bio' }))).toBe(false)
-    expect(hasSparseMetadata(author({ imageUrl: 'http://x/y.jpg' }))).toBe(false)
-    expect(hasSparseMetadata(author({ disambiguation: 'the elder' }))).toBe(false)
-    expect(hasSparseMetadata(author({ ratingsCount: 5 }))).toBe(false)
-    expect(hasSparseMetadata(author({ averageRating: 4.2 }))).toBe(false)
-  })
-  it('defaults to true for a nil author', () => {
-    expect(hasSparseMetadata(undefined)).toBe(true)
   })
 })

--- a/web/src/util/authorMetadata.ts
+++ b/web/src/util/authorMetadata.ts
@@ -12,15 +12,6 @@ export function canLinkAuthorMetadata(author?: Author): boolean {
   return foreignId === '' || foreignId.startsWith('abs:') || foreignId.startsWith('calibre:') || provider === 'audiobookshelf' || provider === 'calibre'
 }
 
-// hasSparseMetadata reports whether a linked author's record is thin enough to be
-// worth relinking to a richer source: no description, image, disambiguation, or
-// ratings. Drives the "Find better metadata" action. A nil author defaults to
-// true for the same reason as canLinkAuthorMetadata.
-export function hasSparseMetadata(author?: Author): boolean {
-  if (!author) return true
-  return !author.description && !author.imageUrl && !author.disambiguation && (author.ratingsCount ?? 0) === 0 && (author.averageRating ?? 0) === 0
-}
-
 // authorProviderKey names the catalogue provider an author record routes to,
 // mirroring models.AuthorProviderFromForeignID on the backend: the foreign-ID
 // prefix decides where every later catalogue fetch goes. Falls back to the


### PR DESCRIPTION
## What

The author page's actions menu only offered "Link metadata" / "Find better
metadata" when `canLinkAuthorMetadata(author) || hasSparseMetadata(author)`.
`hasSparseMetadata` returns false as soon as the author has any one of a
description, image, disambiguation or ratings, so a provider-linked author
with a bio or cover photo got no menu item at all. The relink flow
(`POST /api/v1/author/{id}/relink-upstream`) stayed reachable only via the
API for exactly the records users most want to move to a better provider.

## Why

The backend has no such restriction: `AuthorHandler.RelinkUpstream` accepts
any author, and the candidate search queries every configured provider
without merging same-person records, so a specific provider record can always
be chosen. An author record with a bio and photo but a wrong or thin
catalogue is precisely the case the action exists to serve; the old condition
offered it only for records with nothing at all.

## Change

- `web/src/pages/AuthorDetailPage.tsx`: always include the metadata action in
  the actions menu. The wording is still picked by `canLinkAuthorMetadata`
  ("Link metadata" for `abs:`/`calibre:` authors, "Find better metadata"
  otherwise), and `hasSparseMetadata` is no longer imported by the page.
- `web/src/pages/AuthorDetailPage.test.tsx`: new case asserting that a
  provider-linked author with a full record (description, image,
  disambiguation, ratings) sees the "Find better metadata" menu item.

## Verification

- `npx vitest run src/pages/AuthorDetailPage.test.tsx` — 36 passed
  (35 prior + 1 new). The new test fails on the old body:
  `TestingLibraryElementError: Unable to find role="menuitem" and name "Find better metadata"`.
- `npx tsc --noEmit` — clean.
- `npx eslint src/pages/AuthorDetailPage.tsx src/pages/AuthorDetailPage.test.tsx` — no issues.
- Full frontend suite: `make test-web` — 659 passed (67 files); `make lint-web` — 0 errors (9 pre-existing warnings).

Closes #2329
