### PR TITLE
feat(web): monitor toggle on the book detail page (#2417)

### DIFF
--- a/changelog.d/2417-book-page-monitor-toggle.md
+++ b/changelog.d/2417-book-page-monitor-toggle.md
@@ -1,0 +1,2 @@
+### Added
+- **Monitor toggle on the book page** (#2417) — a book's monitored state can now be flipped from its own page, next to the status badge. Previously the page showed the state but you had to go back to the Books list and use the bulk Monitor / Unmonitor action to change it.

--- a/docs/User-Guide-Wiki.md
+++ b/docs/User-Guide-Wiki.md
@@ -76,7 +76,9 @@ Separately, every book is **monitored** or not. Monitored means "Bindery
 actively pursues this." The **Wanted page** — and the automatic search sweep —
 only covers books that are *all three of*: status `wanted`, monitored, and not
 excluded. A book that is `wanted` but unmonitored shows as "Not monitored" and
-is left alone.
+is left alone. Flip a single book from the switch next to the status badge on
+its own page, or many at once from the Books list (select, then **Monitor** /
+**Unmonitor**).
 
 Two related labels:
 

--- a/web/src/components/Switch.tsx
+++ b/web/src/components/Switch.tsx
@@ -8,6 +8,8 @@ interface SwitchProps {
   /** Optional visible text rendered next to the switch. */
   children?: ReactNode
   title?: string
+  /** Blocks clicks while an in-flight save is settling. */
+  disabled?: boolean
   className?: string
 }
 
@@ -16,7 +18,7 @@ interface SwitchProps {
 // sliding affordance is the whole point: a badge and a toggle must not look
 // alike, or users can't tell which pills they can click. Track/knob sizing
 // matches the original inline switch on the Series page.
-export default function Switch({ checked, onChange, label, children, title, className = '' }: SwitchProps) {
+export default function Switch({ checked, onChange, label, children, title, disabled = false, className = '' }: SwitchProps) {
   return (
     <button
       type="button"
@@ -25,7 +27,8 @@ export default function Switch({ checked, onChange, label, children, title, clas
       aria-label={label}
       title={title ?? label}
       onClick={onChange}
-      className={`group inline-flex items-center gap-2 focus-visible:outline-none ${className}`}
+      disabled={disabled}
+      className={`group inline-flex items-center gap-2 focus-visible:outline-none disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
     >
       <span
         className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 group-focus-visible:ring-2 group-focus-visible:ring-emerald-500 group-focus-visible:ring-offset-1 group-focus-visible:ring-offset-slate-100 dark:group-focus-visible:ring-offset-zinc-900 ${checked ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -1069,3 +1069,49 @@ describe('BookDetailPage metadata source (#1707)', () => {
     expect(within(rows[1]).queryByText('Current')).not.toBeInTheDocument()
   })
 })
+
+describe('BookDetailPage — monitor toggle (#2417)', () => {
+  it('renders a switch carrying the monitored state', async () => {
+    renderBookDetailPage()
+    const toggle = await screen.findByRole('switch', { name: 'Unmonitor' })
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('unmonitors a monitored book and reflects it in the status badge', async () => {
+    renderBookDetailPage()
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Unmonitor' }))
+
+    await waitFor(() => expect(api.updateBook).toHaveBeenCalledWith(42, { monitored: false }))
+    expect(await screen.findByRole('switch', { name: 'Monitor' })).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByText('Not monitored')).toBeInTheDocument()
+  })
+
+  it('monitors an unmonitored book', async () => {
+    vi.mocked(api.getBook).mockResolvedValue(makeBook({ monitored: false }))
+    renderBookDetailPage()
+
+    const toggle = await screen.findByRole('switch', { name: 'Monitor' })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(api.updateBook).toHaveBeenCalledWith(42, { monitored: true }))
+    expect(await screen.findByRole('switch', { name: 'Unmonitor' })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('disables the switch while the update is in flight, so one click sends one PUT', async () => {
+    let settle: ((book: Book) => void) | undefined
+    vi.mocked(api.updateBook).mockImplementation(() => new Promise<Book>(resolve => { settle = resolve }))
+
+    renderBookDetailPage()
+    const toggle = await screen.findByRole('switch', { name: 'Unmonitor' })
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(toggle).toBeDisabled())
+    fireEvent.click(toggle)
+    expect(api.updateBook).toHaveBeenCalledTimes(1)
+
+    await act(async () => { settle?.(makeBook({ monitored: false })) })
+    expect(await screen.findByRole('switch', { name: 'Monitor' })).toBeEnabled()
+  })
+})

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -7,6 +7,7 @@ import CoverPlaceholder from '../components/CoverPlaceholder'
 import MarkdownDescription from '../components/MarkdownDescription'
 import MoreMenu from '../components/MoreMenu'
 import Section from '../components/Section'
+import Switch from '../components/Switch'
 import { btn, btnSize } from '../components/buttons'
 import MediaBadge from '../components/MediaBadge'
 import { bookStatusBadge } from '../components/bookStatus'
@@ -624,6 +625,17 @@ export default function BookDetailPage() {
                 </span>
               )
             })()}
+            {/* The badge only reports monitoring; changing it meant going back
+                to the Books list and using the bulk action (#2417). No state
+                text next to the switch — the badge already carries it, and the
+                label matches the list's Monitor / Unmonitor wording. */}
+            <Switch
+              checked={book.monitored}
+              onChange={() => saveField({ monitored: !book.monitored })}
+              label={book.monitored ? t('common.unmonitor') : t('common.monitor')}
+              disabled={saving}
+              className="px-1"
+            />
             {book.excluded && (
               <span className="inline-flex items-center px-2 py-0.5 rounded font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
                 {t('bookDetail.excludedBadge')}


### PR DESCRIPTION
## Summary

The book page showed whether a book was monitored but gave no way to change it — you had to go
back to the Books list and use the bulk **Monitor** / **Unmonitor** action, or use the Wanted
page's one-way "stop monitoring". This adds a toggle next to the status badge on the book page.

As #2417 notes, the plumbing already existed: `PUT /api/v1/book/{id}` accepts `monitored`, and
`BookDetailPage` already has the generic `saveField` helper wired to it. So this is a control
calling `saveField({ monitored: !book.monitored })`, built from the existing `Switch` component.

- No new i18n keys — the accessible label reuses `common.monitor` / `common.unmonitor`, the same
  strings the Books-list bulk action uses, so the two surfaces can't drift.
- No visible state text on the switch: the status badge immediately to its left already renders
  "Not monitored".
- `Switch` gains an optional `disabled` prop (default `false`, so the four existing call sites are
  unaffected), used here to grey the control out while the save is in flight — matching the
  media-type select further down the page and stopping a double click from sending two PUTs.

I did not add a manual "set to wanted" status setter; the issue says derived status should stay
derived.

Placement follows the issue's wording ("next to the status badge"), so the toggle sits in the
header metadata row. If you would rather have it in a separate actions row like the author and
series pages, that is an 8-line move with no logic change — happy to do it.

Closes #2417

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated — 4 vitest cases in `BookDetailPage.test.tsx` (state reflected in the
      switch, unmonitor updates the badge, monitor from the unmonitored state, one click = one PUT)
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed — n/a
- [x] Added a changelog fragment under `changelog.d/`
- [ ] Wiki pages updated if user-facing behaviour changed — the in-repo mirror
      `docs/User-Guide-Wiki.md` is updated here; tell me if you want the GitHub wiki updated too

## Test plan

- [x] `cd web && npm ci && npm run lint && npm run typecheck && npm run build && npm test`
      — lint 0 errors (6 pre-existing warnings in untouched files), typecheck clean, build clean,
      793/793 tests pass
- [x] `go build ./cmd/bindery` as a smoke check — this diff contains no Go code, so the Go half of
      `make check` was not run
- [ ] No visual check yet — the environment used has no browser, so placement in the metadata row
      at narrow widths is the one thing worth eyeballing in review

Note: `src/pages/HistoryPage.test.tsx` ("fetches later pages", #1467) flaked once under a full
parallel run and passed both in isolation and on a clean re-run of the whole suite. Unrelated to
this change, but you may see it go red intermittently.

This change was developed with AI assistance (Claude Code); the checks listed above were run on
this exact branch.
