### PR TITLE
fix(importer): match an unmatched download on its release title (#2470)

### DIFF
--- a/changelog.d/2470-match-release-title.md
+++ b/changelog.d/2470-match-release-title.md
@@ -1,0 +1,2 @@
+### Fixed
+- **An audiobook grabbed from the Search page can find its book again** (#2470). Searching from the Search page rather than a book's own page does not tie the download to a book, so the importer works out which one it is afterwards. It read the ebook's embedded metadata and the filenames inside the download, neither of which tells you anything about an audiobook made of track files, and it never read the release name you actually picked. It does now, and it checks the author agrees before matching, so a one word title cannot pull in the wrong book.

--- a/internal/importer/lookup.go
+++ b/internal/importer/lookup.go
@@ -373,11 +373,18 @@ func lookupWith(path string, books []models.Book, authors []models.Author) Looku
 // without a BookID, e.g. via the free-text Search page) with a catalogue book.
 // It prefers embedded EPUB metadata (dc:title/dc:creator) over the release
 // filename, since filenames encode author/title/series in inconsistent orders
-// and routinely mis-parse (issue #1014). Returns the book and its author only
-// on a single confident match; (nil, nil) when the catalogue has no
-// unambiguous match, so the caller still surfaces the unmatched failure rather
-// than importing against the wrong book.
-func (s *Scanner) matchBookForDownload(ctx context.Context, files []string) (*models.Book, *models.Author) {
+// and routinely mis-parse (issue #1014), and falls back to the release title
+// last. Returns the book and its author only on a single confident match;
+// (nil, nil) when the catalogue has no unambiguous match, so the caller still
+// surfaces the unmatched failure rather than importing against the wrong book.
+//
+// releaseTitle is dl.Title, the name the user actually saw and chose on the
+// search page. Until #2470 it was never consulted, which made an audiobook
+// grabbed from the free-text Search page unmatchable: tier 1 needs an EPUB an
+// MP3 does not have, and tier 2 reads the track filenames, which are
+// "01 - Chapter One.mp3". The failure then told the user to check the release
+// title, which was the one field nothing had looked at.
+func (s *Scanner) matchBookForDownload(ctx context.Context, files []string, releaseTitle string) (*models.Book, *models.Author) {
 	// Tier 1: embedded EPUB metadata.
 	for _, f := range files {
 		if !IsEpubFile(f) {
@@ -412,7 +419,108 @@ func (s *Scanner) matchBookForDownload(ctx context.Context, files []string) (*mo
 			return res.Book, a
 		}
 	}
+
+	// Tier 3: the release title. Last, so nothing that matches today changes
+	// behaviour; it only answers the case the first two cannot see.
+	if b, a := s.matchByReleaseTitle(ctx, releaseTitle); b != nil {
+		slog.Info("matched download via release title",
+			"release", releaseTitle, "bookID", b.ID, "book", b.Title)
+		return b, a
+	}
 	return nil, nil
+}
+
+// matchByReleaseTitle finds the single catalogue book a release name refers to.
+//
+// Deliberately NOT routed through Lookup, which is the obvious thing to try and
+// is wrong: Lookup runs ParseFilename, which treats its argument as a path, so
+// the "/" inside a "[ENG / MP3]" tag makes it keep only the last segment.
+//
+//	ParseFilename("The Kitchen God's Wife by Amy Tan [ENG / MP3]")
+//	    -> title "MP3]", author ""
+//	ParseFilename("Amy Tan - The Kitchen God's Wife")
+//	    -> title "Amy Tan", author "The Kitchen God's Wife"   (inverted)
+//
+// So the release name is compared whole, by the same token-overlap titleMatch
+// the rest of the importer uses.
+//
+// The author has to corroborate, and that requirement is the difference
+// between this being useful and being dangerous. titleMatch is generous by
+// design, so a one-word book title matches almost any release containing that
+// word:
+//
+//	titleMatch("The Kitchen God's Wife", release) == true    // the real book
+//	titleMatch("Wife",                   release) == true    // any book called "Wife"
+//
+// The "single confident match only" rule below catches that when both books
+// are in the library, since two matches means no match. It does nothing for a
+// library holding only the short one. Requiring every significant token of the
+// author's name to appear in the release name is what separates the two:
+// "Amy Tan" is in the release and the other author is not.
+func (s *Scanner) matchByReleaseTitle(ctx context.Context, releaseTitle string) (*models.Book, *models.Author) {
+	if strings.TrimSpace(releaseTitle) == "" {
+		return nil, nil
+	}
+	books, err := s.books.List(ctx)
+	if err != nil {
+		return nil, nil
+	}
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		return nil, nil
+	}
+	names := make(map[int64]string, len(authors))
+	byID := make(map[int64]models.Author, len(authors))
+	for _, a := range authors {
+		names[a.ID] = a.Name
+		byID[a.ID] = a
+	}
+
+	releaseTokens := make(map[string]bool)
+	for _, w := range titleSigTokens(releaseTitle) {
+		releaseTokens[w] = true
+	}
+
+	var matches []models.Book
+	for _, b := range books {
+		if !titleMatch(b.Title, releaseTitle) {
+			continue
+		}
+		if !releaseNamesAuthor(releaseTokens, names[b.AuthorID]) {
+			continue
+		}
+		matches = append(matches, b)
+	}
+	if len(matches) != 1 {
+		return nil, nil
+	}
+	book := matches[0]
+	author := byID[book.AuthorID]
+	return &book, &author
+}
+
+// releaseNamesAuthor reports whether every significant token of name appears in
+// the release name's token set.
+//
+// Subset rather than equality, because a release names the author however it
+// likes: "Amy Tan", "Tan, Amy", "by Amy Tan" and "Amy.Tan" all reduce to the
+// same tokens once titleSigTokens has run, and the release carries plenty of
+// other words besides. An author whose name reduces to no significant tokens
+// (a single short name, a non-Latin script the token floor rejects) cannot
+// corroborate anything, so it is answered false rather than true: the caller
+// then reports an unmatched download, which is recoverable by hand, instead of
+// importing against a book chosen on the title alone.
+func releaseNamesAuthor(releaseTokens map[string]bool, name string) bool {
+	tokens := titleSigTokens(name)
+	if len(tokens) == 0 {
+		return false
+	}
+	for _, w := range tokens {
+		if !releaseTokens[w] {
+			return false
+		}
+	}
+	return true
 }
 
 // matchByTitleAuthor finds the single catalogue book whose title matches and

--- a/internal/importer/lookup_release_title_test.go
+++ b/internal/importer/lookup_release_title_test.go
@@ -1,0 +1,159 @@
+package importer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// releaseTitleFixture seeds a catalogue and returns a scanner over it. No files
+// on disk: the tier under test reads the release name and nothing else.
+func releaseTitleFixture(t *testing.T, seed func(ctx context.Context, books *db.BookRepo, authors *db.AuthorRepo)) *Scanner {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	seed(context.Background(), books, authors)
+
+	return NewScanner(
+		db.NewDownloadRepo(database),
+		db.NewDownloadClientRepo(database),
+		books,
+		authors,
+		db.NewHistoryRepo(database),
+		t.TempDir(), "", "", "", "",
+	)
+}
+
+func seedBook(t *testing.T, ctx context.Context, books *db.BookRepo, authors *db.AuthorRepo, authorName, title string) *models.Book {
+	t.Helper()
+	a := &models.Author{ForeignID: "OL-" + authorName, Name: authorName, SortName: authorName}
+	if err := authors.Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	b := &models.Book{
+		ForeignID: "OL-" + title, AuthorID: a.ID, Title: title, SortTitle: title,
+		Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{},
+	}
+	if err := books.Create(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// The reported case (#2470). An audiobook grabbed from the free-text Search
+// page: no BookID, no EPUB to read metadata from, and track filenames that say
+// nothing. The release name is the only thing that identifies it, and it says
+// exactly which book it is.
+func TestMatchBookForDownload_MatchesOnReleaseTitle(t *testing.T) {
+	s := releaseTitleFixture(t, func(ctx context.Context, books *db.BookRepo, authors *db.AuthorRepo) {
+		seedBook(t, ctx, books, authors, "Amy Tan", "The Kitchen God's Wife")
+		seedBook(t, ctx, books, authors, "Mike Carey", "The Girl with All the Gifts")
+	})
+
+	files := []string{"/dl/01 - Chapter One.mp3", "/dl/02 - Chapter Two.mp3"}
+	book, author := s.matchBookForDownload(context.Background(), files,
+		"The Kitchen God's Wife by Amy Tan [ENG / MP3]")
+
+	if book == nil {
+		t.Fatal("no match; the release name identifies the book unambiguously (#2470)")
+	}
+	if book.Title != "The Kitchen God's Wife" {
+		t.Errorf("matched %q, want The Kitchen God's Wife", book.Title)
+	}
+	if author == nil || author.Name != "Amy Tan" {
+		t.Errorf("author = %+v, want Amy Tan", author)
+	}
+}
+
+// titleMatch is generous, so a one-word title matches almost any release
+// containing that word. The author is what separates a real match from an
+// accidental one, and here only the accidental candidate is in the library, so
+// the "single confident match" rule cannot save it.
+func TestMatchBookForDownload_ReleaseTitleNeedsTheAuthorToAgree(t *testing.T) {
+	s := releaseTitleFixture(t, func(ctx context.Context, books *db.BookRepo, authors *db.AuthorRepo) {
+		// Titles that titleMatch accepts against the release below, by authors
+		// the release never names.
+		seedBook(t, ctx, books, authors, "Marilynne Robinson", "Wife")
+	})
+
+	book, _ := s.matchBookForDownload(context.Background(), nil,
+		"The Kitchen God's Wife by Amy Tan [ENG / MP3]")
+
+	if book != nil {
+		t.Fatalf("matched %q by a different author on a title-word collision; an unmatched download is recoverable by hand, a wrong import is not", book.Title)
+	}
+}
+
+// Two books whose titles both match and whose authors are both named would be
+// a guess. The tier declines rather than picking one, same rule as every other
+// tier in this matcher.
+func TestMatchBookForDownload_ReleaseTitleDeclinesAmbiguity(t *testing.T) {
+	s := releaseTitleFixture(t, func(ctx context.Context, books *db.BookRepo, authors *db.AuthorRepo) {
+		seedBook(t, ctx, books, authors, "Amy Tan", "The Kitchen God's Wife")
+		// A second edition row under the same author with the same title, the
+		// shape a duplicate import leaves behind.
+		a2 := &models.Author{ForeignID: "OL-Amy Tan 2", Name: "Amy Tan", SortName: "Amy Tan"}
+		if err := authors.Create(ctx, a2); err != nil {
+			t.Fatal(err)
+		}
+		b2 := &models.Book{
+			ForeignID: "OL-dup", AuthorID: a2.ID, Title: "The Kitchen God's Wife", SortTitle: "kitchen gods wife",
+			Status: models.BookStatusWanted, MetadataProvider: "openlibrary", Genres: []string{},
+		}
+		if err := books.Create(ctx, b2); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	book, _ := s.matchBookForDownload(context.Background(), nil,
+		"The Kitchen God's Wife by Amy Tan [ENG / MP3]")
+
+	if book != nil {
+		t.Errorf("picked %q (id %d) between two equally good candidates; the matcher must never guess", book.Title, book.ID)
+	}
+}
+
+// An empty release name must not match the whole catalogue, or the first book
+// in the list becomes the answer to every unmatched download.
+func TestMatchBookForDownload_EmptyReleaseTitleMatchesNothing(t *testing.T) {
+	s := releaseTitleFixture(t, func(ctx context.Context, books *db.BookRepo, authors *db.AuthorRepo) {
+		seedBook(t, ctx, books, authors, "Amy Tan", "The Kitchen God's Wife")
+	})
+
+	if book, _ := s.matchBookForDownload(context.Background(), nil, ""); book != nil {
+		t.Errorf("empty release name matched %q", book.Title)
+	}
+	if book, _ := s.matchBookForDownload(context.Background(), nil, "   "); book != nil {
+		t.Errorf("blank release name matched %q", book.Title)
+	}
+}
+
+// An author whose name carries no significant tokens cannot corroborate
+// anything. Answered as "no match" rather than "author agrees", so a download
+// falls to manual matching instead of being imported on the title alone.
+func TestReleaseNamesAuthor_NoSignificantTokensIsRefusal(t *testing.T) {
+	tokens := map[string]bool{"kitchen": true, "gods": true, "wife": true, "amy": true, "tan": true}
+	for _, name := range []string{"", "   ", "X"} {
+		if releaseNamesAuthor(tokens, name) {
+			t.Errorf("releaseNamesAuthor(%q) = true; an author that cannot be checked must not count as checked", name)
+		}
+	}
+	if !releaseNamesAuthor(tokens, "Amy Tan") {
+		t.Error("releaseNamesAuthor(\"Amy Tan\") = false; the release names that author")
+	}
+	if releaseNamesAuthor(tokens, "Mike Carey") {
+		t.Error("releaseNamesAuthor(\"Mike Carey\") = true; the release does not name that author")
+	}
+	// Order and punctuation are the release's business, not ours.
+	if !releaseNamesAuthor(tokens, "Tan, Amy") {
+		t.Error("an inverted author name should still corroborate")
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1402,7 +1402,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// EPUB metadata (reliable) over the release filename (which encodes
 	// author/title/series in inconsistent orders) — issue #1014.
 	if book == nil {
-		if b, a := s.matchBookForDownload(ctx, bookFiles); b != nil {
+		if b, a := s.matchBookForDownload(ctx, bookFiles, dl.Title); b != nil {
 			book = b
 			author = a
 			edition = s.resolveCalibreEdition(ctx, dl, book)


### PR DESCRIPTION
Closes #2470. Reported on Discord by daize0, two examples, both audiobooks of books already in the library.

## The gap

A download grabbed from the free-text Search page carries no `BookID` (`SearchPage.tsx:49` sends none; `BookDetailPage.tsx:378` does), so the importer has to work out which book it is afterwards. `matchBookForDownload` had two tiers:

1. Embedded EPUB metadata. An MP3 audiobook has none.
2. `s.Lookup` over each file path in the download. For an audiobook those are `01 - Chapter One.mp3`.

Neither reads `dl.Title`. So the import failed five times, hit the retry limit, and told the user to *"check the release title"* — the one field nothing had looked at.

## Why not just call Lookup on the title

That was my first instinct and it does not work. `Lookup` runs `ParseFilename`, which treats its argument as a path:

```
ParseFilename("The Kitchen God's Wife by Amy Tan [ENG / MP3]") -> title "MP3]",  author ""
ParseFilename("Amy Tan - The Kitchen God's Wife")              -> title "Amy Tan", author "The Kitchen God's Wife"
```

The `/` inside the `[ENG / MP3]` tag makes it keep the last segment, and the `-` form comes back inverted. So the release name is compared whole, through the same `titleMatch` the rest of the importer already uses.

## Why the author has to agree

`titleMatch` is generous by design. Against the reported release:

```
titleMatch("The Kitchen God's Wife",      release) = true    <- the real book
titleMatch("Wife",                        release) = true    <- any book called "Wife"
titleMatch("The Girl with All the Gifts", release) = false
titleMatch("The Joy Luck Club",           release) = false
```

The existing "single confident match only, never guess" rule catches the collision when both books are in the library, since two matches means no match. It does nothing for a library holding only the short one. So every significant token of the book's author name must also appear in the release name. `Amy Tan` is there; the other author is not.

An author whose name yields no significant tokens is answered as a **refusal**, not as agreement. An unmatched download is recoverable through the queue's "Match to book" action (#1589); a wrong import is not.

## Tier ordering

Last, after both existing tiers, so nothing that matches today changes behaviour. It only answers the case the first two cannot see.

## Verified failing first

Removing tier 3 and re-running:

```
--- FAIL: TestMatchBookForDownload_MatchesOnReleaseTitle
    no match; the release name identifies the book unambiguously (#2470)
```

Five tests: the reported case, the author-collision refusal, the two-equally-good-candidates refusal, empty and blank release names, and the `releaseNamesAuthor` token rules including the inverted `Tan, Amy` spelling.

`go vet`, `golangci-lint run ./internal/importer/` at 0 issues, full `internal/importer` suite green.

## Not in scope

daize0 also asked for a way to add the author, or link the book, from the Search page results. That is a separate feature request and I have not filed it. The existing recovery path for these downloads is the queue's "Match to book" action, which works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
