### PR TITLE
fix(ci): stop a dev preview rolling bindery-dev back to the placeholder image

### DIFF
--- a/.github/workflows/dev-preview.yml
+++ b/.github/workflows/dev-preview.yml
@@ -52,6 +52,22 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git fetch origin main
+
+          # The image tag in values-dev.yaml is machine-owned state: deploy-dev
+          # writes the sha it just built into it, while main only ever carries a
+          # stale placeholder. Rebuilding development from main therefore reset
+          # the tag to that placeholder and ArgoCD deployed it, so every preview
+          # rolled bindery-dev back to an ancient image for the length of the
+          # image build, and left it there if the build failed. Carry the live
+          # tag across the rebuild. On the first run there is no development
+          # branch to read and main's value stands.
+          LIVE_TAG=""
+          if git fetch origin development 2>/dev/null; then
+            LIVE_TAG=$(git show origin/development:charts/bindery/values-dev.yaml 2>/dev/null \
+              | sed -n '/^image:/,/^[^[:space:]]/{s/^[[:space:]]*tag:[[:space:]]*"\{0,1\}\([^"]*\)"\{0,1\}[[:space:]]*$/\1/p;}' \
+              | head -1)
+          fi
+
           git checkout -B development origin/main
 
           # SECURITY: only merge PRs whose head lives in this same repo. A fork
@@ -74,6 +90,20 @@ jobs:
               SKIPPED+=("$n")
             fi
           done
+
+          # Put the live tag back before pushing so ArgoCD never sees the
+          # placeholder. deploy-dev overwrites it minutes later with the sha it
+          # builds from this very tree; until then dev keeps serving what it was
+          # already serving.
+          if [ -n "$LIVE_TAG" ]; then
+            sed -i '/^image:/,/^[^[:space:]]/ s|^\([[:space:]]*tag:[[:space:]]*\).*$|\1"'"$LIVE_TAG"'"|' charts/bindery/values-dev.yaml
+            grep -q "tag: \"$LIVE_TAG\"" charts/bindery/values-dev.yaml \
+              || { echo "::error::failed to restore the live dev image tag $LIVE_TAG"; exit 1; }
+            if ! git diff --quiet charts/bindery/values-dev.yaml; then
+              git add charts/bindery/values-dev.yaml
+              git commit -m "preview: keep the live dev image tag ${LIVE_TAG}"
+            fi
+          fi
 
           git push --force origin development
 

--- a/changelog.d/dev-preview-tag-rollback.md
+++ b/changelog.d/dev-preview-tag-rollback.md
@@ -1,0 +1,2 @@
+### Fixed
+- **A dev preview no longer rolls bindery-dev back to an ancient image while it builds** — the assembly rebuilt the `development` branch from `main`, which reset the image tag in `values-dev.yaml` to the stale placeholder main carries. ArgoCD deployed that, so every preview served a v1.2.0 container for the length of the image build, and kept serving it if the build failed. The live tag is now carried across the rebuild.


### PR DESCRIPTION
## What broke

`dev-preview.yml` rebuilds `development` as `main` plus every PR carrying the `dev-preview` label:

```
git fetch origin main
git checkout -B development origin/main
```

That takes main's copy of `charts/bindery/values-dev.yaml`, whose image tag is the checked in placeholder `1.2.0`. ArgoCD watches the branch, so it syncs that placeholder immediately. `deploy-dev` overwrites the tag with the real sha once the image finishes building, roughly eight minutes later.

So every preview assembly downgraded bindery-dev to a v1.2.0 container, then brought it forward again. I caught it live: the dev instance was serving the old UI with a v1.2.0 badge while the build ran. If the image build fails, it stays there.

## The fix

The image tag is machine owned state and main is not its source of truth, so read the live value off `origin/development` before the rebuild and restore it before the force push. Only the tag is carried over, so genuine edits to the rest of `values-dev.yaml` still flow from main. On the very first run there is no `development` branch to read and main's value stands.

The restore is verified with a grep and fails the job loudly rather than pushing a tree it could not patch.

## Verification

Ran the extract and restore against a copy of the real file:

- extracts `sha-00c0101` from a live values file and puts it back
- edits only the tag inside the `image:` block; a `tag:` under a sibling key was confirmed untouched
- empty capture (first run) skips the restore and leaves main's value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP