### PR TITLE
feat(web): UX phase 1, presentation declutter

### DIFF
--- a/changelog.d/ux-phase-1-presentation.md
+++ b/changelog.d/ux-phase-1-presentation.md
@@ -1,0 +1,9 @@
+### Fixed
+- **The app no longer flashes light before turning dark** — the theme class was applied from a React effect, which runs after the browser has already painted, so every route showed its light background for a frame. It is now set before the first paint.
+- **A mistyped or shared URL says so instead of showing an empty page** — any path the app did not recognise rendered the header and nav around nothing at all. `/settings/indexers` also works now; it redirects to the tab it names.
+
+### Changed
+- **The Authors and Books filter rows are two menus instead of two rows of pills** — every option is still there, and an applied filter shows both as a count on the Filters button and as a chip beside it that clears it. In table view the sort menu is gone, because the column headers already sort.
+- **Refresh and Delete on an author moved into the row's ⋯ menu**, leaving the monitored toggle where it was. The Discover card's own menu now uses the same component, so it gets the keyboard handling it never had.
+- **The setup checklist is a single strip** naming the next step rather than a box listing all five, and it stops showing once only one step is left.
+- **The Authors rating column is hidden when nothing on the page has a rating** — only OpenLibrary supplies author ratings, so for other libraries it was a column of dashes. It still appears, and still sorts, where there is data.

--- a/web/index.html
+++ b/web/index.html
@@ -13,13 +13,16 @@
       // for a frame before flipping (index.css sets html.dark's background).
       // Kept as a plain inline script on purpose: a module script is deferred
       // and would run too late to help. web/src/theme.bootstrap.test.ts asserts
-      // this stays in agreement with readInitial().
+      // this stays in agreement with readInitial(), and slices the source out
+      // of this file between the two markers below, so keep them.
+      /* theme-bootstrap:start */
       try {
         var saved = null
         try { saved = localStorage.getItem('bindery.theme') } catch (e) { /* storage blocked */ }
         var dark = saved === 'dark' || (saved !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches)
         document.documentElement.classList.toggle('dark', dark)
       } catch (e) { /* leave the light default in place */ }
+      /* theme-bootstrap:end */
     </script>
   </head>
   <body>

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,22 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bindery</title>
+    <script>
+      // Set the theme class before the first paint. This mirrors readInitial()
+      // in src/theme.ts: a stored choice wins, otherwise the OS preference.
+      // useTheme applies the same class from an effect, which runs after the
+      // first paint, so without this the document shows its light background
+      // for a frame before flipping (index.css sets html.dark's background).
+      // Kept as a plain inline script on purpose: a module script is deferred
+      // and would run too late to help. web/src/theme.bootstrap.test.ts asserts
+      // this stays in agreement with readInitial().
+      try {
+        var saved = null
+        try { saved = localStorage.getItem('bindery.theme') } catch (e) { /* storage blocked */ }
+        var dark = saved === 'dark' || (saved !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        document.documentElement.classList.toggle('dark', dark)
+      } catch (e) { /* leave the light default in place */ }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -57,7 +57,11 @@ vi.mock('./theme', () => ({ useTheme: () => {} }))
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    // Resolves like real i18next does: the label table wins, then the inline
+    // default the caller passed, then the bare key. Honouring the default
+    // matters because components written with t(key, 'Fallback') would
+    // otherwise render their key here and read as missing.
+    t: (key: string, fallback?: unknown, vars?: Record<string, unknown>) => {
       const m: Record<string, string> = {
         'nav.authors': 'Authors', 'nav.books': 'Books', 'nav.wanted': 'Wanted',
         'nav.import': 'Import',
@@ -66,7 +70,12 @@ vi.mock('react-i18next', () => ({
         'nav.search': 'Search',
         'login.signOut': 'Sign out', 'login.signedInAs': 'Signed in as',
       }
-      return m[key] ?? key
+      if (m[key]) return m[key]
+      if (typeof fallback !== 'string') return key
+      const interpolations = (vars ?? (typeof fallback === 'string' ? undefined : fallback)) as Record<string, unknown> | undefined
+      return interpolations
+        ? fallback.replace(/\{\{(\w+)\}\}/g, (_m, name: string) => String(interpolations[name] ?? ''))
+        : fallback
     },
   }),
 }))
@@ -118,16 +127,64 @@ describe('App — /authors alias', () => {
     expect(window.location.pathname).toBe('/')
   })
 
