### PR TITLE
feat(metadata): add BINDERY_DISABLE_OPENLIBRARY switch

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -303,7 +303,8 @@ func main() {
 	if s, _ := settingsRepo.Get(ctxBoot, api.SettingMetadataPrimaryProvider); s != nil {
 		configuredPrimary = s.Value
 	}
-	primaryName := resolveMetadataPrimaryProvider(configuredPrimary, api.GetHardcoverAPIToken(ctxBoot, settingsRepo) != "")
+	hardcoverTokenConfigured := api.GetHardcoverAPIToken(ctxBoot, settingsRepo) != ""
+	primaryName := resolveMetadataPrimaryProvider(configuredPrimary, hardcoverTokenConfigured, !cfg.DisableOpenLibrary)
 	var primaryProvider metadata.Provider
 	switch primaryName {
 	case "dnb":
@@ -334,9 +335,11 @@ func main() {
 			slog.Info("hardcover enrichment idle: no api token configured")
 		}
 	}
-	if primaryName != "openlibrary" {
+	if !cfg.DisableOpenLibrary && primaryName != "openlibrary" {
 		enrichers = append(enrichers, olClient)
 		slog.Info("openlibrary enrichment enabled")
+	} else if cfg.DisableOpenLibrary {
+		slog.Info("openlibrary disabled by configuration")
 	}
 	if primaryName != "dnb" {
 		enrichers = append(enrichers, dnbClient)

--- a/cmd/bindery/metadata_providers.go
+++ b/cmd/bindery/metadata_providers.go
@@ -23,16 +23,37 @@ const metadataPrimaryProviderDefault = "openlibrary"
 //     author and book lookup. The settings API refuses to store that
 //     combination, but the token can still be removed out-of-band, so the
 //     boot path degrades loudly instead of silently breaking metadata.
-func resolveMetadataPrimaryProvider(configured string, hardcoverTokenConfigured bool) string {
+func resolveMetadataPrimaryProvider(configured string, hardcoverTokenConfigured, openLibraryEnabled bool) string {
+	if !openLibraryEnabled && configured == "openlibrary" {
+		if hardcoverTokenConfigured {
+			return "hardcover"
+		}
+		return "dnb"
+	}
 	if configured == "" {
+		if !openLibraryEnabled {
+			if hardcoverTokenConfigured {
+				return "hardcover"
+			}
+			return "dnb"
+		}
 		return metadataPrimaryProviderDefault
 	}
 	if !api.IsMetadataPrimaryProviderValid(configured) {
 		slog.Warn("unknown metadata.primary_provider — falling back to openlibrary",
 			"configured", configured)
+		if !openLibraryEnabled {
+			if hardcoverTokenConfigured {
+				return "hardcover"
+			}
+			return "dnb"
+		}
 		return metadataPrimaryProviderDefault
 	}
 	if configured == "hardcover" && !hardcoverTokenConfigured {
+		if !openLibraryEnabled {
+			return "dnb"
+		}
 		slog.Warn("metadata.primary_provider is hardcover but no Hardcover API token is configured — falling back to openlibrary (Hardcover authenticates every query, including search)")
 		return metadataPrimaryProviderDefault
 	}

--- a/cmd/bindery/metadata_providers_test.go
+++ b/cmd/bindery/metadata_providers_test.go
@@ -22,10 +22,26 @@ func TestResolveMetadataPrimaryProvider(t *testing.T) {
 		{"unknown value falls back", "goodreads", true, "openlibrary"},
 		{"enricher-only provider falls back", "googlebooks", true, "openlibrary"},
 	}
+	disabledCases := []struct {
+		name, configured, want string
+		hasToken               bool
+	}{
+		{"disabled default uses hardcover when token exists", "", "hardcover", true},
+		{"disabled explicit openlibrary uses hardcover when token exists", "openlibrary", "hardcover", true},
+		{"disabled default uses dnb without hardcover token", "", "dnb", false},
+	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveMetadataPrimaryProvider(tc.configured, tc.hasToken); got != tc.want {
+			if got := resolveMetadataPrimaryProvider(tc.configured, tc.hasToken, true); got != tc.want {
 				t.Errorf("resolveMetadataPrimaryProvider(%q, %v) = %q, want %q",
+					tc.configured, tc.hasToken, got, tc.want)
+			}
+		})
+	}
+	for _, tc := range disabledCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveMetadataPrimaryProvider(tc.configured, tc.hasToken, false); got != tc.want {
+				t.Errorf("disabled OpenLibrary: resolveMetadataPrimaryProvider(%q, %v) = %q, want %q",
 					tc.configured, tc.hasToken, got, tc.want)
 			}
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,10 @@ type Config struct {
 	AudiobookDir         string
 	// Enhanced Hardcover series API (BINDERY_ENHANCED_HARDCOVER_API, default true).
 	EnhancedHardcoverAPI bool
-	DownloadPathRemap    string
+	// DisableOpenLibrary prevents OpenLibrary from being wired as a primary
+	// provider or metadata enricher (BINDERY_DISABLE_OPENLIBRARY, default false).
+	DisableOpenLibrary bool
+	DownloadPathRemap  string
 	// Proxy SSO settings (Phase 1).
 	ProxyAuthHeader    string // BINDERY_PROXY_AUTH_HEADER
 	ProxyAutoProvision bool   // BINDERY_PROXY_AUTO_PROVISION
@@ -106,6 +109,7 @@ func Load() *Config {
 		LibraryDir:               envOr("BINDERY_LIBRARY_DIR", "/books"),
 		AudiobookDir:             envOr("BINDERY_AUDIOBOOK_DIR", ""),
 		EnhancedHardcoverAPI:     envBool("BINDERY_ENHANCED_HARDCOVER_API", true),
+		DisableOpenLibrary:       envBool("BINDERY_DISABLE_OPENLIBRARY", false),
 		DownloadPathRemap:        envOr("BINDERY_DOWNLOAD_PATH_REMAP", ""),
 		ProxyAuthHeader:          envOr("BINDERY_PROXY_AUTH_HEADER", "X-Forwarded-User"),
 		ProxyAutoProvision:       envBool("BINDERY_PROXY_AUTO_PROVISION", true),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,9 @@ func TestLoadDefaults(t *testing.T) {
 	if !cfg.EnhancedHardcoverAPI {
 		t.Error("expected enhanced Hardcover API to default to enabled")
 	}
+	if cfg.DisableOpenLibrary {
+		t.Error("expected OpenLibrary to default to enabled")
+	}
 
 	// DBPath/DataDir are platform-dependent as of #7. CI runs on linux so
 	// here we only assert the linux invariant; per-platform coverage lives
@@ -39,6 +42,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("BINDERY_PORT", "9999")
 	t.Setenv("BINDERY_LOG_LEVEL", "debug")
 	t.Setenv("BINDERY_ENHANCED_HARDCOVER_API", "false")
+	t.Setenv("BINDERY_DISABLE_OPENLIBRARY", "true")
 
 	cfg := Load()
 
@@ -50,6 +54,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.EnhancedHardcoverAPI {
 		t.Error("expected enhanced Hardcover API to respect BINDERY_ENHANCED_HARDCOVER_API=false")
+	}
+	if !cfg.DisableOpenLibrary {
+		t.Error("expected OpenLibrary disable switch to respect BINDERY_DISABLE_OPENLIBRARY=true")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `BINDERY_DISABLE_OPENLIBRARY` (default `false`)
- omit OpenLibrary from metadata enrichment when disabled
- avoid selecting OpenLibrary as primary when disabled, preferring Hardcover with a configured token
- add provider-selection and environment-loading regression tests

## Motivation
Hardcover-primary installations still receive OpenLibrary enrichment requests. When OpenLibrary is slow or unavailable, author catalogue refreshes can stall or fail to commit. Operators who want Hardcover-only metadata need an explicit deployment switch.

## Testing
- `docker run --rm -v /home/trevor/work/bindery:/src -w /src golang:1.26.6-bookworm sh -c 'gofmt -w internal/config/config.go internal/config/config_test.go cmd/bindery/main.go cmd/bindery/metadata_providers.go cmd/bindery/metadata_providers_test.go && go test ./internal/config ./cmd/bindery'`\n- Result: both packages pass\n\nRelated: #1888