### PR TITLE
perf(indexer): stop compiling regexes on every cache hit

### DIFF
--- a/internal/indexer/inorder.go
+++ b/internal/indexer/inorder.go
@@ -32,6 +32,10 @@ func inOrderRegex(seq []string) *regexp.Regexp {
 	// separator for the next word to assert on, which a bare `.*` would break.
 	gap := wordSep + `(?:.*` + wordSep + `)?`
 	pattern := `(?i)(?:^|` + wordSep + `)` + strings.Join(parts, gap) + `(?:` + wordSep + `|$)`
-	re, _ := regexCache.LoadOrStore(pattern, regexp.MustCompile(pattern))
-	return re.(*regexp.Regexp)
+	if v, ok := regexCache.Load(pattern); ok {
+		return v.(*regexp.Regexp)
+	}
+	re := regexp.MustCompile(pattern)
+	regexCache.Store(pattern, re)
+	return re
 }

--- a/internal/indexer/release.go
+++ b/internal/indexer/release.go
@@ -130,8 +130,12 @@ func phraseRegex(phrase []string) *regexp.Regexp {
 	// wordSep rather than \b/\W so non-ASCII words match (#1642). The inner
 	// separator stays a + run, matching the previous \W+ behaviour.
 	pattern := `(?i)(?:^|` + wordSep + `)` + strings.Join(parts, wordSep+`+`) + `(?:` + wordSep + `|$)`
-	re, _ := regexCache.LoadOrStore(pattern, regexp.MustCompile(pattern))
-	return re.(*regexp.Regexp)
+	if v, ok := regexCache.Load(pattern); ok {
+		return v.(*regexp.Regexp)
+	}
+	re := regexp.MustCompile(pattern)
+	regexCache.Store(pattern, re)
+	return re
 }
 
 // ContainsPhrase returns true if all words in phrase appear in haystack in the


### PR DESCRIPTION
## Summary

`phraseRegex` and `containsInOrder` both cached with:

```go
re, _ := regexCache.LoadOrStore(pattern, regexp.MustCompile(pattern))
```

Go evaluates arguments before the call, so `MustCompile` ran on **every** invocation and the freshly compiled regex was discarded on a cache hit — the cache saved a map entry and nothing else (#2341).

## Fix

Switch both call sites to the Load-then-Store pattern `WordBoundaryRegex` already uses (`internal/indexer/release.go:111`):

- check the cache first, return on hit
- compile only on a miss, then `Store`

`ContainsPhrase` runs once per release inside the search filter loop, so a 500-result search previously compiled the same regex 500 times and threw away 499; fan-out sweeps filtering thousands of releases across indexers felt this the most.

`go build ./internal/indexer/` and `go test ./internal/indexer/` pass.

Fixes #2341