-  // Guards the failure the alias fixes: a path with no route and no catch-all
-  // renders the shell with nothing inside it. If someone later removes the
-  // alias, this is the shape the regression takes.
-  it('still renders the shell chrome around an unrouted path', () => {
+  // The alias is still the right answer for /authors specifically, because it
+  // means something. Everything else now lands on the catch-all below.
+  it('does not send an unrouted path to the authors page', () => {
     window.history.pushState(null, '', '/definitely-not-a-route')
 
     renderShell()
 
     expect(screen.queryByTestId('page-authors')).not.toBeInTheDocument()
     expect(screen.queryByTestId('page-books')).not.toBeInTheDocument()
+  })
+})
+
+describe('App — catch-all route', () => {
+  // Before the catch-all, an unrouted path rendered the header and nav around
+  // an empty <main>. That reads as a broken app rather than a wrong address,
+  // which is exactly how the /authors report arrived.
+  it('says the page was not found instead of rendering an empty main', () => {
+    window.history.pushState(null, '', '/definitely-not-a-route')
+
+    renderShell()
+
+    expect(screen.getByText('Page not found')).toBeInTheDocument()
+    expect(screen.getByText(/definitely-not-a-route/)).toBeInTheDocument()
+  })
+
+  it('offers a way back rather than stranding the user', () => {
+    window.history.pushState(null, '', '/nope')
+
+    renderShell()
+
+    expect(screen.getByRole('link', { name: 'Go to Authors' })).toHaveAttribute('href', '/')
+  })
+})
+
+describe('App — /settings/:tab deep links', () => {
+  // Settings addresses tabs with ?tab=, but /settings/indexers is the shape
+  // people type and share. It matched no route, so before the catch-all it was
+  // a blank page and after it would have been a 404 for a URL that plainly
+  // means something.
+  it('redirects the path form to the canonical query form', async () => {
+    window.history.pushState(null, '', '/settings/indexers')
+
+    renderShell()
+
+    expect(await screen.findByTestId('page-settings')).toBeInTheDocument()
+    expect(window.location.pathname).toBe('/settings')
+    expect(window.location.search).toBe('?tab=indexers')
+  })
+
+  // SettingsPage validates the value against ALL_TABS and falls back to
+  // General, so an unknown tab must still reach Settings rather than the 404.
+  it('still reaches settings for an unrecognised tab', async () => {
+    window.history.pushState(null, '', '/settings/not-a-tab')
+
+    renderShell()
+
+    expect(await screen.findByTestId('page-settings')).toBeInTheDocument()
+    expect(screen.queryByText('Page not found')).not.toBeInTheDocument()
   })
 })
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, NavLink, Link, Navigate, useLocation } from 'react-router'
+import { BrowserRouter, Routes, Route, NavLink, Link, Navigate, useLocation, useParams } from 'react-router'
 import { lazy, Suspense, useEffect, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from './api/client'
@@ -60,6 +60,41 @@ function PageLoadingFallback() {
   return (
     <div className="py-10 text-center text-sm text-slate-600 dark:text-zinc-500">
       {t('common.loading')}
+    </div>
+  )
+}
+
+// Settings addresses its tabs with ?tab=, but /settings/indexers is the shape
+// people type and paste. It matched no route, and with the catch-all below it
+// would now render "not found" for a URL that plainly means something. Redirect
+// it to the canonical query form instead. SettingsPage validates the value
+// against ALL_TABS, so an unknown tab lands on General rather than breaking.
+function SettingsTabRedirect() {
+  const { tab } = useParams<{ tab: string }>()
+  return <Navigate to={`/settings?tab=${encodeURIComponent(tab ?? '')}`} replace />
+}
+
+// Catch-all. Without it an unrouted path rendered the header and nav around an
+// empty <main>, which reads as a broken app rather than a wrong address. That is
+// the failure /authors used to have (see the comment on its alias below).
+function NotFoundPage() {
+  const { t } = useTranslation()
+  const location = useLocation()
+
+  return (
+    <div className="py-16 text-center">
+      <p className="text-lg font-semibold text-slate-800 dark:text-zinc-200">
+        {t('notFound.title', 'Page not found')}
+      </p>
+      <p className="mt-2 text-sm text-fg-muted">
+        {t('notFound.body', 'There is nothing at {{path}}.', { path: location.pathname })}
+      </p>
+      <Link
+        to="/"
+        className="inline-block mt-6 px-4 py-2 rounded bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium"
+      >
+        {t('notFound.home', 'Go to Authors')}
+      </Link>
     </div>
   )
 }
@@ -272,7 +307,9 @@ function Shell() {
             <Route path="/search" element={<SearchPage />} />
             <Route path="/blocklist" element={<Navigate to="/settings?tab=blocklist" replace />} />
             <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/settings/:tab" element={<SettingsTabRedirect />} />
             {isAdmin && <Route path="/users" element={<UsersPage />} />}
+            <Route path="*" element={<NotFoundPage />} />
           </Routes>
           </RoutedErrorBoundary>
         </Suspense>

--- a/web/src/components/FilterPopover.tsx
+++ b/web/src/components/FilterPopover.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
+import { btn, btnSize } from './buttons'
+
+// Filter and sort controls behind one disclosure.
+//
+// Both list pages had grown two rows of pills: Books packed sort, media type
+// and monitored into a single wrapping row, Authors carried five sort pills
+// plus a monitored row. That is a lot of permanent furniture above a list, and
+// it wraps badly at narrow widths.
+//
+// The constraint this is built under: decluttering must not cost the
+// discoverability of a control people actually reach for. So the trigger
+// carries a count when filters are set, and the caller renders the active ones
+// as removable chips beside it. A filter you have applied is never invisible.
+//
+// Dismissal mirrors MoreMenu: Escape and outside pointerdown both close and
+// return focus to the trigger.
+
+export interface FilterOption<T extends string> {
+  value: T
+  label: ReactNode
+  /** Distinct accessible name when `label` carries an emoji or other decoration. */
+  ariaLabel?: string
+}
+
+/**
+ * One single-select facet. A radio group rather than a menu: these set state
+ * that persists, they are not commands, and exactly one value is always active.
+ */
+export function FilterGroup<T extends string>({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string
+  value: T
+  onChange: (next: T) => void
+  options: FilterOption<T>[]
+}) {
+  return (
+    <div role="radiogroup" aria-label={label} className="px-1 py-1.5">
+      <p className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">{label}</p>
+      <div className="flex flex-col">
+        {options.map(opt => {
+          const active = opt.value === value
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              aria-label={opt.ariaLabel}
+              onClick={() => onChange(opt.value)}
+              className={`flex items-center gap-2 px-2 py-1.5 rounded text-left text-sm transition-colors ${
+                active
+                  ? 'text-slate-900 dark:text-white font-medium'
+                  : 'text-slate-700 dark:text-zinc-300 hover:bg-slate-200 dark:hover:bg-zinc-700'
+              }`}
+            >
+              <span aria-hidden="true" className={`w-3 text-emerald-600 dark:text-emerald-400 ${active ? '' : 'opacity-0'}`}>
+                ✓
+              </span>
+              <span className="truncate">{opt.label}</span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default function FilterPopover({
+  label,
+  ariaLabel,
+  activeCount = 0,
+  children,
+}: {
+  label: string
+  ariaLabel?: string
+  /** Shown on the trigger so an applied filter is visible without opening it. */
+  activeCount?: number
+  children: ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelId = useId()
+
+  const close = (returnFocus = true) => {
+    setOpen(false)
+    if (returnFocus) triggerRef.current?.focus()
+  }
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) close(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        close()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        aria-label={ariaLabel}
+        onClick={() => setOpen(o => !o)}
+        className={`${btn.secondary} ${btnSize.sm}`}
+      >
+        {label}
+        {activeCount > 0 && (
+          <span className="ml-1 inline-flex items-center justify-center min-w-[1.25rem] px-1 rounded-full bg-emerald-600 text-white text-[11px] font-semibold">
+            {activeCount}
+          </span>
+        )}
+        <span aria-hidden="true" className="text-[10px] opacity-70">▾</span>
+      </button>
+
+      {open && (
+        <div
+          id={panelId}
+          className="absolute left-0 top-full mt-1 z-20 min-w-[13rem] max-h-[70vh] overflow-y-auto rounded-lg border border-slate-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg divide-y divide-slate-200 dark:divide-zinc-700"
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/RecommendationCard.test.tsx
+++ b/web/src/components/RecommendationCard.test.tsx
@@ -5,12 +5,22 @@ import { Recommendation } from '../api/client'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, opts?: Record<string, unknown>) => {
-      if (key === 'discover.dontSuggestAuthor') return `Don't suggest ${String(opts?.author ?? '')}`
-      return {
+    // Handles both i18next call shapes the components use: t(key, vars) and
+    // t(key, 'Inline default', vars). Returning the bare key for the second
+    // shape would make any component written that way look like it had a
+    // missing string.
+    t: (key: string, second?: unknown, third?: Record<string, unknown>) => {
+      const vars = (typeof second === 'string' ? third : second) as Record<string, unknown> | undefined
+      if (key === 'discover.dontSuggestAuthor') return `Don't suggest ${String(vars?.author ?? '')}`
+      const table: Record<string, string> = {
         'discover.addToWanted': 'Add to Wanted',
         'discover.dismiss': 'Dismiss',
-      }[key] ?? key
+      }
+      if (table[key]) return table[key]
+      if (typeof second !== 'string') return key
+      return vars
+        ? second.replace(/\{\{(\w+)\}\}/g, (_m, name: string) => String(vars[name] ?? ''))
+        : second
     },
   }),
 }))
@@ -110,41 +120,52 @@ describe('RecommendationCard — actions', () => {
     expect(onAdd).not.toHaveBeenCalled()
   })
 
-  it('"···" button opens the author exclusion dropdown', () => {
+  // The overflow menu is the shared MoreMenu now, not a hand-rolled dropdown,
+  // so these address it by its accessible name rather than by the "···" glyph.
+  // MoreMenu gives it the keyboard handling and focus return the local copy
+  // never had; what is asserted here is the behaviour the card still owns.
+  const openMenu = () => fireEvent.click(screen.getByRole('button', { name: /More actions for/ }))
+
+  it('the overflow menu opens the author exclusion item', () => {
     render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
     expect(screen.queryByText(/Don't suggest Jane Author/)).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: '···' }))
-    expect(screen.getByText("Don't suggest Jane Author")).toBeInTheDocument()
+    openMenu()
+    expect(screen.getByRole('menuitem', { name: "Don't suggest Jane Author" })).toBeInTheDocument()
   })
 
-  it('"···" button toggles dropdown closed on second click', () => {
+  it('the overflow menu closes on a second click of its trigger', () => {
     render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
-    const menuBtn = screen.getByRole('button', { name: '···' })
-    fireEvent.click(menuBtn)
-    fireEvent.click(menuBtn)
+    openMenu()
+    openMenu()
     expect(screen.queryByText(/Don't suggest/)).toBeNull()
   })
 
-  it('calls onExcludeAuthor and closes dropdown when "Don\'t suggest author" is clicked', () => {
+  it("calls onExcludeAuthor and closes when the exclusion item is chosen", () => {
     render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
-    fireEvent.click(screen.getByRole('button', { name: '···' }))
-    fireEvent.click(screen.getByText("Don't suggest Jane Author"))
+    openMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: "Don't suggest Jane Author" }))
     expect(onExcludeAuthor).toHaveBeenCalledWith('Jane Author')
     expect(screen.queryByText(/Don't suggest/)).toBeNull()
   })
 
-  it('closes the dropdown when clicking outside', () => {
+  it('closes when the pointer goes down outside it', () => {
     render(
       <div>
         <RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />
         <div data-testid="outside">outside</div>
       </div>
     )
-    fireEvent.click(screen.getByRole('button', { name: '···' }))
-    expect(screen.getByText("Don't suggest Jane Author")).toBeInTheDocument()
+    openMenu()
+    expect(screen.getByRole('menuitem', { name: "Don't suggest Jane Author" })).toBeInTheDocument()
 
-    fireEvent.mouseDown(screen.getByTestId('outside'))
+    // MoreMenu listens on pointerdown rather than mousedown, matching native menus.
+    fireEvent.pointerDown(screen.getByTestId('outside'))
     expect(screen.queryByText(/Don't suggest/)).toBeNull()
+  })
+
+  it('gives each card a distinct accessible name for its menu', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
+    expect(screen.getByRole('button', { name: 'More actions for Test Book' })).toBeInTheDocument()
   })
 })
 

--- a/web/src/components/RecommendationCard.tsx
+++ b/web/src/components/RecommendationCard.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BINDERY_BASE, Recommendation } from '../api/client'
+import MoreMenu from './MoreMenu'
 
 interface RecommendationCardProps {
   rec: Recommendation
@@ -11,19 +11,6 @@ interface RecommendationCardProps {
 
 export default function RecommendationCard({ rec, onDismiss, onAdd, onExcludeAuthor }: RecommendationCardProps) {
   const { t } = useTranslation()
-  const [menuOpen, setMenuOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!menuOpen) return
-    const handleClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [menuOpen])
 
   const imageUrl = rec.imageUrl
     ? `${BINDERY_BASE}/api/v1/images?url=${encodeURIComponent(rec.imageUrl)}`
@@ -104,24 +91,17 @@ export default function RecommendationCard({ rec, onDismiss, onAdd, onExcludeAut
           >
             ✕
           </button>
-          <div className="relative" ref={menuRef}>
-            <button
-              onClick={() => setMenuOpen(o => !o)}
-              className="px-1.5 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs text-slate-600 dark:text-zinc-400 transition-colors"
-            >
-              &middot;&middot;&middot;
-            </button>
-            {menuOpen && (
-              <div className="absolute right-0 bottom-full mb-1 w-48 bg-white dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-lg shadow-lg z-10">
-                <button
-                  onClick={() => { onExcludeAuthor(rec.authorName); setMenuOpen(false) }}
-                  className="w-full text-left px-3 py-2 text-xs text-slate-700 dark:text-zinc-300 hover:bg-slate-100 dark:hover:bg-zinc-700 rounded-lg transition-colors"
-                >
-                  {t('discover.dontSuggestAuthor', { author: rec.authorName })}
-                </button>
-              </div>
-            )}
-          </div>
+          <MoreMenu
+            label={t('common.moreActions', 'More')}
+            ariaLabel={t('discover.moreActionsFor', 'More actions for {{title}}', { title: rec.title })}
+            buttonClassName="px-1.5 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs text-slate-600 dark:text-zinc-400 transition-colors"
+            items={[
+              {
+                label: t('discover.dontSuggestAuthor', { author: rec.authorName }),
+                onSelect: () => onExcludeAuthor(rec.authorName),
+              },
+            ]}
+          />
         </div>
       </div>
     </div>

--- a/web/src/components/SetupChecklist.tsx
+++ b/web/src/components/SetupChecklist.tsx
@@ -71,55 +71,64 @@ export default function SetupChecklist() {
   if (!state || state.complete || dismissed) return null
 
   const done = STEPS.filter(s => state[s.key]).length
+  const next = STEPS.find(s => !state[s.key])
+
+  // Stop nagging once all but one step is done. The server's `complete` is the
+  // real definition of "set up" and already hides this; it counts indexer,
+  // client, author and import, deliberately not the first grab. This second
+  // threshold covers the remaining near-done shapes, where a checklist is more
+  // clutter than help and the last step tends to happen on its own.
+  if (done >= STEPS.length - 1) return null
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, '1')
+    } catch {
+      // localStorage unavailable — dismiss for this render only.
+    }
+    setDismissed(true)
+  }
 
   return (
-    <div className="max-w-xl mx-auto mb-8 px-5 py-4 bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg text-left">
-      <div className="flex items-center justify-between gap-3 mb-3">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
-          {t('setupChecklist.title', 'Setup progress')}{' '}
-          <span className="font-normal text-fg-muted">{done}/{STEPS.length}</span>
-        </h3>
-        <button
-          onClick={() => {
-            try {
-              localStorage.setItem(STORAGE_KEY, '1')
-            } catch {
-              // localStorage unavailable — dismiss for this render only.
-            }
-            setDismissed(true)
-          }}
-          className="text-xs text-fg-muted hover:text-slate-900 dark:hover:text-white transition-colors"
-        >
-          {t('common.dismiss', 'Dismiss')}
-        </button>
-      </div>
-      <ul className="space-y-1.5">
-        {STEPS.map(step => {
-          const complete = state[step.key]
-          return (
-            <li key={step.key} className="flex items-center gap-2 text-sm">
-              <span
-                aria-hidden="true"
-                className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] flex-shrink-0 ${
-                  complete
-                    ? 'bg-emerald-600 text-white'
-                    : 'border border-slate-300 dark:border-zinc-700 text-transparent'
-                }`}
-              >
-                ✓
-              </span>
-              <span className={complete ? 'text-fg-muted line-through' : 'text-slate-800 dark:text-zinc-200'}>
-                {t(step.labelKey, step.fallback)}
-              </span>
-              {!complete && step.to && (
-                <Link to={step.to} className="text-xs text-emerald-700 dark:text-emerald-400 hover:underline">
-                  {t(step.actionKey!, step.actionFallback!)}
-                </Link>
-              )}
-            </li>
-          )
-        })}
-      </ul>
+    <div className="mb-6 flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 text-sm">
+      <span className="font-medium text-slate-900 dark:text-white whitespace-nowrap">
+        {t('setupChecklist.title', 'Setup progress')}
+      </span>
+
+      {/* Segmented progress, one segment per step. Carries the count for
+          assistive tech so the bar is not the only way to read it. */}
+      <span
+        className="hidden sm:flex items-center gap-1"
+        role="img"
+        aria-label={t('setupChecklist.progress', '{{done}} of {{total}} steps done', { done, total: STEPS.length })}
+      >
+        {STEPS.map(step => (
+          <span
+            key={step.key}
+            className={`h-1.5 w-6 rounded-full ${state[step.key] ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
+          />
+        ))}
+      </span>
+      <span className="text-fg-muted whitespace-nowrap sm:hidden">{done}/{STEPS.length}</span>
+
+      {next && (
+        <span className="min-w-0 flex items-center gap-2 truncate">
+          <span className="text-fg-muted whitespace-nowrap">{t('setupChecklist.next', 'Next:')}</span>
+          <span className="text-slate-800 dark:text-zinc-200 truncate">{t(next.labelKey, next.fallback)}</span>
+          {next.to && (
+            <Link to={next.to} className="text-emerald-700 dark:text-emerald-400 hover:underline whitespace-nowrap">
+              {t(next.actionKey!, next.actionFallback!)}
+            </Link>
+          )}
+        </span>
+      )}
+
+      <button
+        onClick={dismiss}
+        className="ml-auto text-xs text-fg-muted hover:text-slate-900 dark:hover:text-white transition-colors whitespace-nowrap"
+      >
+        {t('common.dismiss', 'Dismiss')}
+      </button>
     </div>
   )
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -74,6 +74,11 @@
     "users": "Users",
     "updateAvailable": "Update available"
   },
+  "notFound": {
+    "title": "Page not found",
+    "body": "There is nothing at {{path}}.",
+    "home": "Go to Authors"
+  },
   "manualImport": {
     "title": "Manual Import",
     "description": "Scan a folder of files already on disk, match each book to your library, and import them. A file with no match can be added from a metadata search.",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1168,7 +1168,9 @@
     "client": "Add a download client",
     "author": "Add an author",
     "grab": "Grab a book",
-    "import": "First book imported"
+    "import": "First book imported",
+    "progress": "{{done}} of {{total}} steps done",
+    "next": "Next:"
   },
   "protocolMismatch": {
     "torrent": "A Torznab indexer is enabled but no torrent download client (qBittorrent, Transmission, Deluge, rTorrent) is — its releases can be found but never downloaded.",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -45,7 +45,8 @@
     "saveError": "Error",
     "more": "More",
     "confirm": "Confirm",
-    "confirmTitle": "Are you sure?"
+    "confirmTitle": "Are you sure?",
+    "moreActions": "More"
   },
   "monitorMode": {
     "all": "All books",
@@ -216,7 +217,9 @@
     "bulkSetMonitorModeApply": "Apply monitor mode",
     "bulkSetMonitorModeFailed": "Bulk monitor mode update failed",
     "bulkSetMonitorModePartial": "Monitor mode was not updated for author {{id}}: {{error}}",
-    "sortByColumn": "Sort by {{column}}"
+    "sortByColumn": "Sort by {{column}}",
+    "moreActionsFor": "More actions for {{name}}",
+    "refreshMetadata": "Refresh metadata"
   },
   "authorDetail": {
     "description": {
@@ -1140,7 +1143,8 @@
       "disabled": "Recommendations are disabled. Enable them in Settings to start discovering new books.",
       "coldStart": "Add more books to unlock personalized genre recommendations.",
       "goToSettings": "Go to Settings"
-    }
+    },
+    "moreActionsFor": "More actions for {{title}}"
   },
   "gettingStarted": {
     "title": "Getting started",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -46,7 +46,10 @@
     "more": "More",
     "confirm": "Confirm",
     "confirmTitle": "Are you sure?",
-    "moreActions": "More"
+    "moreActions": "More",
+    "filters": "Filters",
+    "sort": "Sort",
+    "clearFilter": "Clear filter"
   },
   "monitorMode": {
     "all": "All books",

--- a/web/src/pages/AuthorsPage.onboarding.test.tsx
+++ b/web/src/pages/AuthorsPage.onboarding.test.tsx
@@ -82,15 +82,29 @@ describe('AuthorsPage setup checklist', () => {
     vi.mocked(api.listAuthors).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
   })
 
-  it('lists every outstanding step with links to the settings tabs', async () => {
+  // The checklist is a strip now rather than a boxed list, so it names one
+  // step at a time: the next outstanding one, with its link. Showing all five
+  // at once was the bulk that made it worth slimming.
+  it('names the next outstanding step and links to it', async () => {
     vi.mocked(api.setupState).mockResolvedValue(state())
 
     renderPage()
 
     expect(await screen.findByText('Setup progress')).toBeInTheDocument()
     expect(screen.getByText('0/5')).toBeInTheDocument()
+    expect(screen.getByText('Add an indexer')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Set up Indexers' })).toHaveAttribute('href', '/settings?tab=indexers')
+  })
+
+  it('advances to the next step as earlier ones complete', async () => {
+    vi.mocked(api.setupState).mockResolvedValue(state({ hasIndexer: true }))
+
+    renderPage()
+
+    expect(await screen.findByText('Add a download client')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Set up Download Clients' })).toHaveAttribute('href', '/settings?tab=clients')
+    // The finished step is no longer the one being asked for.
+    expect(screen.queryByRole('link', { name: 'Set up Indexers' })).not.toBeInTheDocument()
   })
 
   it('counts completed steps and drops their action links', async () => {
@@ -101,8 +115,23 @@ describe('AuthorsPage setup checklist', () => {
     expect(await screen.findByText('3/5')).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Set up Indexers' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Set up Download Clients' })).not.toBeInTheDocument()
-    // Outstanding steps still listed.
+    // The next outstanding step is what the strip names.
     expect(screen.getByText('Grab a book')).toBeInTheDocument()
+  })
+
+  // Stops nagging once only one step is left. The server's `complete` counts
+  // indexer, client, author and import and not the first grab, so it does not
+  // cover every near-done shape on its own; this is the client-side half.
+  it('hides itself once only one step remains', async () => {
+    vi.mocked(api.setupState).mockResolvedValue(
+      state({ hasIndexer: true, hasClient: true, hasAuthor: true, hasGrab: true }),
+    )
+
+    renderPage()
+
+    expect(await screen.findByText('No authors yet')).toBeInTheDocument()
+    await waitFor(() => expect(api.setupState).toHaveBeenCalled())
+    expect(screen.queryByText('Setup progress')).not.toBeInTheDocument()
   })
 
   // The checklist is a first-run aid, not a permanent fixture: once the

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -396,6 +396,103 @@ describe('AuthorsPage', () => {
 // resolved by search. A Hardcover or DNB library saw a full column of em
 // dashes. Hiding it outright would have cost OpenLibrary users a real sort
 // key, so it is conditional on the page having anything to show.
+// The filter and sort pills moved behind two disclosures. The rule this is
+// built under is that decluttering must not cost discoverability, so these
+// pin the parts that keep an applied filter visible: a count on the trigger
+// and a removable chip beside it.
+describe('AuthorsPage — filter and sort popovers', () => {
+  const seed = () => {
+    vi.mocked(api.listAuthors).mockResolvedValue({
+      items: [
+        {
+          id: 7,
+          foreignAuthorId: 'OL7',
+          authorName: 'Andy Weir',
+          sortName: 'Weir, Andy',
+          description: '',
+          imageUrl: '',
+          disambiguation: '',
+          ratingsCount: 0,
+          averageRating: 0,
+          monitored: true,
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
+  }
+
+  const renderPage = async () => {
+    seed()
+    render(<MemoryRouter><AuthorsPage /></MemoryRouter>)
+    await screen.findByText('Andy Weir')
+  }
+
+  it('keeps every filter option reachable, just one click further in', async () => {
+    await renderPage()
+
+    expect(screen.queryByRole('radio', { name: 'Unmonitored' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /Filters/ }))
+
+    expect(screen.getByRole('radio', { name: 'All' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Monitored' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Unmonitored' })).toBeInTheDocument()
+  })
+
+  it('shows an applied filter on the trigger and as a chip, so it is never hidden', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: /Filters/ }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Unmonitored' }))
+
+    // The count rides on the trigger itself.
+    expect(screen.getByRole('button', { name: /Filters/ })).toHaveTextContent('1')
+    // And the value is spelled out beside it, without opening anything.
+    expect(screen.getByRole('button', { name: /Clear filter/ })).toHaveTextContent('Unmonitored')
+  })
+
+  it('clears the filter from its chip', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: /Filters/ }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Unmonitored' }))
+    fireEvent.click(screen.getByRole('button', { name: /Clear filter/ }))
+
+    expect(screen.queryByRole('button', { name: /Clear filter/ })).toBeNull()
+    expect(screen.getByRole('button', { name: /Filters/ })).not.toHaveTextContent('1')
+  })
+
+  it('closes on Escape', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: /Filters/ }))
+    expect(screen.getByRole('radio', { name: 'Unmonitored' })).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('radio', { name: 'Unmonitored' })).toBeNull()
+  })
+
+  // The column headers already sort in table view. Offering a sort control as
+  // well invites the two to disagree about what is active.
+  it('drops the sort control in table view, where the headers do the job', async () => {
+    localStorage.setItem('bindery.view.authors', 'table')
+    await renderPage()
+
+    expect(screen.queryByRole('button', { name: /Sort/ })).toBeNull()
+    expect(screen.getByRole('button', { name: /Filters/ })).toBeInTheDocument()
+  })
+
+  it('offers sort in grid view, where nothing else does', async () => {
+    localStorage.setItem('bindery.view.authors', 'grid')
+    await renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: /Sort/ }))
+    expect(screen.getByRole('radio', { name: 'Recent' })).toBeInTheDocument()
+  })
+})
+
 describe('AuthorsPage — rating column', () => {
   const authorWith = (averageRating: number) => ({
     id: 7,

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -392,6 +392,48 @@ describe('AuthorsPage', () => {
 // wall of buttons. The governing constraint is that decluttering must not cost
 // discoverability of a control people use: Refresh and Delete are rare and can
 // go behind a menu, the monitored toggle is not and must stay on the row.
+// Only OpenLibrary supplies author-level ratings, and only for authors it
+// resolved by search. A Hardcover or DNB library saw a full column of em
+// dashes. Hiding it outright would have cost OpenLibrary users a real sort
+// key, so it is conditional on the page having anything to show.
+describe('AuthorsPage — rating column', () => {
+  const authorWith = (averageRating: number) => ({
+    id: 7,
+    foreignAuthorId: 'OL7',
+    authorName: 'Andy Weir',
+    sortName: 'Weir, Andy',
+    description: '',
+    imageUrl: '',
+    disambiguation: '',
+    ratingsCount: averageRating > 0 ? 10 : 0,
+    averageRating,
+    monitored: true,
+  })
+
+  const renderTable = async (averageRating: number) => {
+    localStorage.setItem('bindery.view.authors', 'table')
+    vi.mocked(api.listAuthors).mockResolvedValue({
+      items: [authorWith(averageRating)],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
+    render(<MemoryRouter><AuthorsPage /></MemoryRouter>)
+    await screen.findByText('Andy Weir')
+  }
+
+  it('is hidden when no author on the page has a rating', async () => {
+    await renderTable(0)
+    expect(screen.queryByRole('columnheader', { name: /Rating/ })).toBeNull()
+  })
+
+  it('is shown when an author on the page has one', async () => {
+    await renderTable(4.25)
+    expect(screen.getByRole('columnheader', { name: /Rating/ })).toBeInTheDocument()
+    expect(screen.getByText('★ 4.25')).toBeInTheDocument()
+  })
+})
+
 describe('AuthorsPage — row actions behind an overflow menu', () => {
   beforeEach(() => {
     vi.mocked(api.listAuthors).mockResolvedValue({

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../api/client', async importOriginal => {
       createSeries: vi.fn(),
       bulkActionAuthors: vi.fn(),
       bulkSetAuthorMonitorMode: vi.fn(),
+      refreshAuthor: vi.fn(),
     },
   }
 })
@@ -70,6 +71,7 @@ vi.mock('react-i18next', () => ({
         'common.unmonitor': 'Unmonitor',
         'common.search': 'Search',
         'common.delete': 'Delete',
+        'common.refresh': 'Refresh',
         'common.cancel': 'Cancel',
         'bulkActionBar.clear': 'Clear',
         'bulkActionBar.selected': 'Selected',
@@ -383,6 +385,66 @@ describe('AuthorsPage', () => {
     // checkmark is visible instead of white-on-white.
     expect(checkbox).toBeChecked()
     expect(checkbox.className).not.toContain('bg-white/80')
+  })
+})
+
+// Secondary row actions moved behind the shared MoreMenu so the row is not a
+// wall of buttons. The governing constraint is that decluttering must not cost
+// discoverability of a control people use: Refresh and Delete are rare and can
+// go behind a menu, the monitored toggle is not and must stay on the row.
+describe('AuthorsPage — row actions behind an overflow menu', () => {
+  beforeEach(() => {
+    vi.mocked(api.listAuthors).mockResolvedValue({
+      items: [
+        {
+          id: 7,
+          foreignAuthorId: 'OL7',
+          authorName: 'Andy Weir',
+          sortName: 'Weir, Andy',
+          description: '',
+          imageUrl: '',
+          disambiguation: '',
+          ratingsCount: 0,
+          averageRating: 0,
+          monitored: true,
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
+    vi.mocked(api.refreshAuthor).mockResolvedValue(undefined as never)
+  })
+
+  const renderPage = async () => {
+    render(<MemoryRouter><AuthorsPage /></MemoryRouter>)
+    await screen.findByText('Andy Weir')
+  }
+
+  it('keeps the monitored toggle visible without opening anything', async () => {
+    await renderPage()
+    expect(screen.getByRole('switch')).toBeInTheDocument()
+  })
+
+  it('hides refresh and delete until the menu is opened', async () => {
+    await renderPage()
+
+    expect(screen.queryByRole('menuitem', { name: 'Refresh' })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Delete' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /More actions/ }))
+
+    expect(screen.getByRole('menuitem', { name: 'Refresh' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument()
+  })
+
+  it('still refreshes the author from the menu', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: /More actions/ }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Refresh' }))
+
+    await waitFor(() => expect(api.refreshAuthor).toHaveBeenCalledWith(7))
   })
 })
 

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -336,6 +336,13 @@ export default function AuthorsPage() {
     )
   }
 
+  // Only OpenLibrary supplies an author-level rating, and only for authors it
+  // resolved by search rather than by direct id. Hardcover and DNB supply none
+  // at all, so for those libraries the column was a full column of em dashes.
+  // Drop it when this page has nothing to put in it, rather than removing it
+  // outright and costing OpenLibrary users a real sort key.
+  const anyRating = authors.some(a => a.averageRating > 0)
+
   return (
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       {confirmDialog}
@@ -457,7 +464,7 @@ export default function AuthorsPage() {
                   </th>
                   <SortableHeader label={t('authors.colName')} asc="az" desc="za" />
                   <SortableHeader label={t('authors.colBooks')} asc="books-asc" desc="books-desc" />
-                  <SortableHeader label={t('authors.colRating')} asc="rating-asc" desc="rating-desc" />
+                  {anyRating && <SortableHeader label={t('authors.colRating')} asc="rating-asc" desc="rating-desc" />}
                   <SortableHeader label={t('authors.colMonitored')} asc="monitored-asc" desc="monitored-desc" />
                   <th className="px-3 py-2" />
                 </tr>
@@ -490,9 +497,11 @@ export default function AuthorsPage() {
                       </Link>
                     </td>
                     <td className="px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap">{author.statistics?.bookCount ?? '—'}</td>
-                    <td className="px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap">
-                      {author.averageRating > 0 ? `★ ${author.averageRating.toFixed(2)}` : '—'}
-                    </td>
+                    {anyRating && (
+                      <td className="px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap">
+                        {author.averageRating > 0 ? `★ ${author.averageRating.toFixed(2)}` : '—'}
+                      </td>
+                    )}
                     <td className="px-3 py-2 whitespace-nowrap">
                       <Switch
                         checked={author.monitored}

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -8,6 +8,7 @@ import AddBookModal from '../components/AddBookModal'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
 import SeriesNameModal from '../components/SeriesNameModal'
 import BulkActionBar from '../components/BulkActionBar'
+import FilterPopover, { FilterGroup } from '../components/FilterPopover'
 import MoreMenu from '../components/MoreMenu'
 import Pagination from '../components/Pagination'
 import { useServerPagination } from '../components/usePagination'
@@ -306,9 +307,6 @@ export default function AuthorsPage() {
     navigate('/series', { state: { seriesId: series.id } })
   }
 
-  const sortBtnCls = (active: boolean) =>
-    `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
-
   // Column-header sorting, mirroring BooksPage: first click ascending, a second
   // click on the same column flips to descending. Both keys are whitelisted
   // server-side, so an unknown value can only ever fall back to the name sort.
@@ -416,21 +414,55 @@ export default function AuthorsPage() {
           placeholder={t('authors.searchPlaceholder')}
           className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600 placeholder-slate-400 dark:placeholder-zinc-600"
         />
-        <div className="flex gap-1">
-          <button onClick={() => setSort('az')} className={sortBtnCls(sort === 'az')}>{t('authors.sortAZ')}</button>
-          <button onClick={() => setSort('za')} className={sortBtnCls(sort === 'za')}>{t('authors.sortZA')}</button>
-          <button onClick={() => setSort('name-az')} className={sortBtnCls(sort === 'name-az')}>{t('authors.sortFirstNameAZ')}</button>
-          <button onClick={() => setSort('name-za')} className={sortBtnCls(sort === 'name-za')}>{t('authors.sortFirstNameZA')}</button>
-          <button onClick={() => setSort('recent')} className={sortBtnCls(sort === 'recent')}>{t('authors.sortRecent')}</button>
-        </div>
       </div>
 
-      {/* Monitored filter chips */}
-      <div className="flex gap-1 mb-6 flex-wrap">
-        <span className="text-xs text-slate-600 dark:text-zinc-500 mr-1 self-center">{t('authors.filterMonitored')}</span>
-        <button onClick={() => setMonitoredFilter('')} className={sortBtnCls(monitoredFilter === '')}>{t('authors.filterAll')}</button>
-        <button onClick={() => setMonitoredFilter('monitored')} className={sortBtnCls(monitoredFilter === 'monitored')}>{t('authors.filterMonitoredOnly')}</button>
-        <button onClick={() => setMonitoredFilter('unmonitored')} className={sortBtnCls(monitoredFilter === 'unmonitored')}>{t('authors.filterUnmonitored')}</button>
+      {/* Sort and the monitored facet behind two disclosures rather than five
+          sort pills plus a labelled filter row. The Filters trigger carries a
+          count and the applied value also renders as a removable chip, so a
+          filter that is on is never only visible inside the popover.
+
+          Table view drops the sort control: the column headers already sort. */}
+      <div className="flex items-center gap-2 mb-6 flex-wrap">
+        {view === 'grid' && (
+          <FilterPopover label={t('common.sort', 'Sort')}>
+            <FilterGroup
+              label={t('common.sort', 'Sort')}
+              value={sort}
+              onChange={setSort}
+              options={[
+                { value: 'az' as const, label: t('authors.sortAZ') },
+                { value: 'za' as const, label: t('authors.sortZA') },
+                { value: 'name-az' as const, label: t('authors.sortFirstNameAZ') },
+                { value: 'name-za' as const, label: t('authors.sortFirstNameZA') },
+                { value: 'recent' as const, label: t('authors.sortRecent') },
+              ]}
+            />
+          </FilterPopover>
+        )}
+
+        <FilterPopover label={t('common.filters', 'Filters')} activeCount={monitoredFilter ? 1 : 0}>
+          <FilterGroup
+            label={t('authors.filterMonitored')}
+            value={monitoredFilter}
+            onChange={setMonitoredFilter}
+            options={[
+              { value: '' as const, label: t('authors.filterAll') },
+              { value: 'monitored' as const, label: t('authors.filterMonitoredOnly') },
+              { value: 'unmonitored' as const, label: t('authors.filterUnmonitored') },
+            ]}
+          />
+        </FilterPopover>
+
+        {monitoredFilter && (
+          <button
+            onClick={() => setMonitoredFilter('')}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-slate-200 dark:bg-zinc-800 text-xs text-slate-700 dark:text-zinc-300 hover:bg-slate-300 dark:hover:bg-zinc-700"
+          >
+            {monitoredFilter === 'monitored' ? t('authors.filterMonitoredOnly') : t('authors.filterUnmonitored')}
+            <span aria-hidden="true">✕</span>
+            <span className="sr-only">{t('common.clearFilter', 'Clear filter')}</span>
+          </button>
+        )}
       </div>
 
       <SetupChecklist />

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -8,6 +8,7 @@ import AddBookModal from '../components/AddBookModal'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
 import SeriesNameModal from '../components/SeriesNameModal'
 import BulkActionBar from '../components/BulkActionBar'
+import MoreMenu from '../components/MoreMenu'
 import Pagination from '../components/Pagination'
 import { useServerPagination } from '../components/usePagination'
 import ViewToggle from '../components/ViewToggle'
@@ -500,18 +501,15 @@ export default function AuthorsPage() {
                       />
                     </td>
                     <td className="px-3 py-2 text-right whitespace-nowrap">
-                      <button
-                        onClick={() => api.refreshAuthor(author.id).then(load)}
-                        className={`${btn.ghost} ${btnSize.sm} mr-3`}
-                      >
-                        {t('common.refresh')}
-                      </button>
-                      <button
-                        onClick={() => handleDelete(author.id)}
-                        className={`${btn.danger} ${btnSize.sm}`}
-                      >
-                        {t('common.delete')}
-                      </button>
+                      <MoreMenu
+                        label={t('common.moreActions', 'More')}
+                        ariaLabel={t('authors.moreActionsFor', 'More actions for {{name}}', { name: author.authorName })}
+                        buttonClassName={`${btn.ghost} ${btnSize.sm}`}
+                        items={[
+                          { label: t('common.refresh'), onSelect: () => { api.refreshAuthor(author.id).then(load) } },
+                          { label: t('common.delete'), onSelect: () => handleDelete(author.id), danger: true },
+                        ]}
+                      />
                     </td>
                   </tr>
                 ))}
@@ -558,21 +556,15 @@ export default function AuthorsPage() {
                 >
                   {author.monitored ? t('authors.monitored') : t('authors.unmonitored')}
                 </Switch>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => api.refreshAuthor(author.id).then(load)}
-                    className={`${btn.ghost} ${btnSize.sm}`}
-                    title="Refresh metadata"
-                  >
-                    {t('common.refresh')}
-                  </button>
-                  <button
-                    onClick={() => handleDelete(author.id)}
-                    className={`${btn.danger} ${btnSize.sm}`}
-                  >
-                    {t('common.delete')}
-                  </button>
-                </div>
+                <MoreMenu
+                  label={t('common.moreActions', 'More')}
+                  ariaLabel={t('authors.moreActionsFor', 'More actions for {{name}}', { name: author.authorName })}
+                  buttonClassName={`${btn.ghost} ${btnSize.sm}`}
+                  items={[
+                    { label: t('common.refresh'), onSelect: () => { api.refreshAuthor(author.id).then(load) }, title: t('authors.refreshMetadata', 'Refresh metadata') },
+                    { label: t('common.delete'), onSelect: () => handleDelete(author.id), danger: true },
+                  ]}
+                />
               </div>
             </div>
           ))}

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useConfirmDialog } from '../components/useConfirmDialog'
 import ViewToggle from '../components/ViewToggle'
 import { bookStatusBadge } from '../components/bookStatus'
+import FilterPopover, { FilterGroup } from '../components/FilterPopover'
 import BookStatusLegend from '../components/BookStatusLegend'
 import { useView } from '../components/useView'
 import GettingStartedGuidance from '../components/GettingStartedGuidance'
@@ -54,6 +55,10 @@ export default function BooksPage() {
   const selectAllRef = useRef<HTMLInputElement>(null)
 
   const monitoredParam = monitoredFilter === 'monitored' ? true : monitoredFilter === 'unmonitored' ? false : undefined
+
+  // Shown on the Filters trigger so an applied filter is visible without
+  // opening it. Status is not counted: it has its own row and is never hidden.
+  const activeFilterCount = [mediaFilter, monitoredFilter].filter(Boolean).length
   const { page, pageSize, paginationProps, reset } = useServerPagination(total, 50, 'books')
 
   // Server-side list: page, page size, search, status, media type, monitored,
@@ -137,9 +142,6 @@ export default function BooksPage() {
   const statusBtnCls = (active: boolean) =>
     `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'}`
 
-  const sortBtnCls = (active: boolean) =>
-    `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
-
   // Clicking a column header sorts by that column: first click ascending, a
   // second click on the same column flips to descending (mirrors the sort
   // buttons, which use the same whitelisted keys the backend accepts).
@@ -211,25 +213,77 @@ export default function BooksPage() {
         </div>
       </div>
 
-      <div className="flex gap-1 mb-4 flex-wrap">
-        <span className="text-xs text-slate-600 dark:text-zinc-500 mr-1 self-center">{t('books.sortLabel')}</span>
-        <button onClick={() => setSort('title-az')} className={sortBtnCls(sort === 'title-az')}>{t('books.sortTitleAZ')}</button>
-        <button onClick={() => setSort('title-za')} className={sortBtnCls(sort === 'title-za')}>{t('books.sortTitleZA')}</button>
-        <button onClick={() => setSort('date-new')} className={sortBtnCls(sort === 'date-new')}>{t('books.sortNewest')}</button>
-        <button onClick={() => setSort('date-old')} className={sortBtnCls(sort === 'date-old')}>{t('books.sortOldest')}</button>
+      {/* Sort and the secondary facets live behind two disclosures rather than
+          a second wrapping row of pills. Status stays out in the open above:
+          it is the one people change constantly, and burying it would trade
+          tidiness for the thing this page is for.
 
-        <span className="text-xs text-slate-600 dark:text-zinc-500 mx-2 self-center">{t('books.typeLabel')}</span>
-        <button onClick={() => setMediaFilter('')} className={sortBtnCls(mediaFilter === '')}>{t('common.all')}</button>
-        <button onClick={() => setMediaFilter('ebook')} className={sortBtnCls(mediaFilter === 'ebook')}>📖 {t('common.ebook')}</button>
-        <button onClick={() => setMediaFilter('audiobook')} className={sortBtnCls(mediaFilter === 'audiobook')}>🎧 {t('common.audiobook')}</button>
-        {/* The Ebook/Audiobook filters deliberately include dual-format books,
-            so neither one isolates them; this does. */}
-        <button onClick={() => setMediaFilter('both')} className={sortBtnCls(mediaFilter === 'both')}>📖🎧 {t('common.both')}</button>
+          In table view the sort control is dropped entirely, because the column
+          headers already sort and offering both invites them to disagree. */}
+      <div className="flex items-center gap-2 mb-4 flex-wrap">
+        {view === 'grid' && (
+          <FilterPopover label={t('common.sort', 'Sort')} ariaLabel={t('books.sortLabel')}>
+            <FilterGroup
+              label={t('books.sortLabel')}
+              value={sort}
+              onChange={setSort}
+              options={[
+                { value: 'title-az' as const, label: t('books.sortTitleAZ') },
+                { value: 'title-za' as const, label: t('books.sortTitleZA') },
+                { value: 'date-new' as const, label: t('books.sortNewest') },
+                { value: 'date-old' as const, label: t('books.sortOldest') },
+              ]}
+            />
+          </FilterPopover>
+        )}
 
-        <span className="text-xs text-slate-600 dark:text-zinc-500 mx-2 self-center">{t('books.filterMonitored', 'Monitored:')}</span>
-        <button onClick={() => setMonitoredFilter('')} className={sortBtnCls(monitoredFilter === '')}>{t('books.filterAll', 'All')}</button>
-        <button onClick={() => setMonitoredFilter('monitored')} className={sortBtnCls(monitoredFilter === 'monitored')}>{t('books.filterMonitoredOnly', 'Monitored')}</button>
-        <button onClick={() => setMonitoredFilter('unmonitored')} className={sortBtnCls(monitoredFilter === 'unmonitored')}>{t('books.filterUnmonitored', 'Unmonitored')}</button>
+        <FilterPopover label={t('common.filters', 'Filters')} activeCount={activeFilterCount}>
+          <FilterGroup
+            label={t('books.typeLabel')}
+            value={mediaFilter}
+            onChange={setMediaFilter}
+            options={[
+              { value: '' as const, label: t('common.all') },
+              { value: 'ebook' as const, label: `📖 ${t('common.ebook')}`, ariaLabel: t('common.ebook') },
+              { value: 'audiobook' as const, label: `🎧 ${t('common.audiobook')}`, ariaLabel: t('common.audiobook') },
+              // The Ebook/Audiobook filters deliberately include dual-format
+              // books, so neither one isolates them; this does.
+              { value: 'both' as const, label: `📖🎧 ${t('common.both')}`, ariaLabel: t('common.both') },
+            ]}
+          />
+          <FilterGroup
+            label={t('books.filterMonitored', 'Monitored:')}
+            value={monitoredFilter}
+            onChange={setMonitoredFilter}
+            options={[
+              { value: '' as const, label: t('books.filterAll', 'All') },
+              { value: 'monitored' as const, label: t('books.filterMonitoredOnly', 'Monitored') },
+              { value: 'unmonitored' as const, label: t('books.filterUnmonitored', 'Unmonitored') },
+            ]}
+          />
+        </FilterPopover>
+
+        {/* An applied filter is never only visible inside the popover. */}
+        {mediaFilter && (
+          <button
+            onClick={() => setMediaFilter('')}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-slate-200 dark:bg-zinc-800 text-xs text-slate-700 dark:text-zinc-300 hover:bg-slate-300 dark:hover:bg-zinc-700"
+          >
+            {t(`common.${mediaFilter}`)}
+            <span aria-hidden="true">✕</span>
+            <span className="sr-only">{t('common.clearFilter', 'Clear filter')}</span>
+          </button>
+        )}
+        {monitoredFilter && (
+          <button
+            onClick={() => setMonitoredFilter('')}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-slate-200 dark:bg-zinc-800 text-xs text-slate-700 dark:text-zinc-300 hover:bg-slate-300 dark:hover:bg-zinc-700"
+          >
+            {monitoredFilter === 'monitored' ? t('books.filterMonitoredOnly', 'Monitored') : t('books.filterUnmonitored', 'Unmonitored')}
+            <span aria-hidden="true">✕</span>
+            <span className="sr-only">{t('common.clearFilter', 'Clear filter')}</span>
+          </button>
+        )}
       </div>
 
       <BookStatusLegend />

--- a/web/src/theme.bootstrap.test.ts
+++ b/web/src/theme.bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+// Vite's ?raw import rather than node:fs, so this needs no @types/node.
+// src/i18n/inlineDefaults.test.ts reads sources the same way.
+import html from '../index.html?raw'
 
 // index.html carries an inline script that sets the `dark` class before the
 // first paint. It exists because useTheme applies the class from an effect,
@@ -9,8 +10,6 @@ import { resolve } from 'node:path'
 // The bootstrap duplicates readInitial()'s rule by necessity: it runs before
 // any module has loaded, so it cannot import it. This test is the thing that
 // stops the two drifting, which is the whole risk of duplicating a rule.
-
-const html = readFileSync(resolve(__dirname, '../index.html'), 'utf8')
 
 function bootstrapSource(): string {
   const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m => m[1])
@@ -38,7 +37,6 @@ function runBootstrap(opts: { saved: string | null; prefersDark: boolean; storag
       return k === 'bindery.theme' ? opts.saved : null
     },
   }
-  // eslint-disable-next-line no-new-func
   new Function('document', 'window', 'localStorage', bootstrapSource())(documentStub, windowStub, localStorageStub)
   return isDark
 }

--- a/web/src/theme.bootstrap.test.ts
+++ b/web/src/theme.bootstrap.test.ts
@@ -11,11 +11,17 @@ import html from '../index.html?raw'
 // any module has loaded, so it cannot import it. This test is the thing that
 // stops the two drifting, which is the whole risk of duplicating a rule.
 
+const START = '/* theme-bootstrap:start */'
+const END = '/* theme-bootstrap:end */'
+
 function bootstrapSource(): string {
-  const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m => m[1])
-  const found = scripts.find(s => s.includes('bindery.theme'))
-  if (!found) throw new Error('no inline theme bootstrap found in index.html')
-  return found
+  // Sliced between the two markers rather than matched with an HTML-ish
+  // regexp: the markers are an explicit contract with index.html and there is
+  // no tag parsing to get wrong.
+  const from = html.indexOf(START)
+  const to = html.indexOf(END)
+  if (from < 0 || to < from) throw new Error('no theme bootstrap markers found in index.html')
+  return html.slice(from + START.length, to)
 }
 
 /** Runs the real bootstrap source against a fake document and returns the resulting class state. */

--- a/web/src/theme.bootstrap.test.ts
+++ b/web/src/theme.bootstrap.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// index.html carries an inline script that sets the `dark` class before the
+// first paint. It exists because useTheme applies the class from an effect,
+// which runs after the browser has already painted the light background.
+//
+// The bootstrap duplicates readInitial()'s rule by necessity: it runs before
+// any module has loaded, so it cannot import it. This test is the thing that
+// stops the two drifting, which is the whole risk of duplicating a rule.
+
+const html = readFileSync(resolve(__dirname, '../index.html'), 'utf8')
+
+function bootstrapSource(): string {
+  const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m => m[1])
+  const found = scripts.find(s => s.includes('bindery.theme'))
+  if (!found) throw new Error('no inline theme bootstrap found in index.html')
+  return found
+}
+
+/** Runs the real bootstrap source against a fake document and returns the resulting class state. */
+function runBootstrap(opts: { saved: string | null; prefersDark: boolean; storageThrows?: boolean }): boolean {
+  let isDark = false
+  const documentStub = {
+    documentElement: {
+      classList: {
+        toggle: (_cls: string, on: boolean) => { isDark = on },
+      },
+    },
+  }
+  const windowStub = {
+    matchMedia: (q: string) => ({ matches: q.includes('dark') ? opts.prefersDark : false }),
+  }
+  const localStorageStub = {
+    getItem: (k: string) => {
+      if (opts.storageThrows) throw new DOMException('blocked', 'SecurityError')
+      return k === 'bindery.theme' ? opts.saved : null
+    },
+  }
+  // eslint-disable-next-line no-new-func
+  new Function('document', 'window', 'localStorage', bootstrapSource())(documentStub, windowStub, localStorageStub)
+  return isDark
+}
+
+/** readInitial()'s rule, restated. Kept separate so a change to one side fails loudly. */
+function expectedDark(saved: string | null, prefersDark: boolean): boolean {
+  if (saved === 'light' || saved === 'dark') return saved === 'dark'
+  return prefersDark
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('index.html theme bootstrap', () => {
+  it('is present, and is a plain script so it runs before the first paint', () => {
+    expect(() => bootstrapSource()).not.toThrow()
+    // A module script is deferred and would run after paint, defeating the point.
+    expect(html).not.toMatch(/<script type="module">[\s\S]*bindery\.theme/)
+    // It must come before the app bundle, or the effect wins the race anyway.
+    expect(html.indexOf('bindery.theme')).toBeLessThan(html.indexOf('src/main.tsx'))
+  })
+
+  it.each([
+    { saved: 'dark', prefersDark: false },
+    { saved: 'dark', prefersDark: true },
+    { saved: 'light', prefersDark: true },
+    { saved: 'light', prefersDark: false },
+    { saved: null, prefersDark: true },
+    { saved: null, prefersDark: false },
+    { saved: 'garbage', prefersDark: true },
+    { saved: 'garbage', prefersDark: false },
+  ])('agrees with readInitial for saved=$saved prefersDark=$prefersDark', ({ saved, prefersDark }) => {
+    expect(runBootstrap({ saved, prefersDark })).toBe(expectedDark(saved, prefersDark))
+  })
+
+  it('falls back to the OS preference when storage is blocked, instead of throwing', () => {
+    expect(runBootstrap({ saved: null, prefersDark: true, storageThrows: true })).toBe(true)
+    expect(runBootstrap({ saved: null, prefersDark: false, storageThrows: true })).toBe(false)
+  })
+})

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -6,7 +6,14 @@ const STORAGE_KEY = 'bindery.theme'
 
 function readInitial(): Theme {
   if (typeof window === 'undefined') return 'dark'
-  const saved = localStorage.getItem(STORAGE_KEY) as Theme | null
+  let saved: Theme | null = null
+  try {
+    saved = localStorage.getItem(STORAGE_KEY) as Theme | null
+  } catch {
+    // Private mode or blocked storage. Fall through to the OS preference
+    // rather than throwing out of a useState initializer, which would take
+    // the whole app down at boot.
+  }
   if (saved === 'light' || saved === 'dark') return saved
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
 }
@@ -17,10 +24,15 @@ function apply(theme: Theme) {
 }
 
 /**
- * useTheme — returns the current theme and a setter. Persists to
- * localStorage and toggles the `dark` class on <html>. The initial
- * state is read synchronously so the app's first render already
- * reflects the persisted/system theme.
+ * useTheme returns the current theme and a setter. It persists to
+ * localStorage and toggles the `dark` class on <html>.
+ *
+ * The initial state is read synchronously, so the React tree's first render
+ * already reflects the stored theme. The `dark` class is NOT applied that
+ * early: it lands in the effect below, after the first paint. The inline
+ * bootstrap in index.html is what sets the class before the browser paints,
+ * and it has to keep agreeing with readInitial() above; theme.bootstrap.test.ts
+ * fails if the two drift.
  */
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(readInitial)


### PR DESCRIPTION
Phase 1 of the UX pass: presentation only, no data model or API changes. Six commits, one per item, so any of them can be reviewed or reverted on its own.

Labelled `dev-preview` so it assembles onto bindery-dev without merging. **Not for merge yet** — the point is to use it there first.

## What changed

**The theme flash.** The `dark` class was applied from a React effect, which runs after the browser paints, so every route showed its light background for a frame. Now set by a small inline script before the app bundle loads. The rule is written twice by necessity, so `theme.bootstrap.test.ts` extracts the real script out of `index.html`, runs it against a fake document, and fails if it stops agreeing with `readInitial`.

**Unrouted paths.** There was no catch-all, so any unrecognised path rendered the chrome around an empty `<main>`. That is the failure `/authors` had, and its alias fixed the one path rather than the shape. There is a not-found page now. `/settings/:tab` redirects to the `?tab=` form rather than 404ing a URL that plainly means something.

**Author row actions.** Refresh and Delete moved into the shared `MoreMenu`; the monitored toggle stayed put. Discover's card had its own hand-rolled `···` menu with no keyboard handling and no focus return, and now uses the same component.

**Filter and sort rows.** Books packed sort, media type and monitored into one wrapping row; Authors had five sort pills plus a monitored row. Both are now a `Filters` and a `Sort` disclosure.

**Setup checklist.** A strip naming the next step, rather than a box listing all five. Also stops showing once only one step is left, which the server's `complete` did not cover on its own.

**Rating column.** Hidden when nothing on the page has a rating.

## The one thing I want your eye on

The filter popover is the only part of this that can violate the governing principle, since the monitored filter is a control people use constantly and a popover puts it a click further away. It is built with two mitigations: a count on the `Filters` trigger, and the applied value spelled out beside it as a chip that clears it. Status stays out in the open on Books for the same reason.

If it still feels worse in use, the fallback is to keep Monitored inline and move only Sort and Type. That is a judgement to make on dev rather than in review.

## Corrections to the plan this came from

Verification against the code changed the scope before I built anything:

- **The Discover item was dropped.** Covers are already fixed-aspect (#484) and the caption in the artwork is the recommendation reason, not a genre.
- **The rating column is hidden conditionally, not removed.** It carries real OpenLibrary data; Hardcover and DNB supply no author-level rating, which is why it looked universally empty.
- **Sortable headers and the unmonitored filter already shipped** in #1349, so only the popover collapse was left.
- **`MoreMenu` already existed**, so nothing new was written for the overflow menus.

## Testing

`npm run typecheck`, `npm run lint` (0 errors, the same 6 pre-existing warnings, none in files I touched), `npm test` (701 passing), `npm run build`. `go build` and `go vet` clean, though nothing here touches Go.

Every behaviour change has a test that fails without it. I checked that by reverting each fix in place rather than assuming: dropping the stored-light branch from the theme bootstrap fails the agreement test, removing the two routes fails four cases, forcing `anyRating` true fails the hidden-column case.

Two existing test suites asserted the old shapes and were rewritten rather than deleted: the onboarding tests now pin the strip's contract, and Discover's menu tests address the menu by its accessible name instead of the `···` glyph.

Two `react-i18next` mocks resolved `t(key, 'Inline default')` to the bare key, so a component written that way rendered its key and looked like a missing string. Both now resolve the way real i18next does.

## Sequencing

Built on plain `main`, with the five queued 1.34.0 frontend PRs deliberately held per your call. One known collision when they land: #2422 deletes the `downloading` filter button that the new Books popover carries. One line, resolved by dropping the option. Do not fix it here or the two PRs will fight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
