### PR TITLE
fix(ping): make the running build visible, and stop the pin drifting silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           go-version: "1.26.6"
           cache: true
-      - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
+      - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/... ./tools/...
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.out
@@ -245,7 +245,7 @@ jobs:
         with:
           go-version: "1.26.6"
           cache: true
-      - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
+      - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/... ./tools/...
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.out

--- a/.github/workflows/ping-drift.yml
+++ b/.github/workflows/ping-drift.yml
@@ -36,49 +36,19 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - name: Compare
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.26.6"
+          cache: true
+
+      # The comparison lives in tools/pingdrift rather than inline here so it
+      # is unit-testable: the parser and deploy/telemetry-server.yaml are a
+      # pair, and a reformat of that file has to break a PR rather than turn
+      # this nightly job into a permanent red nobody reads.
+      - name: Compare the running build against the pin
         env:
-          STATS_TOKEN: ${{ secrets.TELEMETRY_STATS_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${STATS_TOKEN:-}" ]; then
-            echo "::error::TELEMETRY_STATS_TOKEN secret is not set, cannot read the running build"
-            exit 1
-          fi
-
-          PINNED=$(sed -n 's|.*image: ghcr.io/[^/]*/bindery-ping:sha-\([0-9a-f]\{7,40\}\).*|\1|p' \
-            deploy/telemetry-server.yaml | head -1)
-          if [ -z "$PINNED" ]; then
-            echo "::error::could not read a sha- pinned bindery-ping image from deploy/telemetry-server.yaml"
-            exit 1
-          fi
-
-          BODY=$(curl -sS -m 20 --fail-with-body \
-            -H "Authorization: Bearer ${STATS_TOKEN}" \
-            https://api.getbindery.dev/api/stats) || {
-              echo "::error::could not reach https://api.getbindery.dev/api/stats"
-              exit 1
-            }
-          LIVE=$(printf '%s' "$BODY" | jq -r '.build_sha // ""')
-
-          echo "pinned in deploy/telemetry-server.yaml: ${PINNED}"
-          echo "reported by the running server:         ${LIVE:-<absent>}"
-
-          # A running build from before the stamping change reports nothing,
-          # or the "unknown" default. Either way it is by definition older
-          # than the pin that introduced the field, so it is drift.
-          if [ -z "$LIVE" ] || [ "$LIVE" = "unknown" ]; then
-            echo "::error::the running bindery-ping predates build stamping, so it is at least as old as that change. Deploy the pinned image: kubectl apply -f deploy/telemetry-server.yaml"
-            exit 1
-          fi
-
-          # The pin may be short or full length; compare on the shorter one.
-          N=${#PINNED}; [ "${#LIVE}" -lt "$N" ] && N=${#LIVE}
-          if [ "${PINNED:0:$N}" != "${LIVE:0:$N}" ]; then
-            echo "::error::bindery-ping is running ${LIVE} but deploy/telemetry-server.yaml pins ${PINNED}. Apply it: kubectl apply -f deploy/telemetry-server.yaml"
-            exit 1
-          fi
-
-          echo "in step"
+          TELEMETRY_STATS_TOKEN: ${{ secrets.TELEMETRY_STATS_TOKEN }}
+        run: go run ./tools/pingdrift

--- a/.github/workflows/ping-drift.yml
+++ b/.github/workflows/ping-drift.yml
@@ -1,0 +1,84 @@
+name: Ping Server drift
+
+# The bindery-ping deployment is applied by hand: it is not in the ArgoCD
+# application (that tracks charts/bindery only) and CI has no kubectl or SSH
+# to that host, just an HTTPS token. So the running container can fall behind
+# the repo indefinitely and nothing says so.
+#
+# It did. deploy/telemetry-server.yaml pinned the #1521 build from 2026-07-11
+# while main had shipped the new_install ping log (#2155, 2026-08-21), the
+# Debian 13 base and x/crypto v0.56.0 (#2425). The service was serving an
+# end-of-life base with two High advisories for weeks, on the public
+# internet, and it surfaced only because someone went looking in pod logs for
+# a line that could not be there.
+#
+# This job asks the running server which build it is and compares that with
+# the pin on main. It cannot deploy; it can make the gap visible the day it
+# opens instead of six weeks later.
+
+on:
+  schedule:
+    - cron: "41 6 * * *" # daily, off-hour and off-minute to dodge runner contention
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Compare the running build against the pin
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Compare
+        env:
+          STATS_TOKEN: ${{ secrets.TELEMETRY_STATS_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${STATS_TOKEN:-}" ]; then
+            echo "::error::TELEMETRY_STATS_TOKEN secret is not set, cannot read the running build"
+            exit 1
+          fi
+
+          PINNED=$(sed -n 's|.*image: ghcr.io/[^/]*/bindery-ping:sha-\([0-9a-f]\{7,40\}\).*|\1|p' \
+            deploy/telemetry-server.yaml | head -1)
+          if [ -z "$PINNED" ]; then
+            echo "::error::could not read a sha- pinned bindery-ping image from deploy/telemetry-server.yaml"
+            exit 1
+          fi
+
+          BODY=$(curl -sS -m 20 --fail-with-body \
+            -H "Authorization: Bearer ${STATS_TOKEN}" \
+            https://api.getbindery.dev/api/stats) || {
+              echo "::error::could not reach https://api.getbindery.dev/api/stats"
+              exit 1
+            }
+          LIVE=$(printf '%s' "$BODY" | jq -r '.build_sha // ""')
+
+          echo "pinned in deploy/telemetry-server.yaml: ${PINNED}"
+          echo "reported by the running server:         ${LIVE:-<absent>}"
+
+          # A running build from before the stamping change reports nothing,
+          # or the "unknown" default. Either way it is by definition older
+          # than the pin that introduced the field, so it is drift.
+          if [ -z "$LIVE" ] || [ "$LIVE" = "unknown" ]; then
+            echo "::error::the running bindery-ping predates build stamping, so it is at least as old as that change. Deploy the pinned image: kubectl apply -f deploy/telemetry-server.yaml"
+            exit 1
+          fi
+
+          # The pin may be short or full length; compare on the shorter one.
+          N=${#PINNED}; [ "${#LIVE}" -lt "$N" ] && N=${#LIVE}
+          if [ "${PINNED:0:$N}" != "${LIVE:0:$N}" ]; then
+            echo "::error::bindery-ping is running ${LIVE} but deploy/telemetry-server.yaml pins ${PINNED}. Apply it: kubectl apply -f deploy/telemetry-server.yaml"
+            exit 1
+          fi
+
+          echo "in step"

--- a/.github/workflows/ping-server.yml
+++ b/.github/workflows/ping-server.yml
@@ -15,8 +15,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # move the image pin in deploy/telemetry-server.yaml
       packages: write # push the image to GHCR
+      pull-requests: write # the pin lands through an auto-merged PR
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -45,8 +46,49 @@ jobs:
           file: cmd/telemetry-server/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/bindery-ping:latest
             ghcr.io/${{ github.repository_owner }}/bindery-ping:sha-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # The manifest pin used to be moved by hand, and was not moved for 41
+      # days: deploy/telemetry-server.yaml pointed at the #1521 build while
+      # main had already shipped the new_install ping log (#2155), the
+      # Debian 13 base and x/crypto v0.56.0 (#2425). Writing it here means
+      # `kubectl apply -f deploy/telemetry-server.yaml` always applies the
+      # image this workflow just pushed. Applying it is still manual: this
+      # host is not in the ArgoCD app and CI has no credentials for it.
+      - name: Pin the new image in deploy/telemetry-server.yaml
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FILE_PATH="deploy/telemetry-server.yaml"
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER}/bindery-ping:sha-${GITHUB_SHA}"
+          PIN_BRANCH="auto/ping-pin-${GITHUB_SHA::7}"
+
+          MAIN_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/main" --jq .object.sha)
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/heads/${PIN_BRANCH}" -f sha="${MAIN_SHA}"
+
+          FILE_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE_PATH}?ref=${PIN_BRANCH}" --jq .sha)
+          CONTENT=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE_PATH}?ref=${PIN_BRANCH}" --jq .content \
+            | base64 -d \
+            | sed "s|image: ghcr.io/.*/bindery-ping:.*|image: ${IMAGE}|" \
+            | base64 -w0)
+
+          # No [skip ci] on the branch commit: the required checks have to
+          # run on the PR head or the merge below is blocked forever. It
+          # goes in the squash subject instead, matching deploy-prod.
+          gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE_PATH}" -X PUT \
+            -f message="chore(ping): pin bindery-ping to sha-${GITHUB_SHA::7}" \
+            -f content="${CONTENT}" -f sha="${FILE_SHA}" -f branch="${PIN_BRANCH}"
+
+          gh pr create --repo "${GITHUB_REPOSITORY}" --head "${PIN_BRANCH}" --base main \
+            --title "chore(ping): pin bindery-ping to sha-${GITHUB_SHA::7}" \
+            --body "Automated: pins \`${FILE_PATH}\` to the image this build pushed. Apply with \`kubectl apply -f ${FILE_PATH}\`." 2>/dev/null || true
+          gh pr merge "${PIN_BRANCH}" --repo "${GITHUB_REPOSITORY}" --squash --admin --delete-branch \
+            --subject "chore(ping): pin bindery-ping to sha-${GITHUB_SHA::7} [skip ci]" 

--- a/.github/workflows/ping-server.yml
+++ b/.github/workflows/ping-server.yml
@@ -6,13 +6,89 @@ on:
     paths:
       - cmd/telemetry-server/**
       - .github/workflows/ping-server.yml
+  # On a PR the image is built but not pushed, purely to prove the build sha
+  # is still wired through. deploy/telemetry-server.yaml is deliberately not
+  # in the push filter above: the pin commit this workflow makes would
+  # retrigger it. It is safe here because a PR never pushes or pins.
+  pull_request:
+    paths:
+      - cmd/telemetry-server/**
+      - tools/pingdrift/**
+      - deploy/telemetry-server.yaml
+      - .github/workflows/ping-server.yml
+      - .github/workflows/ping-drift.yml
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  # The drift check is only as good as the stamping it reads. A typo in the
+  # -X path, or the ARG drifting out of the builder stage, leaves buildSHA on
+  # its "unknown" default: the image still builds, every Go test still
+  # passes, and the drift check goes permanently red for a reason that looks
+  # like a stale deploy. Nothing but an actual image build catches that, so
+  # this job does one and asserts the binary reports the sha it was given.
+  stamp:
+    name: build sha is stamped into the binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build with a sentinel BUILD_SHA
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: cmd/telemetry-server/Dockerfile
+          push: false
+          load: true
+          build-args: |
+            BUILD_SHA=stampcheck0123456789
+          tags: bindery-ping:stampcheck
+          cache-from: type=gha
+
+      - name: Assert the binary reports it
+        run: |
+          set -euo pipefail
+          SENTINEL=stampcheck0123456789
+
+          # distroless has no shell, so the binary comes out of the image
+          # rather than running inside it.
+          cid=$(docker create bindery-ping:stampcheck)
+          docker cp "$cid":/telemetry-server ./telemetry-server
+          docker rm "$cid" >/dev/null
+
+          # DB_PATH defaults to /data/telemetry.db, which does not exist on
+          # a runner, and the startup line is only reached after migrate
+          # succeeds. Point it at a temp file and bind a high port so this
+          # cannot collide with anything. The line is written before any
+          # network work, so a short timeout is enough and a non-zero exit
+          # from timeout is expected.
+          WORK=$(mktemp -d)
+          OUT=$(DB_PATH="${WORK}/telemetry.db" ADDR=127.0.0.1:18711 \
+            timeout 15 "${GITHUB_WORKSPACE}/telemetry-server" 2>&1 | head -5 || true)
+          echo "$OUT"
+
+          if ! printf '%s' "$OUT" | grep -q "build=${SENTINEL}"; then
+            echo "::error::the telemetry-server binary did not report build=${SENTINEL}. The -X main.buildSHA wiring in cmd/telemetry-server/Dockerfile is broken, so every image would ship the \"unknown\" default and the ping drift check would be meaningless."
+            exit 1
+          fi
+          echo "build sha stamping verified"
+
   build:
+    needs: stamp
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write # move the image pin in deploy/telemetry-server.yaml

--- a/cmd/telemetry-server/Dockerfile
+++ b/cmd/telemetry-server/Dockerfile
@@ -3,7 +3,13 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /telemetry-server ./cmd/telemetry-server
+# BUILD_SHA is stamped into the binary and reported on /api/stats, so the
+# drift check can ask the running server which build it is. Defaults to
+# "unknown" for a local build that does not pass it.
+ARG BUILD_SHA=unknown
+RUN CGO_ENABLED=0 go build -trimpath \
+      -ldflags="-s -w -X main.buildSHA=${BUILD_SHA}" \
+      -o /telemetry-server ./cmd/telemetry-server
 
 # Distroless runtime — parity with the main Dockerfile. The binary is a static
 # CGO-free build (modernc.org/sqlite is pure Go), so distroless/static is

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -40,6 +40,18 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// buildSHA is stamped at image build time with -X main.buildSHA=<git sha>.
+// It exists because nothing could previously tell which build was serving:
+// /health returns a bare 200 and the binary carries no version. The image
+// pin in deploy/telemetry-server.yaml sat 41 days behind the code once
+// (a July build serving after the August new_install logging landed) and
+// the only way anyone noticed was grepping pod logs for a line that could
+// not be there. Reported on the token-gated /api/stats rather than public
+// /health: a public exact build sha tells a stranger precisely which
+// advisories apply, and the drift check that reads it already holds the
+// stats token.
+var buildSHA = "unknown"
+
 var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 // releaseVersionPattern matches semver-shaped release tags ("1.7.0", "v1.7.0").
@@ -772,6 +784,7 @@ type statsResponse struct {
 	Total      int            `json:"total"`
 	Cumulative int            `json:"cumulative"`
 	Versions   map[string]int `json:"versions"`
+	BuildSHA   string         `json:"build_sha"`
 }
 
 // statsJSON is the response shape for the public /stats.json endpoint. It
@@ -957,7 +970,7 @@ func main() {
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
-	slog.Info("telemetry-server starting", "addr", addr, "latest", latestVersion)
+	slog.Info("telemetry-server starting", "addr", addr, "latest", latestVersion, "build", buildSHA)
 	if err := srv.ListenAndServe(); err != nil {
 		slog.Error("listen", "error", err)
 		os.Exit(1)
@@ -1727,6 +1740,7 @@ func (s *server) handleStats(w http.ResponseWriter, r *http.Request) {
 		Total:      d.Total,
 		Cumulative: d.Cumulative,
 		Versions:   versions,
+		BuildSHA:   buildSHA,
 	})
 }
 

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -1663,3 +1663,42 @@ func TestHandlePing_PreservesFunnelFields(t *testing.T) {
 		t.Errorf("setup_client_day = %d, want nil (not sent)", *f.SetupClientDay)
 	}
 }
+
+// TestHandleStatsReportsBuildSHA covers the field the drift check reads.
+// The point of stamping the build is that something outside the cluster can
+// ask the running server which image it is; if this field ever silently
+// stops being populated, the drift check goes green while the deployment
+// rots, which is the exact failure it exists to catch.
+func TestHandleStatsReportsBuildSHA(t *testing.T) {
+	s := newTestServer(t, "v1.9.5")
+	s.statsToken = "s3cret"
+
+	old := buildSHA
+	buildSHA = "abc1234def"
+	t.Cleanup(func() { buildSHA = old })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+	req.Header.Set("Authorization", "Bearer s3cret")
+	rec := httptest.NewRecorder()
+	s.handleStats(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got statsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.BuildSHA != "abc1234def" {
+		t.Errorf("build_sha = %q, want %q", got.BuildSHA, "abc1234def")
+	}
+}
+
+// An unstamped binary must report the "unknown" sentinel rather than an
+// empty string. The drift check treats both as drift, but "unknown" says
+// plainly that nobody passed BUILD_SHA, while "" reads like a bug.
+func TestBuildSHADefaultsToUnknown(t *testing.T) {
+	if buildSHA != "unknown" {
+		t.Errorf("buildSHA = %q at test time, want the unstamped default %q", buildSHA, "unknown")
+	}
+}

--- a/tools/pingdrift/main.go
+++ b/tools/pingdrift/main.go
@@ -1,0 +1,156 @@
+// Command pingdrift compares the bindery-ping image pinned in
+// deploy/telemetry-server.yaml against the build the live server reports.
+//
+// It exists because that deployment is applied by hand: the host is not in
+// the ArgoCD application (which tracks charts/bindery only) and CI has no
+// kubectl or SSH to it, only an HTTPS token. The pin sat at the 2026-07-11
+// build for 41 days while main shipped a new ping log line, a Debian 13 base
+// and a crypto bump, and nothing said so. This turns that into a daily
+// failure.
+//
+// It is a Go tool rather than shell in a workflow step so the parsing and
+// comparison are unit-testable, matching tools/licensegen.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"time"
+)
+
+// imageRE matches the pinned bindery-ping image line and captures the sha.
+//
+// A regexp rather than a YAML parse on purpose: pulling in a YAML library
+// for one line would make it a direct dependency, with the licence check and
+// THIRD_PARTY_LICENSES regeneration that implies, to read a field whose
+// shape this repo controls. The hazards a parser would have handled are
+// covered instead: `^\s*image:` will not match a `#` commented line, and
+// pinnedImageSHA refuses a file with more than one match rather than
+// silently taking the first, so adding a second bindery-ping container fails
+// loudly here instead of being ignored.
+var imageRE = regexp.MustCompile(`(?m)^\s*image:\s*ghcr\.io/[^/\s]+/bindery-ping:sha-([0-9a-f]{7,40})\s*$`)
+
+// errNoPin distinguishes "the manifest does not pin a sha" (someone moved it
+// back to :latest, which defeats the whole check) from a read failure.
+var errNoPin = errors.New("no sha-pinned bindery-ping image found")
+
+// pinnedImageSHA returns the sha the manifest pins bindery-ping to.
+func pinnedImageSHA(manifest []byte) (string, error) {
+	m := imageRE.FindAllSubmatch(manifest, -1)
+	switch len(m) {
+	case 0:
+		return "", errNoPin
+	case 1:
+		return string(m[0][1]), nil
+	default:
+		return "", fmt.Errorf("found %d sha-pinned bindery-ping images, expected exactly one", len(m))
+	}
+}
+
+// compareSHA reports whether the running build matches the pin.
+//
+// The comparison is on the shorter of the two, because the manifest may
+// carry a short sha while the server reports the full one (or the reverse).
+func compareSHA(pinned, live string) error {
+	// A build from before the stamping change reports the "unknown" default,
+	// or nothing at all on a build from before the field existed. Both mean
+	// the running image is older than the change that added the field, so
+	// both are drift rather than an inconclusive result.
+	switch live {
+	case "":
+		return errors.New("the running server reports no build sha at all, so it predates the build_sha field entirely")
+	case "unknown":
+		return errors.New("the running server reports build sha \"unknown\", so it was built without BUILD_SHA and predates the stamping")
+	}
+
+	n := len(pinned)
+	if len(live) < n {
+		n = len(live)
+	}
+	if pinned[:n] != live[:n] {
+		return fmt.Errorf("running %s but the manifest pins %s", live, pinned)
+	}
+	return nil
+}
+
+// liveBuildSHA reads build_sha from the token-gated stats endpoint. The sha
+// is not on public /health deliberately: an exact build identifier tells a
+// stranger which advisories apply, and this caller already holds the token.
+func liveBuildSHA(url, token string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := (&http.Client{Timeout: 20 * time.Second}).Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s returned HTTP %d", url, resp.StatusCode)
+	}
+
+	var body struct {
+		BuildSHA string `json:"build_sha"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode %s: %w", url, err)
+	}
+	return body.BuildSHA, nil
+}
+
+func main() {
+	manifestPath := os.Getenv("PING_MANIFEST")
+	if manifestPath == "" {
+		manifestPath = "deploy/telemetry-server.yaml"
+	}
+	statsURL := os.Getenv("PING_STATS_URL")
+	if statsURL == "" {
+		statsURL = "https://api.getbindery.dev/api/stats"
+	}
+	token := os.Getenv("TELEMETRY_STATS_TOKEN")
+	if token == "" {
+		fail("TELEMETRY_STATS_TOKEN is not set, cannot read the running build")
+	}
+
+	raw, err := os.ReadFile(manifestPath) // #nosec G304 -- path is a repo file, operator supplied
+	if err != nil {
+		fail("read %s: %v", manifestPath, err)
+	}
+	pinned, err := pinnedImageSHA(raw)
+	if err != nil {
+		fail("%s: %v", manifestPath, err)
+	}
+
+	live, err := liveBuildSHA(statsURL, token)
+	if err != nil {
+		fail("%v", err)
+	}
+
+	fmt.Printf("pinned in %s: %s\n", manifestPath, pinned)
+	fmt.Printf("running:     %s\n", orPlaceholder(live))
+
+	if err := compareSHA(pinned, live); err != nil {
+		fail("bindery-ping drift: %v. Deploy the pinned image: kubectl apply -f %s", err, manifestPath)
+	}
+	fmt.Println("in step")
+}
+
+func orPlaceholder(s string) string {
+	if s == "" {
+		return "<absent>"
+	}
+	return s
+}
+
+// fail writes a GitHub Actions error annotation and exits non-zero.
+func fail(format string, args ...any) {
+	fmt.Printf("::error::"+format+"\n", args...)
+	os.Exit(1)
+}

--- a/tools/pingdrift/main.go
+++ b/tools/pingdrift/main.go
@@ -13,10 +13,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"time"
@@ -77,30 +80,77 @@ func compareSHA(pinned, live string) error {
 	return nil
 }
 
+// checkStatsURL constrains where the bearer token may be sent.
+//
+// The URL is overridable through PING_STATS_URL so the tests can point at a
+// stub, which makes it a taint source: without this, anyone who can set the
+// environment of this job redirects a live credential to a host of their
+// choosing. https everywhere, except a loopback host, which is the only
+// shape the test seam needs and cannot leave the machine.
+func checkStatsURL(raw string) error {
+	u, err := parseURL(raw)
+	if err != nil {
+		return fmt.Errorf("PING_STATS_URL is not a valid URL: %w", err)
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	if u.Scheme == "http" && isLoopbackHost(u.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf("PING_STATS_URL must be https, or http on loopback for tests, got %q", raw)
+}
+
+func parseURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if u.Host == "" {
+		return nil, errors.New("no host")
+	}
+	return u, nil
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
 // liveBuildSHA reads build_sha from the token-gated stats endpoint. The sha
 // is not on public /health deliberately: an exact build identifier tells a
 // stranger which advisories apply, and this caller already holds the token.
-func liveBuildSHA(url, token string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+func liveBuildSHA(ctx context.Context, statsURL, token string) (string, error) {
+	if err := checkStatsURL(statsURL); err != nil {
+		return "", err
+	}
+
+	// #nosec G704 -- statsURL is checked by checkStatsURL above: https, or
+	// http on loopback for the test stub. Nothing here reaches an arbitrary
+	// host with the token.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, statsURL, nil)
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	resp, err := (&http.Client{Timeout: 20 * time.Second}).Do(req)
+	resp, err := (&http.Client{Timeout: 20 * time.Second}).Do(req) // #nosec G704 -- see above
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("%s returned HTTP %d", url, resp.StatusCode)
+		return "", fmt.Errorf("%s returned HTTP %d", statsURL, resp.StatusCode)
 	}
 
 	var body struct {
 		BuildSHA string `json:"build_sha"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return "", fmt.Errorf("decode %s: %w", url, err)
+		return "", fmt.Errorf("decode %s: %w", statsURL, err)
 	}
 	return body.BuildSHA, nil
 }
@@ -128,7 +178,7 @@ func main() {
 		fail("%s: %v", manifestPath, err)
 	}
 
-	live, err := liveBuildSHA(statsURL, token)
+	live, err := liveBuildSHA(context.Background(), statsURL, token)
 	if err != nil {
 		fail("%v", err)
 	}

--- a/tools/pingdrift/main.go
+++ b/tools/pingdrift/main.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -155,41 +156,55 @@ func liveBuildSHA(ctx context.Context, statsURL, token string) (string, error) {
 	return body.BuildSHA, nil
 }
 
-func main() {
-	manifestPath := os.Getenv("PING_MANIFEST")
-	if manifestPath == "" {
-		manifestPath = "deploy/telemetry-server.yaml"
-	}
-	statsURL := os.Getenv("PING_STATS_URL")
-	if statsURL == "" {
-		statsURL = "https://api.getbindery.dev/api/stats"
-	}
+// run does the work and returns an error rather than exiting, so the whole
+// path is reachable from a test. main is the only part that cannot be, and
+// it is now three lines.
+func run(ctx context.Context, out io.Writer) error {
+	manifestPath := env("PING_MANIFEST", "deploy/telemetry-server.yaml")
+	statsURL := env("PING_STATS_URL", "https://api.getbindery.dev/api/stats")
 	token := os.Getenv("TELEMETRY_STATS_TOKEN")
 	if token == "" {
-		fail("TELEMETRY_STATS_TOKEN is not set, cannot read the running build")
+		return errors.New("TELEMETRY_STATS_TOKEN is not set, cannot read the running build")
 	}
 
-	raw, err := os.ReadFile(manifestPath) // #nosec G304 -- path is a repo file, operator supplied
+	raw, err := os.ReadFile(manifestPath) // #nosec G304 -- a repo file named by the operator, not by a request
 	if err != nil {
-		fail("read %s: %v", manifestPath, err)
+		return fmt.Errorf("read %s: %w", manifestPath, err)
 	}
 	pinned, err := pinnedImageSHA(raw)
 	if err != nil {
-		fail("%s: %v", manifestPath, err)
+		return fmt.Errorf("%s: %w", manifestPath, err)
 	}
 
-	live, err := liveBuildSHA(context.Background(), statsURL, token)
+	live, err := liveBuildSHA(ctx, statsURL, token)
 	if err != nil {
-		fail("%v", err)
+		return err
 	}
 
-	fmt.Printf("pinned in %s: %s\n", manifestPath, pinned)
-	fmt.Printf("running:     %s\n", orPlaceholder(live))
+	_, _ = fmt.Fprintf(out, "pinned in %s: %s\n", manifestPath, pinned)
+	_, _ = fmt.Fprintf(out, "running:     %s\n", orPlaceholder(live))
 
 	if err := compareSHA(pinned, live); err != nil {
-		fail("bindery-ping drift: %v. Deploy the pinned image: kubectl apply -f %s", err, manifestPath)
+		return fmt.Errorf("bindery-ping drift: %w. Deploy the pinned image: kubectl apply -f %s", err, manifestPath)
 	}
-	fmt.Println("in step")
+	_, _ = fmt.Fprintln(out, "in step")
+	return nil
+}
+
+func main() {
+	if err := run(context.Background(), os.Stdout); err != nil {
+		// A GitHub Actions error annotation, so the reason lands on the run
+		// summary rather than only in the log.
+		fmt.Printf("::error::%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func env(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }
 
 func orPlaceholder(s string) string {
@@ -197,10 +212,4 @@ func orPlaceholder(s string) string {
 		return "<absent>"
 	}
 	return s
-}
-
-// fail writes a GitHub Actions error annotation and exits non-zero.
-func fail(format string, args ...any) {
-	fmt.Printf("::error::"+format+"\n", args...)
-	os.Exit(1)
 }

--- a/tools/pingdrift/main_test.go
+++ b/tools/pingdrift/main_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The highest-value test here: parse the manifest as actually committed.
+// The parser and the file are a pair, and the failure this whole tool exists
+// to catch is a silent one, so a reformat of deploy/telemetry-server.yaml
+// that the regexp stops matching has to break a PR rather than turn the
+// nightly check into a permanent red nobody reads.
+func TestPinnedImageSHA_RealManifest(t *testing.T) {
+	raw, err := os.ReadFile("../../deploy/telemetry-server.yaml")
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	sha, err := pinnedImageSHA(raw)
+	if err != nil {
+		t.Fatalf("pinnedImageSHA on the committed manifest: %v", err)
+	}
+	if len(sha) < 7 {
+		t.Errorf("sha = %q, want at least 7 hex chars", sha)
+	}
+}
+
+func TestPinnedImageSHA(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "full sha, as committed",
+			manifest: "        containers:\n          image: ghcr.io/vavallee/bindery-ping:sha-23586cd355e40700e2b60e8d9344ba4e2afd3cb3\n",
+			want:     "23586cd355e40700e2b60e8d9344ba4e2afd3cb3",
+		},
+		{
+			name:     "short sha",
+			manifest: "          image: ghcr.io/vavallee/bindery-ping:sha-d2aee75\n",
+			want:     "d2aee75",
+		},
+		{
+			name:     "trailing whitespace is tolerated",
+			manifest: "          image: ghcr.io/vavallee/bindery-ping:sha-abc1234   \n",
+			want:     "abc1234",
+		},
+		{
+			// The pin was set by hand once and never moved. Someone putting
+			// it back on a floating tag would make the check meaningless, so
+			// it has to be an error rather than a pass.
+			name:     "floating latest tag is not a pin",
+			manifest: "          image: ghcr.io/vavallee/bindery-ping:latest\n",
+			wantErr:  true,
+		},
+		{
+			name:     "commented out line does not count",
+			manifest: "          # image: ghcr.io/vavallee/bindery-ping:sha-abc1234\n",
+			wantErr:  true,
+		},
+		{
+			// A second bindery-ping container (a sidecar, an initContainer)
+			// would make "the pinned image" ambiguous. Refuse rather than
+			// silently checking whichever came first.
+			name: "two pinned images is ambiguous",
+			manifest: "          image: ghcr.io/vavallee/bindery-ping:sha-abc1234\n" +
+				"          image: ghcr.io/vavallee/bindery-ping:sha-def5678\n",
+			wantErr: true,
+		},
+		{
+			name:     "a different image is ignored",
+			manifest: "          image: ghcr.io/vavallee/bindery:sha-abc1234\n",
+			wantErr:  true,
+		},
+		{
+			name:     "empty manifest",
+			manifest: "",
+			wantErr:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pinnedImageSHA([]byte(tc.manifest))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("pinnedImageSHA = %q, want an error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("pinnedImageSHA: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("pinnedImageSHA = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPinnedImageSHA_NoPinIsDistinguishable(t *testing.T) {
+	_, err := pinnedImageSHA([]byte("          image: ghcr.io/vavallee/bindery-ping:latest\n"))
+	if !errors.Is(err, errNoPin) {
+		t.Errorf("err = %v, want errNoPin so a read failure and a missing pin stay distinguishable", err)
+	}
+}
+
+func TestCompareSHA(t *testing.T) {
+	const full = "d2aee75fb3c9e49e8639d7016e73c4533d1e5af6"
+	cases := []struct {
+		name         string
+		pinned, live string
+		wantErr      bool
+	}{
+		{name: "identical full shas", pinned: full, live: full},
+		{name: "pin short, live full", pinned: "d2aee75", live: full},
+		{name: "pin full, live short", pinned: full, live: "d2aee75"},
+		{name: "different builds", pinned: full, live: "23586cd355e40700e2b60e8d9344ba4e2afd3cb3", wantErr: true},
+		// Both of these mean the running image predates the stamping, which
+		// is by definition older than the pin that introduced the field.
+		{name: "live reports the unstamped default", pinned: full, live: "unknown", wantErr: true},
+		{name: "live reports nothing at all", pinned: full, live: "", wantErr: true},
+		// The July build this tool was written for: differs from the pin in
+		// the first character, so a prefix comparison must not pass it.
+		{name: "the drift that started this", pinned: "d2aee75", live: "23586cd", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := compareSHA(tc.pinned, tc.live)
+			if tc.wantErr && err == nil {
+				t.Errorf("compareSHA(%q, %q) = nil, want an error", tc.pinned, tc.live)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("compareSHA(%q, %q) = %v, want nil", tc.pinned, tc.live, err)
+			}
+		})
+	}
+}
+
+// compareSHA indexes both strings, so an empty pin must not panic. It cannot
+// reach here through main (pinnedImageSHA rejects it first) but the function
+// is exported to the test and should not be a trap.
+func TestCompareSHA_EmptyPinDoesNotPanic(t *testing.T) {
+	if err := compareSHA("", "abc1234"); err != nil {
+		t.Logf("compareSHA(\"\", ...) = %v", err)
+	}
+}
+
+func TestLiveBuildSHA(t *testing.T) {
+	t.Run("reads build_sha and sends the token", func(t *testing.T) {
+		var gotAuth string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			_ = json.NewEncoder(w).Encode(map[string]any{"build_sha": "abc1234", "total": 7})
+		}))
+		defer srv.Close()
+
+		got, err := liveBuildSHA(srv.URL, "s3cret")
+		if err != nil {
+			t.Fatalf("liveBuildSHA: %v", err)
+		}
+		if got != "abc1234" {
+			t.Errorf("build_sha = %q, want %q", got, "abc1234")
+		}
+		if gotAuth != "Bearer s3cret" {
+			t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer s3cret")
+		}
+	})
+
+	t.Run("a server without the field yields empty, not an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"total": 7})
+		}))
+		defer srv.Close()
+
+		got, err := liveBuildSHA(srv.URL, "s3cret")
+		if err != nil {
+			t.Fatalf("liveBuildSHA: %v", err)
+		}
+		if got != "" {
+			t.Errorf("build_sha = %q, want empty so compareSHA reports it as drift", got)
+		}
+	})
+
+	t.Run("a rejected token is an error, not silent drift", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		if _, err := liveBuildSHA(srv.URL, "wrong"); err == nil {
+			t.Error("liveBuildSHA = nil error on HTTP 401, want an error")
+		} else if !strings.Contains(err.Error(), "401") {
+			t.Errorf("err = %v, want it to name the status", err)
+		}
+	})
+}

--- a/tools/pingdrift/main_test.go
+++ b/tools/pingdrift/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -160,7 +161,7 @@ func TestLiveBuildSHA(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		got, err := liveBuildSHA(srv.URL, "s3cret")
+		got, err := liveBuildSHA(context.Background(), srv.URL, "s3cret")
 		if err != nil {
 			t.Fatalf("liveBuildSHA: %v", err)
 		}
@@ -178,7 +179,7 @@ func TestLiveBuildSHA(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		got, err := liveBuildSHA(srv.URL, "s3cret")
+		got, err := liveBuildSHA(context.Background(), srv.URL, "s3cret")
 		if err != nil {
 			t.Fatalf("liveBuildSHA: %v", err)
 		}
@@ -193,10 +194,52 @@ func TestLiveBuildSHA(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		if _, err := liveBuildSHA(srv.URL, "wrong"); err == nil {
+		if _, err := liveBuildSHA(context.Background(), srv.URL, "wrong"); err == nil {
 			t.Error("liveBuildSHA = nil error on HTTP 401, want an error")
 		} else if !strings.Contains(err.Error(), "401") {
 			t.Errorf("err = %v, want it to name the status", err)
 		}
 	})
+}
+
+// PING_STATS_URL is a test seam, which makes it a taint source: it decides
+// where a live bearer token gets sent. These are the cases that matter.
+func TestCheckStatsURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "the real endpoint", url: "https://api.getbindery.dev/api/stats"},
+		{name: "https anywhere is allowed", url: "https://example.test/api/stats"},
+		{name: "loopback over http, the test stub", url: "http://127.0.0.1:18711/api/stats"},
+		{name: "localhost over http", url: "http://localhost:18711/api/stats"},
+		{name: "ipv6 loopback", url: "http://[::1]:18711/api/stats"},
+		// The token must not leave the machine in the clear, and must not go
+		// to a host someone picked by setting an environment variable.
+		{name: "plain http to a remote host", url: "http://example.test/api/stats", wantErr: true},
+		{name: "http to a non-loopback ip", url: "http://10.0.0.5/api/stats", wantErr: true},
+		{name: "a scheme that is not http", url: "file:///etc/passwd", wantErr: true},
+		{name: "no host", url: "https:///api/stats", wantErr: true},
+		{name: "empty", url: "", wantErr: true},
+		{name: "not a url", url: "://nope", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkStatsURL(tc.url)
+			if tc.wantErr && err == nil {
+				t.Errorf("checkStatsURL(%q) = nil, want an error", tc.url)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("checkStatsURL(%q) = %v, want nil", tc.url, err)
+			}
+		})
+	}
+}
+
+// liveBuildSHA must refuse before it sends anything, not after.
+func TestLiveBuildSHA_RefusesABadURLWithoutDialling(t *testing.T) {
+	if _, err := liveBuildSHA(context.Background(), "http://example.test/api/stats", "s3cret"); err == nil {
+		t.Error("liveBuildSHA accepted plain http to a remote host")
+	}
 }

--- a/tools/pingdrift/main_test.go
+++ b/tools/pingdrift/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -241,5 +242,118 @@ func TestCheckStatsURL(t *testing.T) {
 func TestLiveBuildSHA_RefusesABadURLWithoutDialling(t *testing.T) {
 	if _, err := liveBuildSHA(context.Background(), "http://example.test/api/stats", "s3cret"); err == nil {
 		t.Error("liveBuildSHA accepted plain http to a remote host")
+	}
+}
+
+// run is the whole path the workflow takes, so it is worth exercising end to
+// end against a stub rather than leaving it as untested glue.
+func TestRun(t *testing.T) {
+	const pinned = "23586cd355e40700e2b60e8d9344ba4e2afd3cb3"
+
+	// writeManifest returns a path to a manifest pinning the given sha.
+	writeManifest := func(t *testing.T, sha string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "telemetry-server.yaml")
+		body := "        containers:\n          - name: ping\n            image: ghcr.io/vavallee/bindery-ping:sha-" + sha + "\n"
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		return p
+	}
+	// stub serves the given build_sha on any authorised request.
+	stub := func(t *testing.T, sha string) string {
+		t.Helper()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"build_sha": sha})
+		}))
+		t.Cleanup(srv.Close)
+		return srv.URL
+	}
+
+	t.Run("in step", func(t *testing.T) {
+		t.Setenv("PING_MANIFEST", writeManifest(t, pinned))
+		t.Setenv("PING_STATS_URL", stub(t, pinned))
+		t.Setenv("TELEMETRY_STATS_TOKEN", "s3cret")
+
+		var out strings.Builder
+		if err := run(context.Background(), &out); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if !strings.Contains(out.String(), "in step") {
+			t.Errorf("output = %q, want it to say the deployment is in step", out.String())
+		}
+	})
+
+	t.Run("drift names the remedy", func(t *testing.T) {
+		manifest := writeManifest(t, pinned)
+		t.Setenv("PING_MANIFEST", manifest)
+		t.Setenv("PING_STATS_URL", stub(t, "d2aee75fb3c9e49e8639d7016e73c4533d1e5af6"))
+		t.Setenv("TELEMETRY_STATS_TOKEN", "s3cret")
+
+		var out strings.Builder
+		err := run(context.Background(), &out)
+		if err == nil {
+			t.Fatal("run = nil, want a drift error")
+		}
+		// The person reading a red nightly job needs the command, not just
+		// the fact. This is the whole value of the check.
+		if !strings.Contains(err.Error(), "kubectl apply -f "+manifest) {
+			t.Errorf("err = %v, want it to name the kubectl command and the manifest", err)
+		}
+	})
+
+	t.Run("an unstamped running build is drift", func(t *testing.T) {
+		t.Setenv("PING_MANIFEST", writeManifest(t, pinned))
+		t.Setenv("PING_STATS_URL", stub(t, "unknown"))
+		t.Setenv("TELEMETRY_STATS_TOKEN", "s3cret")
+
+		var out strings.Builder
+		if err := run(context.Background(), &out); err == nil {
+			t.Error("run = nil for a build reporting \"unknown\", want drift")
+		}
+	})
+
+	t.Run("a missing token is an error, not a pass", func(t *testing.T) {
+		t.Setenv("PING_MANIFEST", writeManifest(t, pinned))
+		t.Setenv("PING_STATS_URL", stub(t, pinned))
+		t.Setenv("TELEMETRY_STATS_TOKEN", "")
+
+		var out strings.Builder
+		err := run(context.Background(), &out)
+		if err == nil {
+			t.Fatal("run = nil with no token, want an error")
+		}
+		if !strings.Contains(err.Error(), "TELEMETRY_STATS_TOKEN") {
+			t.Errorf("err = %v, want it to name the missing variable", err)
+		}
+	})
+
+	t.Run("a missing manifest is an error", func(t *testing.T) {
+		t.Setenv("PING_MANIFEST", filepath.Join(t.TempDir(), "absent.yaml"))
+		t.Setenv("PING_STATS_URL", stub(t, pinned))
+		t.Setenv("TELEMETRY_STATS_TOKEN", "s3cret")
+
+		var out strings.Builder
+		if err := run(context.Background(), &out); err == nil {
+			t.Error("run = nil for a manifest that does not exist, want an error")
+		}
+	})
+
+	// The default is the real endpoint, so a test that forgets to set
+	// PING_STATS_URL must not reach out over the network.
+	t.Run("the default stats URL is the production endpoint", func(t *testing.T) {
+		t.Setenv("PING_STATS_URL", "")
+		if got := env("PING_STATS_URL", "https://api.getbindery.dev/api/stats"); got != "https://api.getbindery.dev/api/stats" {
+			t.Errorf("default = %q", got)
+		}
+	})
+}
+
+func TestOrPlaceholder(t *testing.T) {
+	if got := orPlaceholder(""); got != "<absent>" {
+		t.Errorf("orPlaceholder(\"\") = %q, want %q", got, "<absent>")
+	}
+	if got := orPlaceholder("abc1234"); got != "abc1234" {
+		t.Errorf("orPlaceholder(%q) = %q, want it unchanged", "abc1234", got)
 	}
 }


### PR DESCRIPTION
## What went wrong

`deploy/telemetry-server.yaml` pinned bindery-ping to `sha-23586cd3`, the #1521 build from **2026-07-11**. main had since shipped the `new_install` ping log (#2155, 2026-08-21), the Debian 13 base and `x/crypto` v0.56.0 (#2425).

| | running | main |
|---|---|---|
| base | `distroless/static-debian12` (EOL 2026-06-30) | `distroless/static-debian13` |
| `x/crypto` | v0.53.0 | v0.56.0 |
| `new_install` ping log | absent | present |

So `api.getbindery.dev` served an end of life base with two High advisories for weeks, and the way it surfaced was someone grepping pod logs for a line that could not be in that build.

Bumping the pin fixes today and nothing else. Three separate things were wrong.

## 1. The running build was unobservable

`/health` returns a bare 200 with no body and the binary carried no version, so there was no way to ask the service which image it was.

`buildSHA` is now stamped with `-X main.buildSHA=` at image build time from a `BUILD_SHA` build arg, logged on startup, and reported on `/api/stats`.

On the **token gated** endpoint, not public `/health`, on purpose: a public exact build sha tells a stranger precisely which advisories apply, and the only consumer already holds `TELEMETRY_STATS_TOKEN`.

## 2. The pin was moved by hand exactly once

`a91386de` set it and nothing moved it again. The Ping Server workflow now writes it after pushing the image, using the same branch, PR and admin merge shape as `deploy-prod`, so `kubectl apply -f deploy/telemetry-server.yaml` always applies the image the last build pushed.

`[skip ci]` sits in the squash subject rather than the branch commit, for the reason `deploy-prod` already documents in `ci.yml`: required checks have to run on the PR head or the merge is blocked forever.

## 3. Nothing compared the container against the repo

`ping-drift.yml` asks the live server for its build sha daily and fails when it does not match the pin on main. A build predating the stamping reports `unknown` and is treated as drift, which is correct: it is by definition older than the change that added the field.

## What this does not do

It does not deploy. That host is not in the ArgoCD application, which tracks `charts/bindery` only, and CI has no kubectl or SSH to it, just an HTTPS token. Applying stays manual. The check turns a six week gap into a next morning failure.

**The pin is deliberately untouched here.** Merging this triggers the Ping Server workflow, which builds an image that has the stamping and writes the pin itself. Hand bumping now would pin a build that reports `unknown` and make the first drift run confusing.

**After merging, the deploy is yours:** `kubectl apply -f deploy/telemetry-server.yaml` on the ping host. Until then the drift check will fail daily, correctly.

## Verification

Built the image with `--build-arg BUILD_SHA=testsha1234567`, copied the binary out of it and ran it:

```
INFO telemetry-server starting addr=:18099 latest=v1.4.3 build=testsha1234567
```

Two new tests cover the field the drift check reads and the unstamped default. `go vet` and the full `cmd/telemetry-server` suite pass. Both workflow files parse as YAML and the new shell block passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP