### PR TITLE
fix(indexer): read the ampersand as a word, not as punctuation (#1660)

### DIFF
--- a/changelog.d/1660-dedup-character-classes.md
+++ b/changelog.d/1660-dedup-character-classes.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Books written with `&` and with `and` are no longer treated as two different books** (#1660) — the key that decides whether two records are the same edition treated an ampersand as punctuation and dropped it, so *Foundation & Empire* keyed as "foundation empire" and *Foundation and Empire* as "foundation and empire". Providers disagree about which form to send, so the same book could be added twice and a release named with one spelling would not match a book stored with the other. An ampersand is now read as the word it stands for.
+- **Authors whose names arrive in full-width or ligature form no longer duplicate** (#1660) — some catalogues send *Ｈａｒｕｋｉ　Ｍｕｒａｋａｍｉ* or a name containing a typographic ligature. Those forms did not compare equal to the ordinary spelling, so the same author could be created twice depending on which source a record came from.
+
+### Changed
+- **Existing libraries repair their book comparison keys once on the first start after upgrading** (#1660) — the ampersand change alters the stored key for any title containing one, so the keys are recomputed on the next boot. This is a single pass and is not repeated.

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2372,8 +2372,13 @@ var titleStopwords = map[string]bool{
 	"and": true, "in": true, "to": true, "for": true,
 }
 
-// titleSigTokens returns the significant (2+ char, non-stopword) tokens of a
-// title, reduced through the shared title-comparison alphabet.
+// titleSigTokens returns the significant (long enough, non-stopword) tokens of
+// a title, reduced through the shared title-comparison alphabet.
+//
+// The floor is two BYTES of UTF-8, not two characters, and like the three-byte
+// one in newznab.SigWords that is deliberate: it scales the character
+// requirement by how much a script packs into a character. Do not rewrite it as
+// a rune count; see SigWords for what that would break.
 //
 // This used to keep only [a-z0-9] and treat every other rune as a separator,
 // which quietly destroyed non-ASCII titles: "Die Höhle" tokenised to

--- a/internal/indexer/dedup.go
+++ b/internal/indexer/dedup.go
@@ -59,8 +59,17 @@ func NormalizeTitleForDedup(title string) string {
 //     forms) are INTRA-word and are DELETED, so "Poseidon's Arrow" folds onto
 //     "Poseidons Arrow". Replacing them with a space instead yields
 //     "poseidon s arrow", which matches neither spelling.
+//   - An ampersand is a SPELLING of the word "and", not punctuation, so it
+//     expands rather than separating. "Foundation & Empire" and "Foundation
+//     and Empire" are the same book and providers disagree about which form to
+//     send; as a separator they produced "foundation empire" and "foundation
+//     and empire" and never met. beets makes the same call in its own
+//     string_dist. Note this is deliberately NOT done in
+//     textutil.FoldForTitleMatch, which feeds ContainsPhrase: that alphabet
+//     needs its keywords contiguous, and an injected "and" token would break
+//     every phrase hit on a release named "Foundation.&.Empire".
 //   - Every other non-alphanumeric rune (colon, hyphen, comma, '#', em dash,
-//     ampersand, …) is a SEPARATOR and becomes a space. This is what lets
+//     …) is a SEPARATOR and becomes a space. This is what lets
 //     "Journey of the Pharaohs: Numa Files #17" and
 //     "Journey of the Pharaohs Numa Files #17" produce one key: the colon
 //     stops being a distinction rather than becoming a truncation point.
@@ -73,8 +82,12 @@ func foldPunctuation(title string) string {
 	b.Grow(len(title))
 	for _, r := range title {
 		switch {
-		case isApostrophe(r):
+		case textutil.IsApostrophe(r):
 			// Deleted, not replaced — see the doc comment.
+		case r == '&':
+			// Expanded, not separated — see the doc comment. The spaces are
+			// unconditional; strings.Fields collapses whatever they duplicate.
+			b.WriteString(" and ")
 		case unicode.IsLetter(r) || unicode.IsDigit(r):
 			b.WriteRune(r)
 		default:
@@ -82,14 +95,6 @@ func foldPunctuation(title string) string {
 		}
 	}
 	return strings.Join(strings.Fields(b.String()), " ")
-}
-
-func isApostrophe(r rune) bool {
-	switch r {
-	case '\'', '`', '‘', '’', 'ʼ':
-		return true
-	}
-	return false
 }
 
 // bracketSuffixRe matches one trailing square-bracketed qualifier. Provider
@@ -143,7 +148,10 @@ func CanonicalDedupKey(title string) string {
 // a bump leaves existing rows on the old key with nothing to correct them,
 // which is the asymmetry #940 and #2042 were both about. Bumping when nothing
 // changed costs one extra table scan, so when in doubt, bump.
-const CanonicalDedupKeyRev = 1
+// Revision 2 expanded the ampersand to " and " in foldPunctuation, which
+// changes the key for every title containing one. Stored books.dedup_key
+// values hold revision 1, so the bump is what makes the next boot repair them.
+const CanonicalDedupKeyRev = 2
 
 // MainTitleKey is the canonical key of the title with any ": subtitle" tail
 // removed. It is the BLOCKING key: two rows for the same work always share it,

--- a/internal/indexer/dedup_test.go
+++ b/internal/indexer/dedup_test.go
@@ -157,3 +157,53 @@ func TestNormalizeTitleForDedup_Symmetric(t *testing.T) {
 		}
 	}
 }
+
+// TestNormalizeTitleForDedupExpandsAmpersand pins the ampersand as a spelling
+// of "and" rather than as punctuation. Providers disagree about which form to
+// send for the same book, and as a separator the two spellings produced
+// "foundation empire" and "foundation and empire", which could never meet.
+func TestNormalizeTitleForDedupExpandsAmpersand(t *testing.T) {
+	pairs := [][2]string{
+		{"Foundation & Empire", "Foundation and Empire"},
+		{"Sense & Sensibility", "Sense and Sensibility"},
+		{"Q&A", "Q and A"},
+		{"Crime & Punishment: A Novel", "Crime and Punishment: A Novel"},
+	}
+	for _, p := range pairs {
+		got, want := NormalizeTitleForDedup(p[0]), NormalizeTitleForDedup(p[1])
+		if got != want {
+			t.Errorf("NormalizeTitleForDedup(%q) = %q, NormalizeTitleForDedup(%q) = %q; the two spellings must produce one key",
+				p[0], got, p[1], want)
+		}
+	}
+
+	// The expansion must not weld its neighbours together, which is what a bare
+	// deletion would have done: "Q&A" has to become three tokens, not "qa".
+	if got := NormalizeTitleForDedup("Q&A"); got != "q and a" {
+		t.Errorf("NormalizeTitleForDedup(%q) = %q, want %q", "Q&A", got, "q and a")
+	}
+
+	// And a title with no ampersand is untouched, so the change cannot move a
+	// key it has no business moving.
+	if got := NormalizeTitleForDedup("The Hobbit"); got != "the hobbit" {
+		t.Errorf("NormalizeTitleForDedup(%q) = %q, want %q", "The Hobbit", got, "the hobbit")
+	}
+}
+
+// TestFoldPunctuationUsesTheSharedApostropheSet guards the delegation to
+// textutil.IsApostrophe. The two sets were identical when this file stopped
+// keeping its own copy, and the point of the delegation is that they cannot
+// drift apart again.
+func TestFoldPunctuationUsesTheSharedApostropheSet(t *testing.T) {
+	for _, spelling := range []string{
+		"Poseidon's Arrow",  // ASCII
+		"Poseidon’s Arrow", // right single quotation mark
+		"Poseidon‘s Arrow", // left single quotation mark
+		"Poseidon`s Arrow",  // backtick
+		"Poseidonʼs Arrow", // modifier letter apostrophe
+	} {
+		if got := NormalizeTitleForDedup(spelling); got != "poseidons arrow" {
+			t.Errorf("NormalizeTitleForDedup(%q) = %q, want %q", spelling, got, "poseidons arrow")
+		}
+	}
+}

--- a/internal/indexer/dedup_test.go
+++ b/internal/indexer/dedup_test.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"testing"
 
+	"github.com/vavallee/bindery/internal/indexer/newznab"
 	"github.com/vavallee/bindery/internal/textutil"
 )
 
@@ -217,10 +218,15 @@ func TestFoldPunctuationUsesTheSharedApostropheSet(t *testing.T) {
 // that anyone setting out to "fix" the inconsistency finds the reason first.
 //
 // CanonicalDedupKey expands "&" to " and " because it answers "are these the
-// same book", and providers send both spellings for one book. FoldForTitleMatch
-// leaves it a separator because it feeds ContainsPhrase, which requires the
-// keywords contiguous: an injected "and" token would break every phrase hit on
-// a release named "Foundation.&.Empire".
+// same book", and providers send both spellings for one book.
+//
+// FoldForTitleMatch must not, and the reason is subtler than it first looks.
+// Both the phrase and the haystack fold through it, so expanding on both sides
+// would be symmetric and would cost nothing by itself. What breaks is that the
+// keyword side additionally drops "and" as a stop word and the haystack side
+// does not, while phraseRegex joins its parts with a separator run that no
+// letter may interrupt. TestAmpersandPhraseAsymmetry measures that rather than
+// arguing it.
 //
 // The two are safe only as long as no caller compares a key from one against a
 // key from the other. Nothing does today.
@@ -242,5 +248,50 @@ func TestDedupAndTitleMatchAlphabetsDifferOnAmpersand(t *testing.T) {
 	if dedup == match {
 		t.Errorf("the dedup and title-match alphabets agree on %q (%q); they are meant to differ, and a caller comparing across them would now silently pass",
 			title, dedup)
+	}
+}
+
+// TestAmpersandPhraseAsymmetry is the evidence behind the rule that alphabet 1
+// must not expand "&", and it is here because the obvious argument for that
+// rule is wrong. The phrase and the haystack both fold through
+// FoldForTitleMatch, so an expansion would be symmetric; symmetry is not what
+// saves the match.
+//
+// The asymmetry is the stop word list. SigWords drops "and" from the keywords
+// and nothing drops it from the haystack, so an expanded haystack gains a word
+// the phrase cannot account for, and phraseRegex admits only separators
+// between its parts.
+//
+// The second assertion records a live false negative that is nobody's
+// regression: a release spelling the word out is already missed today.
+func TestAmpersandPhraseAsymmetry(t *testing.T) {
+	kws := newznab.SigWords("Foundation & Empire")
+	if len(kws) != 2 || kws[0] != "foundation" || kws[1] != "empire" {
+		t.Fatalf(`SigWords("Foundation & Empire") = %q, want ["foundation" "empire"]; "and" is a stop word on this side and that is the whole point`, kws)
+	}
+	if got := newznab.SigWords("Foundation and Empire"); len(got) != 2 {
+		t.Errorf(`SigWords("Foundation and Empire") = %q, want two tokens; both spellings must reduce to the same phrase`, got)
+	}
+
+	// What the haystack looks like today, and what it would look like if
+	// alphabet 1 expanded the ampersand.
+	const today = "foundation empire 1952 retail epub grp"
+	const ifExpanded = "foundation and empire 1952 retail epub grp"
+
+	if got := NormalizeRelease("Foundation.&.Empire.1952.RETAIL.EPUB-GRP"); got != today {
+		t.Fatalf("NormalizeRelease = %q, want %q", got, today)
+	}
+	if !ContainsPhrase(today, kws) {
+		t.Error("the ampersand release stopped matching its own phrase; alphabet 1 must be leaving & as a separator")
+	}
+	if ContainsPhrase(ifExpanded, kws) {
+		t.Error(`an expanded haystack still matched [foundation empire]; if this ever passes, the stop word asymmetry is gone and alphabet 1 could expand "&" after all`)
+	}
+
+	// Live false negative, recorded so it is not mistaken for damage done by
+	// the dedup change. A release spelling the word out is missed regardless of
+	// which spelling the user asked for, because "and" interrupts the phrase.
+	if ContainsPhrase(ifExpanded, newznab.SigWords("Foundation and Empire")) {
+		t.Error("a release named \"Foundation and Empire\" now matches; if this passes, the miss recorded here has been fixed and this assertion should become the positive one")
 	}
 }

--- a/internal/indexer/dedup_test.go
+++ b/internal/indexer/dedup_test.go
@@ -196,10 +196,10 @@ func TestNormalizeTitleForDedupExpandsAmpersand(t *testing.T) {
 // drift apart again.
 func TestFoldPunctuationUsesTheSharedApostropheSet(t *testing.T) {
 	for _, spelling := range []string{
-		"Poseidon's Arrow",  // ASCII
+		"Poseidon's Arrow", // ASCII
 		"Poseidon’s Arrow", // right single quotation mark
 		"Poseidon‘s Arrow", // left single quotation mark
-		"Poseidon`s Arrow",  // backtick
+		"Poseidon`s Arrow", // backtick
 		"Poseidonʼs Arrow", // modifier letter apostrophe
 	} {
 		if got := NormalizeTitleForDedup(spelling); got != "poseidons arrow" {

--- a/internal/indexer/dedup_test.go
+++ b/internal/indexer/dedup_test.go
@@ -1,6 +1,10 @@
 package indexer
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/textutil"
+)
 
 func TestNormalizeTitleForDedup(t *testing.T) {
 	cases := []struct {
@@ -205,5 +209,38 @@ func TestFoldPunctuationUsesTheSharedApostropheSet(t *testing.T) {
 		if got := NormalizeTitleForDedup(spelling); got != "poseidons arrow" {
 			t.Errorf("NormalizeTitleForDedup(%q) = %q, want %q", spelling, got, "poseidons arrow")
 		}
+	}
+}
+
+// TestDedupAndTitleMatchAlphabetsDifferOnAmpersand pins a deliberate
+// disagreement between two alphabets that otherwise look interchangeable, so
+// that anyone setting out to "fix" the inconsistency finds the reason first.
+//
+// CanonicalDedupKey expands "&" to " and " because it answers "are these the
+// same book", and providers send both spellings for one book. FoldForTitleMatch
+// leaves it a separator because it feeds ContainsPhrase, which requires the
+// keywords contiguous: an injected "and" token would break every phrase hit on
+// a release named "Foundation.&.Empire".
+//
+// The two are safe only as long as no caller compares a key from one against a
+// key from the other. Nothing does today.
+func TestDedupAndTitleMatchAlphabetsDifferOnAmpersand(t *testing.T) {
+	const title = "Foundation & Empire"
+
+	dedup := NormalizeTitleForDedup(title)
+	if dedup != "foundation and empire" {
+		t.Errorf("NormalizeTitleForDedup(%q) = %q, want %q — the dedup alphabet must expand the ampersand so both provider spellings share a key",
+			title, dedup, "foundation and empire")
+	}
+
+	match := textutil.FoldForTitleMatch(title)
+	if match != "foundation empire" {
+		t.Errorf("FoldForTitleMatch(%q) = %q, want %q — the match alphabet must leave the ampersand a separator, or ContainsPhrase stops finding \"Foundation.&.Empire\"",
+			title, match, "foundation empire")
+	}
+
+	if dedup == match {
+		t.Errorf("the dedup and title-match alphabets agree on %q (%q); they are meant to differ, and a caller comparing across them would now silently pass",
+			title, dedup)
 	}
 }

--- a/internal/indexer/newznab/words.go
+++ b/internal/indexer/newznab/words.go
@@ -17,7 +17,18 @@ var stopWords = map[string]bool{
 	"as": true, "on": true, "be": true,
 }
 
-// SigWords returns the meaningful (non-stop, 3+ char) words from s.
+// SigWords returns the meaningful (non-stop, long enough) words from s.
+//
+// "Long enough" is three BYTES of UTF-8, not three characters, and that is
+// deliberate even though it reads like an oversight. The byte threshold scales
+// the character requirement by how much a script packs into one character:
+// three ASCII letters, two Cyrillic or Greek letters, or one CJK ideograph.
+// That matches how much a token actually narrows a search in each script.
+//
+// Do not "fix" this into a rune count. Requiring three runes drops "Мы"
+// (Zamyatin's We) to no significant tokens at all, and requiring one drops the
+// floor under single Cyrillic and Greek letters, which are as weak as single
+// English ones. TestSigWordsThresholdScalesWithScript pins the cases.
 //
 // Tokenisation is kept symmetric with NormalizeRelease
 // (internal/indexer/release.go): both strip apostrophes, transliterate German

--- a/internal/indexer/unicode_boundary_test.go
+++ b/internal/indexer/unicode_boundary_test.go
@@ -173,3 +173,42 @@ func TestNonASCIISigWordsSurviveTokenization(t *testing.T) {
 		t.Errorf(`SigWords("Ölümün Sonu") = %v, want 2 tokens`, got)
 	}
 }
+
+// TestSigWordsThresholdScalesWithScript pins the byte threshold in SigWords,
+// which reads like a bug and is not one. Three bytes of UTF-8 means three
+// ASCII letters, two Cyrillic or Greek letters, or one CJK ideograph, which is
+// roughly how much each has to be worth before it narrows a search.
+//
+// This test exists because the obvious "fix" is to count runes, and both
+// obvious rune rules are worse than what is here. A three-rune floor empties
+// "Мы" (Zamyatin's We) of every significant token, so no release could match
+// it. A one-rune floor keeps single Cyrillic and Greek letters, which carry no
+// more than a single English letter and would make matching needlessly strict.
+func TestSigWordsThresholdScalesWithScript(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+		why  string
+	}{
+		{"三体", []string{"三体"}, "two Han characters are a whole title"},
+		{"刘慈欣", []string{"刘慈欣"}, "a three-character Chinese name"},
+		{"Мы", []string{"мы"}, "a real two-letter Cyrillic title; a three-rune floor would lose it"},
+		{"Война и мир", []string{"война", "мир"}, "the one-letter Cyrillic conjunction drops, as a one-letter English one would"},
+		{"ハリー・ポッター", []string{"ハリー", "ポッター"}, "the katakana middle dot separates"},
+		{"이방인", []string{"이방인"}, "Hangul"},
+		{"The Hobbit", []string{"hobbit"}, "ASCII stopword removed, three-letter floor applies"},
+	}
+	for _, c := range cases {
+		got := newznab.SigWords(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("SigWords(%q) = %q, want %q (%s)", c.in, got, c.want, c.why)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("SigWords(%q) = %q, want %q (%s)", c.in, got, c.want, c.why)
+				break
+			}
+		}
+	}
+}

--- a/internal/textutil/author.go
+++ b/internal/textutil/author.go
@@ -11,8 +11,15 @@ import (
 // NormalizeAuthorName lower-cases the name, strips punctuation/diacritics-adjacent
 // characters, and collapses whitespace. Returned form is suitable for key-style
 // equality comparisons but still preserves token spacing.
+//
+// The decomposition is NFKD rather than NFD, so the compatibility forms fold
+// too. Providers and scraped catalogues carry full-width Latin ("Ｍｕｒａｋａｍｉ")
+// and typographic ligatures ("ﬁ"), which NFD leaves alone and which therefore
+// used to key as a different author from the ordinary spelling. NFKD is lossy,
+// but this is a comparison key and never a displayed value, which is the
+// condition UAX #15 attaches to using a compatibility form at all.
 func NormalizeAuthorName(name string) string {
-	name = norm.NFD.String(strings.TrimSpace(name))
+	name = norm.NFKD.String(strings.TrimSpace(name))
 	if name == "" {
 		return ""
 	}

--- a/internal/textutil/author_test.go
+++ b/internal/textutil/author_test.go
@@ -147,3 +147,28 @@ func TestMatchAuthorNameStillRejectsDistinctAuthors(t *testing.T) {
 		}
 	}
 }
+
+// TestNormalizeAuthorNameFoldsCompatibilityForms covers the move from NFD to
+// NFKD. Providers and scraped catalogues carry full-width Latin and
+// typographic ligatures, which NFD leaves standing, so the same author keyed
+// two different ways depending on which source the record came from.
+func TestNormalizeAuthorNameFoldsCompatibilityForms(t *testing.T) {
+	cases := []struct{ full, plain string }{
+		{"Ｈａｒｕｋｉ　Ｍｕｒａｋａｍｉ", "Haruki Murakami"},
+		{"ﬁona ﬂeming", "fiona fleming"},
+		{"Ｊｏｒｇｅ Ｌｕｉｓ Ｂｏｒｇｅｓ", "Jorge Luis Borges"},
+	}
+	for _, c := range cases {
+		got, want := NormalizeAuthorName(c.full), NormalizeAuthorName(c.plain)
+		if got != want {
+			t.Errorf("NormalizeAuthorName(%q) = %q, NormalizeAuthorName(%q) = %q; compatibility forms must fold onto the plain spelling",
+				c.full, got, c.plain, want)
+		}
+	}
+
+	// The ordinary path is unchanged: this must stay a diacritic-stripping,
+	// lower-casing, space-collapsing key.
+	if got := NormalizeAuthorName("  Jörg   Müller  "); got != "jorg muller" {
+		t.Errorf("NormalizeAuthorName = %q, want %q", got, "jorg muller")
+	}
+}

--- a/internal/textutil/fold.go
+++ b/internal/textutil/fold.go
@@ -30,6 +30,20 @@ import (
 //     Used by indexer.NormalizeRelease, newznab.SigWords, importer title
 //     matching. Producers and consumers of a title comparison MUST share it.
 //
+//  1a. EDITION DEDUP — indexer.CanonicalDedupKey / NormalizeTitleForDedup.
+//     Alphabet (1)'s sibling, and the one place the two deliberately DISAGREE:
+//     an ampersand EXPANDS to " and " here and is a SEPARATOR in (1). That is
+//     not an oversight to tidy up. Dedup asks "are these the same book", and
+//     providers send "Foundation & Empire" and "Foundation and Empire" for one
+//     book, so the two spellings must produce one key. Alphabet (1) feeds
+//     indexer.ContainsPhrase, which requires its keywords contiguous, and an
+//     injected "and" token would break every phrase hit on a release named
+//     "Foundation.&.Empire".
+//     Nothing may compare a key from (1) against a key from (1a). Today
+//     nothing does: every caller stays inside one or the other. Before making
+//     them agree, read TestDedupAndTitleMatchAlphabetsDifferOnAmpersand, which
+//     exists to explain why they do not.
+//
 //  2. AUTHOR IDENTITY — NormalizeAuthorName (author.go).
 //     Diacritics are STRIPPED (ö→o) rather than expanded, because author names
 //     arrive from providers in every romanisation and the goal is one identity

--- a/internal/textutil/fold.go
+++ b/internal/textutil/fold.go
@@ -35,10 +35,16 @@ import (
 //     an ampersand EXPANDS to " and " here and is a SEPARATOR in (1). That is
 //     not an oversight to tidy up. Dedup asks "are these the same book", and
 //     providers send "Foundation & Empire" and "Foundation and Empire" for one
-//     book, so the two spellings must produce one key. Alphabet (1) feeds
-//     indexer.ContainsPhrase, which requires its keywords contiguous, and an
-//     injected "and" token would break every phrase hit on a release named
-//     "Foundation.&.Empire".
+//     book, so the two spellings must produce one key.
+//     Alphabet (1) must NOT expand, and the reason is an asymmetry rather than
+//     the fold. Both the phrase and the haystack fold through (1), so expanding
+//     on both sides would be symmetric and harmless on its own. What breaks is
+//     that the keyword side then drops "and" as a stop word (newznab.SigWords)
+//     and the haystack side does not, while indexer.phraseRegex joins its parts
+//     with a separator run that no letter may interrupt. Under expansion a
+//     release named "Foundation.&.Empire" folds to a haystack reading
+//     "foundation and empire" while its phrase stays [foundation, empire], and
+//     the "and" between them loses the hit.
 //     Nothing may compare a key from (1) against a key from (1a). Today
 //     nothing does: every caller stays inside one or the other. Before making
 //     them agree, read TestDedupAndTitleMatchAlphabetsDifferOnAmpersand, which
@@ -323,10 +329,12 @@ var nonDecomposableFolder = strings.NewReplacer(
 //	                         "ハリーポッター" (#1645).
 //	& → " and "              So "Foundation & Empire" meets "Foundation and
 //	                         Empire". Deliberately NOT done in FoldForTitleMatch:
-//	                         that alphabet feeds ContainsPhrase, which needs the
-//	                         keywords contiguous, and an injected "and" token
-//	                         would break every phrase hit on a release named
-//	                         "Foundation.&.Empire".
+//	                         its keyword side drops "and" as a stop word and its
+//	                         haystack side does not, so expanding there would
+//	                         leave an "and" sitting inside a phrase that no
+//	                         longer contains it, and ContainsPhrase requires the
+//	                         parts uninterrupted by any letter. See alphabet 1a
+//	                         in the header.
 //
 // The result is folded, single-space separated and trimmed. Callers own
 // tokenisation policy, as with FoldForTitleMatch — only the character rewriting


### PR DESCRIPTION
Phase B2 of the search work, the character-class half. Follows #2447 and #2448.

## The bug

`foldPunctuation` in `internal/indexer/dedup.go` put `&` in the separator branch with the colons and hyphens, so it was dropped rather than read. Providers disagree about which spelling to send for the same book, and the two keys could never meet.

Measured on `main`:

| title | key on `main` |
|---|---|
| `Foundation & Empire` | `foundation empire` |
| `Foundation and Empire` | `foundation and empire` |
| `Q&A` | `q a` |
| `Q and A` | `q and a` |
| `Crime & Punishment: A Novel` | `crime punishment a novel` |
| `Crime and Punishment: A Novel` | `crime and punishment a novel` |

So the same book was addable twice, and a release named with one spelling did not match a book stored with the other.

## Fail-before evidence

`TestNormalizeTitleForDedupExpandsAmpersand` on `origin/main`:

```
--- FAIL: TestNormalizeTitleForDedupExpandsAmpersand (0.00s)
    dedup_test.go:175: NormalizeTitleForDedup("Foundation & Empire") = "foundation empire", NormalizeTitleForDedup("Foundation and Empire") = "foundation and empire"; the two spellings must produce one key
    dedup_test.go:175: NormalizeTitleForDedup("Sense & Sensibility") = "sense sensibility", NormalizeTitleForDedup("Sense and Sensibility") = "sense and sensibility"; the two spellings must produce one key
    dedup_test.go:175: NormalizeTitleForDedup("Q&A") = "q a", NormalizeTitleForDedup("Q and A") = "q and a"; the two spellings must produce one key
    dedup_test.go:175: NormalizeTitleForDedup("Crime & Punishment: A Novel") = "crime punishment a novel", NormalizeTitleForDedup("Crime and Punishment: A Novel") = "crime and punishment a novel"; the two spellings must produce one key
    dedup_test.go:183: NormalizeTitleForDedup("Q&A") = "q a", want "q and a"
FAIL
```

`TestNormalizeAuthorNameFoldsCompatibilityForms` on `origin/main`:

```
--- FAIL: TestNormalizeAuthorNameFoldsCompatibilityForms (0.00s)
    author_test.go:164: NormalizeAuthorName("Ｈａｒｕｋｉ　Ｍｕｒａｋａｍｉ") = "ｈａｒｕｋｉ ｍｕｒａｋａｍｉ", NormalizeAuthorName("Haruki Murakami") = "haruki murakami"; compatibility forms must fold onto the plain spelling
    author_test.go:164: NormalizeAuthorName("ﬁona ﬂeming") = "ﬁona ﬂeming", NormalizeAuthorName("fiona fleming") = "fiona fleming"; compatibility forms must fold onto the plain spelling
    author_test.go:164: NormalizeAuthorName("Ｊｏｒｇｅ Ｌｕｉｓ Ｂｏｒｇｅｓ") = "ｊｏｒｇｅ ｌｕｉｓ ｂｏｒｇｅｓ", NormalizeAuthorName("Jorge Luis Borges") = "jorge luis borges"; compatibility forms must fold onto the plain spelling
FAIL
```

Both pass on this branch.

## Why not in `FoldForTitleMatch`

That alphabet feeds `ContainsPhrase`, which requires its keywords contiguous up to separators, so an injected `and` token would break every phrase hit on a release named `Foundation.&.Empire`. I checked this rather than assuming it: `ContainsPhrase` is called only from `searcher.go` on `normResult`, which is built by `NormalizeRelease`, never by `NormalizeTitleForDedup`. The two alphabets do not meet.

## The revision bump

`CanonicalDedupKeyRev` goes 1 to 2. Stored `books.dedup_key` values hold revision 1 and the ampersand change moves the key for any title containing one, so the marker gate runs the repair pass once on the next boot. That mechanism is the one already used by migrations 051, 058 and 083.

## Two smaller things in the same pass

- `foldPunctuation` kept a private `isApostrophe` identical to `textutil.IsApostrophe`. It now calls the shared one. **No behaviour change today, and its test passes on `main`** — it is a guard against the copies drifting apart again, not a fix, and I am not presenting it as one.
- `NormalizeAuthorName` decomposes with NFKD rather than NFD, so full-width Latin and typographic ligatures fold onto the ordinary spelling. It is a comparison key and never a displayed value, which is the condition UAX #15 attaches to using a compatibility form at all.

## A plan item that turned out to be wrong

Phase B2 also called for replacing the token length gates in `newznab.SigWords`
(`len(w) >= 3`) and `importer.titleSigTokens` (`len(w) >= 2`) with rune counts,
on the grounds that byte lengths on UTF-8 data are a bug. Checked against real
titles first, the byte threshold is the better rule and the proposed fix is a
regression, so this PR documents the code instead of changing it.

Three bytes of UTF-8 is three ASCII letters, two Cyrillic or Greek letters, or
one CJK ideograph, which is about how much each has to be worth before it
narrows a search. Measured on `main`:

| title | `SigWords` | bytes / runes per token |
|---|---|---|
| `三体` | `["三体"]` | 6 / 2 |
| `Мы` | `["мы"]` | 4 / 2 |
| `Война и мир` | `["война" "мир"]` | 10/5, 6/3 |
| `ハリー・ポッター` | `["ハリー" "ポッター"]` | 9/3, 12/4 |
| `The Hobbit` | `["hobbit"]` | 6 / 6 |

Both obvious rune rules are worse. A three-rune floor reduces `Мы` (Zamyatin's
*We*) to no significant tokens at all, so no release could ever match it. A
one-rune floor admits single Cyrillic and Greek letters, which carry no more
than a single English letter and would make matching needlessly strict.

The second commit therefore changes only comments and adds
`TestSigWordsThresholdScalesWithScript`, which **passes on `main`** and says so:
it is there because the next person to notice `len()` on a UTF-8 string will
otherwise "fix" it.

## Not in this PR

ISBN/ASIN normalisation, also bundled into B2 by the plan. Token significance changes release matching, which decides grabs, and deserves its own review rather than riding along with a dedup key change. ISBN and ASIN validation is a different subsystem entirely. Both follow separately.

## Verification

- `go build ./...`, `go vet ./...` clean.
- Full `go test ./...` passes. Notably no existing test asserted the ampersand was a separator.
- `internal/normdrift` already registers `NormalizeTitleForDedup`, `CanonicalDedupKey` and `NormalizeAuthorName`, so the cross-fold and Unicode-form properties covered these changes and stayed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFoegsicFfhT8stKRTwbBo
