### PR TITLE
fix(metadata): fold the four ISO 639 tables into one (#2463)

### DIFF
--- a/changelog.d/2463-one-iso639-table.md
+++ b/changelog.d/2463-one-iso639-table.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **A metadata profile no longer accepts a book and then hides every release of it** (#2463) — the language list was read twice on the way to a download, and the two readings did not agree. The book side understood a language written with a region or script on it (`pt-BR`, `pt_BR`, `zh-Hans`, and the very common `en-US`), the release side did not. So a profile set to Brazilian Portuguese let the book in, then dropped every Portuguese release found for it, and the book sat wanted forever with no explanation. Both sides now read the profile the same way.
+- **Books reported in the other legal spelling of a language are filtered as that language** (#2463) — ISO 639 gives many languages two three-letter codes, and providers use either, so a profile allowing German (`ger`) rejected any book a provider reported as `deu`, French rejected `fra`, Dutch rejected `nld`, Chinese rejected `zho`, and the same for Czech, Romanian and Greek. All twenty affected languages now match either spelling.
+- **Audiobooks whose language arrives as a word are matched correctly** (#2463) — Audible reports a language as `German` or `English` rather than as a code. Two copies of the translation table existed and one had fallen five languages behind, so the same audiobook could be filed under a different language depending on which lookup path reached it first. Hungarian, Romanian, Catalan and Latin audiobooks were affected. German edition matching also now recognises `German`, `Deutsch` and `de-DE`, not only `ger`, `deu` and `de`.
+
+### Changed
+
+- **Language handling comes from one table** (#2463) — the four separate and disagreeing lists of language codes are now one, so a language Bindery understands in one place it understands everywhere: in the book filter, in the release filter, and when importing from Audible. A new test fails the build if a language can be normalised to a code the profile editor does not offer.

--- a/internal/indexer/language_editor_vocab_test.go
+++ b/internal/indexer/language_editor_vocab_test.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"slices"
 	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
 )
 
 // metadataTabPath points at the metadata profile editor relative to this
@@ -63,12 +65,14 @@ func TestMetadataEditorLanguageVocabulary(t *testing.T) {
 		}
 	}
 
-	// The two-letter aliases exist so a hand-edited profile still normalizes
-	// onto this vocabulary; an alias pointing at a code the filter never emits
-	// would silently do nothing.
-	for short, long := range iso639TwoLetterAliases {
-		if !emitted[long] {
-			t.Errorf("iso639TwoLetterAliases maps %q to %q, which no marker in releaseLanguageTags produces", short, long)
+	// FilterByAllowedLanguages reduces each profile entry through
+	// models.NormalizeLanguageCode before comparing it to a release's tags, so
+	// every code the editor offers has to survive that reduction unchanged. A
+	// canonicaliser that rewrote "ger" to "deu" would leave the checkbox
+	// checked and the filter matching nothing.
+	for _, code := range offered {
+		if got := models.NormalizeLanguageCode(code); got != code {
+			t.Errorf("KNOWN_LANGUAGES offers %q but models.NormalizeLanguageCode rewrites it to %q, so ticking that box would filter on a code no release tag produces", code, got)
 		}
 	}
 }

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -1170,14 +1170,6 @@ var releaseLanguageTags = map[string]string{
 	"hindi":   "hin",
 }
 
-// iso639TwoLetterAliases maps common two-letter (ISO 639-1) codes to the
-// 639-2/B codes used by releaseLanguageTags and the profile editor, so a
-// hand-edited profile like "it,en" still filters correctly.
-var iso639TwoLetterAliases = map[string]string{
-	"en": "eng", "fr": "fre", "de": "ger", "nl": "dut", "es": "spa",
-	"it": "ita", "pt": "por", "ja": "jpn", "zh": "chi", "ru": "rus",
-}
-
 // releaseLanguageCodes returns the distinct language codes indicated by
 // markers in the normalized release title. Empty means the release carries no
 // recognisable language tag.
@@ -1200,20 +1192,27 @@ func releaseLanguageCodes(norm string) []string {
 // language outside the metadata profile's allowed set. Untagged releases
 // always pass — most releases carry no language marker, and dropping them
 // would empty nearly every search; the tag check can only ever be a negative
-// signal. An empty allowed list disables the filter, and codes are normalized
-// to the ISO 639-2/B vocabulary the profile editor writes ("en" → "eng").
+// signal. An empty allowed list disables the filter.
+//
+// Profile codes are reduced through models.NormalizeLanguageCode, the same
+// canonicaliser models.IsLanguageAllowed runs the book-level filter through,
+// so both halves of one setting read it with one vocabulary: "en", "en-US",
+// "deu" and "German" all mean "eng"/"ger" on both sides. This filter kept its
+// own two-letter table until #2463, which knew neither region subtags nor
+// ISO 639-2/T, so a profile written "pt-BR" accepted the book and then dropped
+// every Portuguese release of it.
 func FilterByAllowedLanguages(results []newznab.SearchResult, allowed []string) []newznab.SearchResult {
 	if len(allowed) == 0 {
 		return results
 	}
 	set := make(map[string]bool, len(allowed))
 	for _, code := range allowed {
-		code = strings.ToLower(strings.TrimSpace(code))
-		if alias, ok := iso639TwoLetterAliases[code]; ok {
-			code = alias
-		}
-		if code == "any" {
+		if strings.ToLower(strings.TrimSpace(code)) == "any" {
 			return results
+		}
+		code = models.NormalizeLanguageCode(code)
+		if code == "" {
+			continue
 		}
 		set[code] = true
 	}

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -1984,3 +1984,59 @@ func TestVideoMarkerReNoFalsePositives(t *testing.T) {
 		}
 	}
 }
+
+// TestFilterByAllowedLanguagesAgreesWithBookFilter is the drift guard for the
+// two halves of one setting. A metadata profile's allowed_languages list is
+// consulted twice on the way to a grab: models.IsLanguageAllowed decides
+// whether the *book* may be added, and FilterByAllowedLanguages decides
+// whether a *release* of it may be grabbed. Both must read the profile with
+// the same vocabulary, or a profile can accept a book and then reject every
+// release of it, leaving the book permanently wanted with no explanation.
+//
+// The four spellings below are the ones the two sides used to disagree on:
+// a region subtag ("pt-BR"), a script subtag ("zh-Hans"), an ISO 639-2/T code
+// ("deu", "fra", "zho") and a language name ("German"). Only the book filter
+// stripped subtags, and only it knew 639-2/T, so a profile written in any of
+// them filtered releases as if the code were an unknown language and dropped
+// every tagged release.
+func TestFilterByAllowedLanguagesAgreesWithBookFilter(t *testing.T) {
+	cases := []struct {
+		allowed string // one profile entry, as stored in allowed_languages
+		keep    string // a release tagged with that same language
+		drop    string // a release tagged with a different one
+	}{
+		{"pt-BR", "O.Livro.PORTUGUESE.epub", "The.Book.ENGLISH.epub"},
+		{"pt_BR", "O.Livro.PORTUGUESE.epub", "The.Book.ENGLISH.epub"},
+		{"zh-Hans", "Shu.CHINESE.epub", "The.Book.ENGLISH.epub"},
+		{"deu", "Das.Buch.GERMAN.epub", "The.Book.ENGLISH.epub"},
+		{"fra", "Le.Livre.FRENCH.epub", "The.Book.ENGLISH.epub"},
+		{"zho", "Shu.CHINESE.epub", "The.Book.ENGLISH.epub"},
+		{"German", "Das.Buch.GERMAN.epub", "The.Book.ENGLISH.epub"},
+		{"en-US", "The.Book.ENGLISH.epub", "Das.Buch.GERMAN.epub"},
+	}
+	for _, tc := range cases {
+		allowed := models.ParseAllowedLanguages(tc.allowed)
+		kept := resultTitles(FilterByAllowedLanguages(toResults(tc.keep, tc.drop), allowed))
+
+		// What the book filter says about the same profile, for the language
+		// the kept release is tagged with.
+		keepCode := releaseLanguageCodes(NormalizeRelease(tc.keep))
+		if len(keepCode) != 1 {
+			t.Fatalf("%q: test fixture must carry exactly one language tag, got %v", tc.keep, keepCode)
+		}
+		bookAllows := models.IsLanguageAllowed(keepCode[0], allowed, false)
+
+		if !bookAllows {
+			t.Errorf("profile %q: models.IsLanguageAllowed rejects a %s book, so this fixture is wrong", tc.allowed, keepCode[0])
+			continue
+		}
+		if !slices.Contains(kept, tc.keep) {
+			t.Errorf("profile %q accepts a %s book but FilterByAllowedLanguages drops %q (kept %v) — "+
+				"the book would stay wanted forever with every release of it filtered away",
+				tc.allowed, keepCode[0], tc.keep, kept)
+		}
+		if slices.Contains(kept, tc.drop) {
+			t.Errorf("profile %q must still drop %q, kept %v", tc.allowed, tc.drop, kept)
+		}
+	}
+}

--- a/internal/metadata/aggregator_canonical.go
+++ b/internal/metadata/aggregator_canonical.go
@@ -306,13 +306,12 @@ func canonicalTitleVariantKey(title string) string {
 	return b.String()
 }
 
+// isGermanBookLanguage reports whether a book's reported language is German,
+// in any of the spellings a provider might use. It matched only "ger", "deu"
+// and "de" until #2463, so a record whose language arrived as "German",
+// "Deutsch" or "de-DE" missed the German-specific title handling entirely.
 func isGermanBookLanguage(language string) bool {
-	switch strings.ToLower(strings.TrimSpace(language)) {
-	case "ger", "deu", "de":
-		return true
-	default:
-		return false
-	}
+	return models.NormalizeLanguageCode(language) == "ger"
 }
 
 func cleanCanonicalTitleVariant(title string) string {

--- a/internal/metadata/aggregator_enrichment.go
+++ b/internal/metadata/aggregator_enrichment.go
@@ -145,39 +145,12 @@ func normalizeASIN(asin string) string {
 	return strings.ToUpper(strings.TrimSpace(asin))
 }
 
+// normalizeAudibleLanguage canonicalizes the language an Audnex record
+// reports. It used to carry its own copy of the Audible name table, which had
+// drifted five languages behind the copy in internal/metadata/audible; both
+// now defer to models.NormalizeLanguageCode (#2463).
 func normalizeAudibleLanguage(language string) string {
-	language = strings.ToLower(strings.TrimSpace(language))
-	if language == "" {
-		return ""
-	}
-	if normalized, ok := audibleLanguageAliases[language]; ok {
-		return normalized
-	}
-	return language
-}
-
-var audibleLanguageAliases = map[string]string{
-	"english":    "eng",
-	"german":     "ger",
-	"french":     "fre",
-	"spanish":    "spa",
-	"italian":    "ita",
-	"dutch":      "dut",
-	"portuguese": "por",
-	"japanese":   "jpn",
-	"russian":    "rus",
-	"chinese":    "chi",
-	"danish":     "dan",
-	"swedish":    "swe",
-	"norwegian":  "nor",
-	"polish":     "pol",
-	"finnish":    "fin",
-	"hindi":      "hin",
-	"turkish":    "tur",
-	"arabic":     "ara",
-	"korean":     "kor",
-	"czech":      "cze",
-	"greek":      "gre",
+	return models.NormalizeLanguageCode(language)
 }
 
 // GetAuthorAudiobooks queries the Audible catalogue directly for the given

--- a/internal/metadata/audible/client.go
+++ b/internal/metadata/audible/client.go
@@ -250,48 +250,17 @@ func productToBook(p catalogueProduct) *models.Book {
 	return b
 }
 
-// languageAliases maps the full-word language names that Audible returns
-// ("english", "german") to the three-letter ISO 639-2/B codes Bindery uses
+// normalizeLanguage turns the full-word language names Audible returns
+// ("english", "german") into the three-letter ISO 639-2/B codes Bindery uses
 // everywhere else (OpenLibrary, DNB, metadata profiles). Anything unmapped
 // passes through untouched so unusual values still reach the bead without
 // being silently dropped.
-var languageAliases = map[string]string{
-	"english":    "eng",
-	"german":     "ger",
-	"french":     "fre",
-	"spanish":    "spa",
-	"italian":    "ita",
-	"dutch":      "dut",
-	"portuguese": "por",
-	"japanese":   "jpn",
-	"russian":    "rus",
-	"chinese":    "chi",
-	"danish":     "dan",
-	"swedish":    "swe",
-	"norwegian":  "nor",
-	"polish":     "pol",
-	"finnish":    "fin",
-	"hindi":      "hin",
-	"turkish":    "tur",
-	"arabic":     "ara",
-	"korean":     "kor",
-	"czech":      "cze",
-	"greek":      "gre",
-	"hungarian":  "hun",
-	"romanian":   "rum",
-	"catalan":    "cat",
-	"latin":      "lat",
-}
-
+//
+// The name table used to live here. It is now shared with the release-name
+// language filter and the book-level filter (#2463), because four private
+// copies of it disagreed about which languages exist.
 func normalizeLanguage(s string) string {
-	code := strings.ToLower(strings.TrimSpace(s))
-	if code == "" {
-		return ""
-	}
-	if mapped, ok := languageAliases[code]; ok {
-		return mapped
-	}
-	return code
+	return models.NormalizeLanguageCode(s)
 }
 
 // pickLargestCover returns the highest-resolution image URL in the product

--- a/internal/models/language.go
+++ b/internal/models/language.go
@@ -33,29 +33,92 @@ func ParseAllowedLanguages(csv string) []string {
 	return out
 }
 
-// iso639TwoLetterToB maps common ISO 639-1 two-letter codes to the ISO 639-2/B
+// The three tables below are the only ISO 639 tables in the codebase, and
+// NormalizeLanguageCode is the only thing that reads them. There used to be
+// four such tables (here, in the indexer's release filter, and twice over in
+// the Audible ingestion paths) and they disagreed with each other, so the same
+// language filtered differently depending on which code path happened to be
+// consulted. Add a language here and every caller learns it at once.
+
+// iso639TwoLetterToB maps ISO 639-1 two-letter codes to the ISO 639-2/B
 // three-letter vocabulary Bindery stores in Book.Language and metadata-profile
-// allowed_languages. Deliberately scoped to the languages users actually filter
-// on; anything not listed passes through unchanged so a rarer language still
-// round-trips rather than being silently dropped. Mirrors the indexer's
-// release-tag alias table (internal/indexer/searcher.go).
+// allowed_languages. Anything not listed passes through unchanged so a rarer
+// language still round-trips rather than being silently dropped.
 var iso639TwoLetterToB = map[string]string{
 	"en": "eng", "fr": "fre", "de": "ger", "nl": "dut", "es": "spa",
 	"it": "ita", "pt": "por", "ja": "jpn", "zh": "chi", "ru": "rus",
 	"sv": "swe", "no": "nor", "da": "dan", "pl": "pol", "cs": "cze",
-	"tr": "tur", "hi": "hin", "ko": "kor", "ar": "ara",
+	"tr": "tur", "hi": "hin", "ko": "kor", "ar": "ara", "fi": "fin",
+	"el": "gre", "hu": "hun", "ro": "rum", "ca": "cat", "la": "lat",
 }
 
-// NormalizeLanguageCode canonicalizes a language code from any source (an EPUB's
-// dc:language, provider metadata) into the lowercased ISO 639-2/B form the
-// language filter compares against. It drops a region/script subtag
-// ("en-US" → "en" → "eng", "zh-Hans" → "chi"), maps known two-letter codes to
-// their three-letter equivalent, and passes anything already three-letter (or
-// unrecognised) through lowercased so it still round-trips. Empty in, empty out.
+// iso639TermToB maps the ISO 639-2/T (terminology) code onto the 639-2/B
+// (bibliographic) code for the twenty languages where the two standards
+// disagree. Both spellings are legal ISO 639-2 and providers emit either, but
+// Bindery stores and filters on the /B form, so /T has to fold onto it or a
+// profile allowing "ger" rejects every book a provider reported as "deu".
+// This is a closed set: ISO 639-2 defines exactly these twenty pairs.
+var iso639TermToB = map[string]string{
+	"sqi": "alb", "hye": "arm", "eus": "baq", "bod": "tib", "mya": "bur",
+	"ces": "cze", "cym": "wel", "deu": "ger", "ell": "gre", "fas": "per",
+	"fra": "fre", "isl": "ice", "kat": "geo", "mkd": "mac", "mri": "mao",
+	"msa": "may", "nld": "dut", "ron": "rum", "slk": "slo", "zho": "chi",
+}
+
+// iso639NameToB maps a language written out as a word onto its 639-2/B code.
+// Audible reports languages this way ("english", "german"), and release names
+// carry them in English and in the language's own spelling.
+//
+// Only genuine names of languages belong here. The release filter also
+// recognises words that merely imply a language (the local word for
+// "audiobook", say), but those are evidence read off a release title rather
+// than a language a provider reported, so they stay in releaseLanguageTags in
+// internal/indexer/searcher.go.
+var iso639NameToB = map[string]string{
+	"english": "eng",
+	"french":  "fre", "francais": "fre", "français": "fre",
+	"german": "ger", "deutsch": "ger",
+	"spanish": "spa", "espanol": "spa", "español": "spa",
+	"italian": "ita", "italiano": "ita",
+	"dutch": "dut", "nederlands": "dut",
+	"portuguese": "por", "portugues": "por", "português": "por",
+	"japanese": "jpn",
+	"russian":  "rus",
+	"chinese":  "chi", "mandarin": "chi",
+	"danish": "dan", "dansk": "dan",
+	"swedish": "swe", "svenska": "swe",
+	"norwegian": "nor", "norsk": "nor",
+	"polish": "pol", "polski": "pol",
+	"finnish": "fin", "suomi": "fin",
+	"hindi":   "hin",
+	"turkish": "tur", "turkce": "tur", "türkçe": "tur",
+	"arabic": "ara",
+	"korean": "kor",
+	"czech":  "cze", "cestina": "cze", "čeština": "cze",
+	"greek": "gre", "ellinika": "gre",
+	"hungarian": "hun", "magyar": "hun",
+	"romanian": "rum", "romana": "rum", "română": "rum",
+	"catalan": "cat", "catala": "cat", "català": "cat",
+	"latin": "lat",
+}
+
+// NormalizeLanguageCode canonicalizes a language code from any source (an
+// EPUB's dc:language, provider metadata, a hand-edited metadata profile) into
+// the lowercased ISO 639-2/B form the language filter compares against. It
+// resolves a written-out language name ("German", "Deutsch"), drops a region
+// or script subtag ("en-US" to "en" to "eng", "zh-Hans" to "chi"), maps a
+// known two-letter code to its three-letter equivalent, folds ISO 639-2/T onto
+// 639-2/B ("deu" to "ger"), and passes anything unrecognised through
+// lowercased so it still round-trips. Empty in, empty out.
 func NormalizeLanguageCode(code string) string {
 	code = strings.ToLower(strings.TrimSpace(code))
 	if code == "" {
 		return ""
+	}
+	// Names are matched whole. A name is not a code carrying a subtag, so the
+	// stripping below must not run before this lookup.
+	if b, ok := iso639NameToB[code]; ok {
+		return b
 	}
 	// Drop a region/script subtag: "en-US", "pt_BR", "zh-Hans".
 	if i := strings.IndexAny(code, "-_"); i > 0 {
@@ -65,6 +128,10 @@ func NormalizeLanguageCode(code string) string {
 		if b, ok := iso639TwoLetterToB[code]; ok {
 			return b
 		}
+		return code
+	}
+	if b, ok := iso639TermToB[code]; ok {
+		return b
 	}
 	return code
 }

--- a/internal/models/language_test.go
+++ b/internal/models/language_test.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"os"
 	"reflect"
+	"regexp"
+	"slices"
 	"testing"
 )
 
@@ -49,6 +52,27 @@ func TestNormalizeLanguageCode(t *testing.T) {
 		{"GER", "ger"},
 		// Unknown two-letter code round-trips rather than being dropped.
 		{"xx", "xx"},
+
+		// #2463. ISO 639-2/T folds onto the /B form Bindery stores and
+		// filters on; both spellings are legal and providers emit either.
+		{"deu", "ger"},
+		{"fra", "fre"},
+		{"nld", "dut"},
+		{"ces", "cze"},
+		{"zho", "chi"},
+		{"ron", "rum"},
+		{"ell", "gre"},
+		{"deu-DE", "ger"},
+		// A language written out as a word, which is how Audible and Audnex
+		// report it and how release names carry it.
+		{"German", "ger"},
+		{"Deutsch", "ger"},
+		{"english", "eng"},
+		{"Português", "por"},
+		{"magyar", "hun"},
+		// Still not a language, and still round-trips rather than vanishing.
+		{"zulu", "zulu"},
+		{"not a language", "not a language"},
 	}
 	for _, tc := range cases {
 		if got := NormalizeLanguageCode(tc.in); got != tc.want {
@@ -95,6 +119,102 @@ func TestIsLanguageAllowed(t *testing.T) {
 		got := IsLanguageAllowed(tc.code, tc.allowed, tc.unknownFail)
 		if got != tc.want {
 			t.Errorf("IsLanguageAllowed(%q, %v, unknownFail=%v) = %v, want %v", tc.code, tc.allowed, tc.unknownFail, got, tc.want)
+		}
+	}
+}
+
+// metadataTabPath points at the metadata profile editor, relative to this
+// package directory (go test runs with the package dir as cwd).
+const metadataTabPath = "../../web/src/pages/settings/MetadataTab.tsx"
+
+// editorLanguageCodes returns the ISO 639-2/B codes KNOWN_LANGUAGES offers as
+// checkboxes in the metadata profile editor.
+func editorLanguageCodes(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile(metadataTabPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v (this guard needs the full repo checkout)", metadataTabPath, err)
+	}
+	block := regexp.MustCompile(`const KNOWN_LANGUAGES[^=]*=\s*\[([\s\S]*?)\n\]`).FindStringSubmatch(string(raw))
+	if block == nil {
+		t.Fatalf("could not find `const KNOWN_LANGUAGES = [...]` in %s; if it was renamed or moved, update this drift guard to follow it", metadataTabPath)
+	}
+	var offered []string
+	for _, m := range regexp.MustCompile(`code:\s*'([^']+)'`).FindAllStringSubmatch(block[1], -1) {
+		offered = append(offered, m[1])
+	}
+	if len(offered) == 0 {
+		t.Fatalf("`const KNOWN_LANGUAGES` in %s parsed to an empty list", metadataTabPath)
+	}
+	return offered
+}
+
+// TestNormalizedLanguagesStayInTheEditorVocabulary is the property behind
+// #2463: whatever spelling of a language reaches NormalizeLanguageCode, the
+// code it comes out as has to be one an operator could have ticked in the
+// profile editor, or the filter compares a normalized book against a profile
+// written in a vocabulary it can never match.
+//
+// The expected exceptions below are the languages the alias tables know but
+// the editor does not offer, and they are listed rather than tolerated so that
+// widening the tables stays a decision. They are safe precisely because each
+// is a whole language the editor has no entry for at all, never a rival
+// spelling of one it does offer: normalizing onto "cat" cannot steal a book
+// away from a ticked box, because there is no Catalan box to steal it from.
+// The editor's list is pinned to what the release-name filter can produce
+// (TestMetadataEditorLanguageVocabulary in internal/indexer), so it can only
+// grow once someone adds a release marker they can actually read; until then a
+// Catalan book is unfiltered rather than misfiltered.
+func TestNormalizedLanguagesStayInTheEditorVocabulary(t *testing.T) {
+	offered := editorLanguageCodes(t)
+
+	// Languages the tables normalize onto that the editor cannot offer yet.
+	expectedUnoffered := []string{
+		// 639-1 and name aliases for languages Audible reports but no
+		// release marker names.
+		"cat", "fin", "gre", "hun", "lat", "rum",
+		// The remaining ISO 639-2 T/B pairs. Folding these is free: the /B
+		// side is the standard's own spelling of the same language.
+		"alb", "arm", "baq", "bur", "geo", "ice", "mac", "mao", "may",
+		"per", "slo", "tib", "wel",
+	}
+
+	produced := map[string]bool{}
+	for _, table := range []map[string]string{iso639TwoLetterToB, iso639TermToB, iso639NameToB} {
+		for in, out := range table {
+			// Every table has to agree with the finished canonicaliser, or
+			// one of them is a second opinion again.
+			if got := NormalizeLanguageCode(in); got != out {
+				t.Errorf("a table maps %q to %q but NormalizeLanguageCode(%q) = %q", in, out, in, got)
+			}
+			// And no table may produce a code another table would rewrite.
+			if got := NormalizeLanguageCode(out); got != out {
+				t.Errorf("a table produces %q, which NormalizeLanguageCode then rewrites to %q", out, got)
+			}
+			produced[out] = true
+		}
+	}
+
+	var unoffered []string
+	for code := range produced {
+		if !slices.Contains(offered, code) {
+			unoffered = append(unoffered, code)
+		}
+	}
+	slices.Sort(unoffered)
+	slices.Sort(expectedUnoffered)
+	if !slices.Equal(unoffered, expectedUnoffered) {
+		t.Errorf("codes the alias tables produce but KNOWN_LANGUAGES in %s does not offer:\n got %v\nwant %v\n"+
+			"A new entry here is a language a normalized value can land on that no operator can select. "+
+			"Either add it to the editor (which needs a marker in releaseLanguageTags first) or drop the alias.",
+			metadataTabPath, unoffered, expectedUnoffered)
+	}
+
+	// The other direction: a code the editor offers must survive
+	// normalization untouched, or ticking its box filters on something else.
+	for _, code := range offered {
+		if got := NormalizeLanguageCode(code); got != code {
+			t.Errorf("KNOWN_LANGUAGES offers %q but NormalizeLanguageCode rewrites it to %q", code, got)
 		}
 	}
 }

--- a/internal/normdrift/normdrift_test.go
+++ b/internal/normdrift/normdrift_test.go
@@ -324,9 +324,14 @@ var adversarialSearchInputs = []string{
 // with optional region ("en", "en-US"), EPUBs carry whatever dc:language
 // says, DNB emits 639-2 natively, and profiles are written in 639-2/B —
 // plus empty (work-level OpenLibrary data) and plain garbage.
+// Audible and Audnex report a language as a word rather than a code, and
+// providers mix ISO 639-2/B with ISO 639-2/T, so "ger" and "deu" or "fre" and
+// "fra" are the same language spelled two legal ways. All four vocabularies
+// used to reach the filter from different code paths (#2463).
 var adversarialLanguageCodes = []string{
 	"en", "en-US", "EN", "eng", "de", "ger", "deu", "pt-BR", "pt_BR",
 	"zh-Hans", "fr", "fre", " Eng ", "", "xx", "not a language",
+	"fra", "zho", "nld", "ces", "German", "Deutsch", "english", "Português",
 }
 
 // TestLanguageFilterIsInvariantUnderItsOwnCanonicaliser is the language


### PR DESCRIPTION
## Summary

Four ISO 639 tables lived in this repo and they disagreed, so which one a code path happened to consult decided how a language filtered. This makes `models.NormalizeLanguageCode` the only one.

Removed:

- `iso639TwoLetterAliases` (`internal/indexer/searcher.go`, 10 entries)
- `languageAliases` (`internal/metadata/audible/client.go`, 26 entries)
- `audibleLanguageAliases` (`internal/metadata/aggregator_enrichment.go`, 21 entries, a copy of the previous one that had fallen five languages behind)

`internal/models/language.go` now holds three tables and nothing else reads them:

- `iso639TwoLetterToB`, widened from 19 to 25 entries: the union of what the four covered, so the 639-1 forms of the languages only Audible knew (`fi`, `el`, `hu`, `ro`, `ca`, `la`) resolve too.
- `iso639TermToB`, new: the twenty ISO 639-2 pairs where the terminology code and the bibliographic code differ (`deu`/`ger`, `fra`/`fre`, `nld`/`dut`, `ces`/`cze`, `zho`/`chi`, `ron`/`rum`, `ell`/`gre` and thirteen more). Both spellings are legal and providers emit either; Bindery stores and filters on the /B form. This is a closed set, so it is complete rather than scoped.
- `iso639NameToB`, new: the union of the two Audible name tables, plus the endonyms `releaseLanguageTags` already recognised as names of languages (`Deutsch`, `español`, `nederlands`, `svenska`, `polski` and so on). Deliberately excluded are the release markers that only *imply* a language, such as `hoerbuch` and `luisterboek`. Those are evidence read off a release title, not a language a provider reported, so they stay in `releaseLanguageTags`.

Delegating to it now: `FilterByAllowedLanguages`, `audible.normalizeLanguage`, `normalizeAudibleLanguage`, `isGermanBookLanguage`.

`NormalizeLanguageCode` keeps every input it already handled at the value it already returned. `TestNormalizeLanguageCode` retains its previous cases verbatim; the new ones are appended below them.

## Fail-before evidence

`TestFilterByAllowedLanguagesAgreesWithBookFilter` asserts that the two halves of one setting agree: `models.IsLanguageAllowed` decides whether a book may be added, `FilterByAllowedLanguages` decides whether a release of it may be grabbed, and a profile entry that admits the book must not then reject every release of it.

On `origin/main` (`caa2cbfa`), with only the test file added and no source change:

```
$ go test ./internal/indexer/ -run TestFilterByAllowedLanguagesAgreesWithBookFilter -v
=== RUN   TestFilterByAllowedLanguagesAgreesWithBookFilter
    searcher_test.go:2034: profile "pt-BR" accepts a por book but FilterByAllowedLanguages drops "O.Livro.PORTUGUESE.epub" (kept []) — the book would stay wanted forever with every release of it filtered away
    searcher_test.go:2034: profile "pt_BR" accepts a por book but FilterByAllowedLanguages drops "O.Livro.PORTUGUESE.epub" (kept []) — the book would stay wanted forever with every release of it filtered away
    searcher_test.go:2034: profile "zh-Hans" accepts a chi book but FilterByAllowedLanguages drops "Shu.CHINESE.epub" (kept []) — the book would stay wanted forever with every release of it filtered away
    searcher_test.go:2030: profile "deu": models.IsLanguageAllowed rejects a ger book, so this fixture is wrong
    searcher_test.go:2030: profile "fra": models.IsLanguageAllowed rejects a fre book, so this fixture is wrong
    searcher_test.go:2030: profile "zho": models.IsLanguageAllowed rejects a chi book, so this fixture is wrong
    searcher_test.go:2030: profile "German": models.IsLanguageAllowed rejects a ger book, so this fixture is wrong
    searcher_test.go:2034: profile "en-US" accepts a eng book but FilterByAllowedLanguages drops "The.Book.ENGLISH.epub" (kept []) — the book would stay wanted forever with every release of it filtered away
--- FAIL: TestFilterByAllowedLanguagesAgreesWithBookFilter (0.02s)
FAIL
FAIL	github.com/vavallee/bindery/internal/indexer	0.023s
FAIL
```

Two shapes of failure there. The three `pt-BR` / `pt_BR` / `zh-Hans` lines and the `en-US` line are the divergence in the brief: the book filter strips a region or script subtag, the release filter did not, so the profile admitted the book and then filtered away every release of it. `en-US` is worth calling out because it is not exotic: it is the form Google
Books returns. Its blast radius is narrower than the others though, and the
distinction matters. Measured on `main` with a three-release set:

```
profile "en-US" kept 2 of 3: ["Author.-.The.Book.2007.RETAIL.EPUB-GRP" "Author.-.The.Book.EPUB-GRP"]
profile "eng"   kept 3 of 3
profile "en"    kept 3 of 3
```

Only the release carrying an explicit `ENGLISH` tag is dropped; untagged ones
pass, because a release with no detected language code skips the check
entirely. Since scene convention tags non-English releases and leaves English
untagged, an `en-US` profile loses a subset of English releases rather than all
of them. The `pt-BR` and `zh-Hans` cases are the severe ones, because
non-English releases *are* conventionally tagged, so nearly every release of
such a book is filtered away.

The four `fixture is wrong` lines are the second half of the same bug seen from the other side: on main `models.IsLanguageAllowed` itself did not know ISO 639-2/T or language names, so `deu`, `fra`, `zho` and `German` failed at the book filter before the release filter ever saw them.

On this branch the whole suite passes.

## Other tests

- `adversarialLanguageCodes` in `internal/normdrift` gains `fra`, `zho`, `nld`, `ces`, `German`, `Deutsch`, `english`, `Português`. `deu`, `pt-BR`, `pt_BR` and `zh-Hans` were already in the corpus, so only the 639-2/T and name forms were actually missing.
- `TestNormalizedLanguagesStayInTheEditorVocabulary` (new, `internal/models`) parses `KNOWN_LANGUAGES` out of `MetadataTab.tsx` and asserts that every code the three tables can produce is one an operator could tick, that every table agrees with the finished canonicaliser, and that no table produces a code another table would rewrite.
- `TestMetadataEditorLanguageVocabulary` lost its `iso639TwoLetterAliases` loop along with the map. It now checks the successor property: every code the editor offers survives `NormalizeLanguageCode` untouched, so a canonicaliser that rewrote `ger` to `deu` would leave the checkbox ticked and matching nothing.

## Where the plan and the code disagreed

**The property test cannot be asserted unconditionally.** The brief asked for "every value the alias maps can produce is a code the metadata-profile editor actually offers". That property is false and cannot be made true. The editor offers 19 codes, and `TestMetadataEditorLanguageVocabulary` already pins that list to exactly what `releaseLanguageTags` can emit, in *both* directions. Meanwhile the Audible tables already normalise Finnish, Greek, Hungarian, Romanian, Catalan and Latin, none of which the editor offers. So there were three ways out:

1. Drop those languages from the name map. That regresses Audible ingestion, which has handled them for as long as the table has existed.
2. Add them to `KNOWN_LANGUAGES`. That fails the existing guard unless release markers are added for each, and `releaseLanguageTags` carries an explicit warning against guessing at markers in a language you do not read.
3. Assert the property with the exceptions listed explicitly.

I took the third. The exception list holds 19 codes and each one is a *whole language the editor has no entry for*, never a rival spelling of one it does offer. That distinction is what makes it safe: normalising onto `cat` cannot steal a book away from a ticked box, because there is no Catalan box to steal it from. A Catalan book is unfiltered, not misfiltered. Adding a code to that list is a visible decision in review rather than a silent widening, which is the guarantee the property was after.

**`NormalizeLanguageCode` already stripped region subtags.** The brief said it did not. It has since #1729; the doc comment and `TestNormalizeLanguageCode` both cover `en-US`, `pt_BR` and `zh-Hans`. What was missing on the book side was ISO 639-2/T and the name forms. The subtag gap was real but it was entirely on the release side, in `FilterByAllowedLanguages`, which never called the shared function at all.

**Most of the normdrift additions were already there.** `deu`, `pt-BR`, `pt_BR` and `zh-Hans` were in `adversarialLanguageCodes` on main. Only `fra`, `zho`, `German` and `Deutsch` were new, so I added `nld`, `ces`, `english` and `Português` alongside them to cover the remaining shapes.

## Conflicts with #2391

Checked. **My hunks in `searcher.go` do not overlap #2391's**, and a trial merge of the two branches confirms it: `FilterByAllowedLanguages` merges cleanly, with their result-loop addition and my allowed-loop rewrite sitting side by side. The two conflicts the trial merge does raise (`searcher.go:322`, `debug.go:155`) are between #2391 and current `main` over the query-budget change and have nothing to do with this branch.

**There is a semantic conflict, though, and it will break the build if both land unrebased.** #2391 adds `internal/indexer/title_candidates.go` with

```go
func normalizeLanguageCode(language string) string {
	language = strings.ToLower(strings.TrimSpace(language))
	if alias, ok := iso639TwoLetterAliases[language]; ok {
		return alias
	}
	return language
}
```

which is a fifth copy of the same table's lookup, and this branch deletes `iso639TwoLetterAliases`. Git merges both changes without a conflict and the result does not compile. After the second of the two merges, that function body should become `return models.NormalizeLanguageCode(language)` — which also gives #2391's new `r.Language` check the subtag and 639-2/T handling it currently lacks. Whoever merges second owns the one-line fix.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` full run, every package passing
- `gofmt -l internal/` clean

No new dependencies.

Fixes #2463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFoegsicFfhT8stKRTwbBo


