### PR TITLE
fix(import): skip files already tracked in library

### DIFF
--- a/docs/User-Guide-Wiki.md
+++ b/docs/User-Guide-Wiki.md
@@ -42,7 +42,8 @@ an arbitrary release is unreliable. The escape hatches:
 - **Search Indexers** (the magnifier icon in the header) — free-text search
   across all your indexers; any result can be grabbed.
 - **Manual Import** (`/import`) — point it at a folder of files you already
-  have and match them to books. A file with no catalogue match gets a metadata
+  have and match them to books. Files already tracked in the library are skipped
+  by default. A file with no catalogue match gets a metadata
   search on its row, which creates the book (and its author, if new) and links
   the file to it, so an unmatched file is no longer a dead end.
 

--- a/docs/User-Guide-Wiki.md
+++ b/docs/User-Guide-Wiki.md
@@ -43,9 +43,10 @@ an arbitrary release is unreliable. The escape hatches:
   across all your indexers; any result can be grabbed.
 - **Manual Import** (`/import`) — point it at a folder of files you already
   have and match them to books. Files already tracked in the library are skipped
-  by default. A file with no catalogue match gets a metadata
-  search on its row, which creates the book (and its author, if new) and links
-  the file to it, so an unmatched file is no longer a dead end.
+  by default; toggle **Show already imported** to surface them again, e.g. to
+  spot a corrupted file or relink one. A file with no catalogue match gets a
+  metadata search on its row, which creates the book (and its author, if new)
+  and links the file to it, so an unmatched file is no longer a dead end.
 
 Both still end by attaching a file to a catalogue record.
 

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -456,6 +456,33 @@ func directoryMatchesTracked(path string, tracked map[string]struct{}, trackedFi
 	return found && allTracked
 }
 
+// bookHasImportedFormat reports whether the matched book already has an
+// on-disk file or directory for format. Manual import's idempotency guard will
+// skip such a candidate, so presenting it in the scan only creates a row that
+// appears importable but can never change state.
+func bookHasImportedFormat(book *models.Book, format string) bool {
+	if book == nil {
+		return false
+	}
+	var path string
+	switch format {
+	case models.MediaTypeAudiobook:
+		path = book.AudiobookFilePath
+	case models.MediaTypeEbook:
+		path = book.EbookFilePath
+		if path == "" {
+			path = book.FilePath
+		}
+	default:
+		return false
+	}
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // ScanItem is one candidate book unit discovered under a folder during Scan.
 type ScanItem struct {
 	Path           string        `json:"path"`
@@ -548,6 +575,16 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		tracked[cleaned] = struct{}{}
 		if info, statErr := os.Stat(cleaned); statErr == nil {
 			trackedFiles = append(trackedFiles, info)
+			if info.IsDir() {
+				_ = filepath.WalkDir(cleaned, func(p string, entry os.DirEntry, walkErr error) error {
+					if walkErr == nil && !entry.IsDir() && (importer.IsEbookFile(p) || importer.IsAudioFile(p)) {
+						if childInfo, childErr := os.Stat(p); childErr == nil {
+							trackedFiles = append(trackedFiles, childInfo)
+						}
+					}
+					return nil
+				})
+			}
 		}
 	}
 	filteredCands := cands[:0]
@@ -575,6 +612,17 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		writeServerError(w, r, err)
 		return
 	}
+	filteredCands = cands[:0]
+	filteredResults := results[:0]
+	for i, res := range results {
+		if res.Match == "confident" && bookHasImportedFormat(res.Book, res.DetectedFormat) {
+			continue
+		}
+		filteredCands = append(filteredCands, cands[i])
+		filteredResults = append(filteredResults, res)
+	}
+	cands = filteredCands
+	results = filteredResults
 
 	resp := ScanResponse{Items: make([]ScanItem, 0, len(cands)), Truncated: truncated}
 	matched := 0

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -453,6 +453,32 @@ type ScanResponse struct {
 // an enormous tree can't produce an unbounded response or stall the request.
 const maxScanEntries = 1000
 
+// resolveImportFolder validates the user-selected scan folder and returns the
+// symlink-resolved path that is safe for subsequent filesystem operations.
+// The caller may select any configured library subfolder, but the raw query
+// value must never reach the filesystem before ResolveContained approves it.
+func (h *ManualImportHandler) resolveImportFolder(ctx context.Context, rawPath string) (string, int, string) {
+	path := filepath.Clean(rawPath)
+	if path == "" || path == "." {
+		return "", http.StatusBadRequest, "path parameter required"
+	}
+	if !filepath.IsAbs(path) {
+		return "", http.StatusBadRequest, "path must be absolute"
+	}
+	resolved, ok := h.roots.ResolveContained(ctx, path)
+	if !ok {
+		return "", http.StatusForbidden, "path is outside the configured library roots"
+	}
+	info, err := os.Stat(resolved) //nolint:gosec // #nosec G304 -- resolved by ResolveContained after symlink-aware root containment; route requires admin
+	if err != nil {
+		return "", http.StatusBadRequest, fmt.Sprintf("path not accessible: %v", err)
+	}
+	if !info.IsDir() {
+		return "", http.StatusBadRequest, "path must be a folder; use lookup for a single book"
+	}
+	return resolved, 0, ""
+}
+
 // Scan handles GET /api/v1/queue/manual-import/scan?path=...
 // It walks a folder RECURSIVELY (issue #1434), enumerating individual ebook
 // files as units at whatever depth they live while keeping a genuine
@@ -461,28 +487,9 @@ const maxScanEntries = 1000
 // filename alone — returning a per-unit match list to review and bulk-import. No
 // state is modified.
 func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
-	path := filepath.Clean(r.URL.Query().Get("path"))
-	if path == "" || path == "." {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path parameter required"})
-		return
-	}
-	if !filepath.IsAbs(path) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path must be absolute"})
-		return
-	}
-	resolved, ok := h.roots.ResolveContained(r.Context(), path)
-	if !ok {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "path is outside the configured library roots"})
-		return
-	}
-	path = resolved
-	info, err := os.Stat(path) //nolint:gosec // #nosec G304 -- symlink-resolved and confirmed inside a configured library root; RequireAdmin enforced at route level
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("path not accessible: %v", err)})
-		return
-	}
-	if !info.IsDir() {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path must be a folder; use lookup for a single book"})
+	path, status, message := h.resolveImportFolder(r.Context(), r.URL.Query().Get("path"))
+	if status != 0 {
+		writeJSON(w, status, map[string]string{"error": message})
 		return
 	}
 	start := time.Now()

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -431,6 +431,31 @@ func fileMatchesTracked(path string, tracked []os.FileInfo) bool {
 	return false
 }
 
+// directoryMatchesTracked reports whether every importable file below path is
+// already registered in book_files. Directory units represent either a
+// multi-format ebook or a folder audiobook, so checking only the directory's
+// own path cannot identify an already-imported unit. A directory with even one
+// untracked ebook/audio file remains eligible for import.
+func directoryMatchesTracked(path string, tracked map[string]struct{}, trackedFiles []os.FileInfo) bool {
+	found := false
+	allTracked := true
+	_ = filepath.WalkDir(path, func(p string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			allTracked = false
+			return nil
+		}
+		if entry.IsDir() || (!importer.IsEbookFile(p) && !importer.IsAudioFile(p)) {
+			return nil
+		}
+		found = true
+		if _, ok := tracked[filepath.Clean(p)]; !ok && !fileMatchesTracked(p, trackedFiles) {
+			allTracked = false
+		}
+		return nil
+	})
+	return found && allTracked
+}
+
 // ScanItem is one candidate book unit discovered under a folder during Scan.
 type ScanItem struct {
 	Path           string        `json:"path"`
@@ -527,7 +552,14 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	}
 	filteredCands := cands[:0]
 	for _, c := range cands {
-		if _, ok := tracked[filepath.Clean(c.path)]; ok || fileMatchesTracked(c.path, trackedFiles) {
+		alreadyTracked := false
+		if c.isDir {
+			alreadyTracked = directoryMatchesTracked(c.path, tracked, trackedFiles)
+		} else {
+			_, alreadyTracked = tracked[filepath.Clean(c.path)]
+			alreadyTracked = alreadyTracked || fileMatchesTracked(c.path, trackedFiles)
+		}
+		if alreadyTracked {
 			continue
 		}
 		filteredCands = append(filteredCands, c)

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -457,30 +457,24 @@ func directoryMatchesTracked(path string, tracked map[string]struct{}, trackedFi
 }
 
 // bookHasImportedFormat reports whether the matched book already has an
-// on-disk file or directory for format. Manual import's idempotency guard will
-// skip such a candidate, so presenting it in the scan only creates a row that
-// appears importable but can never change state.
-func bookHasImportedFormat(book *models.Book, format string) bool {
+// on-disk file or directory for format. Read book_files directly rather than
+// relying on the hydrated compatibility fields on models.Book: LookupBatchLayout
+// may receive a book value from a catalogue projection where those fields are
+// empty even though the tracking row exists. This must match the importer's
+// idempotency guard, or a copied manual-import source will keep reappearing.
+func bookHasImportedFormat(book *models.Book, format string, files []models.BookFile) bool {
 	if book == nil {
 		return false
 	}
-	var path string
-	switch format {
-	case models.MediaTypeAudiobook:
-		path = book.AudiobookFilePath
-	case models.MediaTypeEbook:
-		path = book.EbookFilePath
-		if path == "" {
-			path = book.FilePath
+	for _, file := range files {
+		if file.Format != format {
+			continue
 		}
-	default:
-		return false
+		if _, err := os.Stat(file.Path); err == nil {
+			return true
+		}
 	}
-	if path == "" {
-		return false
-	}
-	_, err := os.Stat(path)
-	return err == nil
+	return false
 }
 
 // ScanItem is one candidate book unit discovered under a folder during Scan.
@@ -615,8 +609,14 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	filteredCands = cands[:0]
 	filteredResults := results[:0]
 	for i, res := range results {
-		if res.Match == "confident" && bookHasImportedFormat(res.Book, res.DetectedFormat) {
-			continue
+		if res.Match == "confident" && res.Book != nil {
+			files, filesErr := h.books.ListFiles(r.Context(), res.Book.ID)
+			if filesErr != nil {
+				slog.Warn("bulk folder import scan could not verify matched book files; retaining candidate",
+					"bookID", res.Book.ID, "path", cands[i].path, "error", filesErr)
+			} else if bookHasImportedFormat(res.Book, res.DetectedFormat, files) {
+				continue
+			}
 		}
 		filteredCands = append(filteredCands, cands[i])
 		filteredResults = append(filteredResults, res)

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -486,7 +486,7 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	for i, c := range cands {
 		paths[i] = c.path
 	}
-	trackedPaths, err := h.books.ListAllFilePaths(r.Context())
+	trackedPaths, err := h.books.ListAllBookFilePaths(r.Context())
 	if err != nil {
 		slog.Error("bulk folder import scan failed to load tracked files", "path", path, "error", err)
 		writeServerError(w, r, err)

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -414,6 +414,23 @@ func (h *ManualImportHandler) removeStaleSource(ctx context.Context, src string,
 	_ = os.Remove(filepath.Dir(src)) // best-effort: prune the now-empty folder
 }
 
+// fileMatchesTracked reports whether path is another directory entry for a
+// file already registered in book_files. Imports may hard-link the source into
+// its canonical library destination, so comparing path strings alone is not
+// sufficient to keep a repeated scan from presenting the same file again.
+func fileMatchesTracked(path string, tracked []os.FileInfo) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	for _, trackedInfo := range tracked {
+		if os.SameFile(info, trackedInfo) {
+			return true
+		}
+	}
+	return false
+}
+
 // ScanItem is one candidate book unit discovered under a folder during Scan.
 type ScanItem struct {
 	Path           string        `json:"path"`
@@ -493,12 +510,17 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tracked := make(map[string]struct{}, len(trackedPaths))
+	trackedFiles := make([]os.FileInfo, 0, len(trackedPaths))
 	for _, trackedPath := range trackedPaths {
-		tracked[filepath.Clean(trackedPath)] = struct{}{}
+		cleaned := filepath.Clean(trackedPath)
+		tracked[cleaned] = struct{}{}
+		if info, statErr := os.Stat(cleaned); statErr == nil {
+			trackedFiles = append(trackedFiles, info)
+		}
 	}
 	filteredCands := cands[:0]
 	for _, c := range cands {
-		if _, ok := tracked[filepath.Clean(c.path)]; ok {
+		if _, ok := tracked[filepath.Clean(c.path)]; ok || fileMatchesTracked(c.path, trackedFiles) {
 			continue
 		}
 		filteredCands = append(filteredCands, c)

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -486,6 +486,28 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	for i, c := range cands {
 		paths[i] = c.path
 	}
+	trackedPaths, err := h.books.ListAllFilePaths(r.Context())
+	if err != nil {
+		slog.Error("bulk folder import scan failed to load tracked files", "path", path, "error", err)
+		writeServerError(w, r, err)
+		return
+	}
+	tracked := make(map[string]struct{}, len(trackedPaths))
+	for _, trackedPath := range trackedPaths {
+		tracked[filepath.Clean(trackedPath)] = struct{}{}
+	}
+	filteredCands := cands[:0]
+	for _, c := range cands {
+		if _, ok := tracked[filepath.Clean(c.path)]; ok {
+			continue
+		}
+		filteredCands = append(filteredCands, c)
+	}
+	cands = filteredCands
+	paths = paths[:0]
+	for _, c := range cands {
+		paths = append(paths, c.path)
+	}
 	results, err := h.scanner.LookupBatchLayout(r.Context(), path, paths)
 	if err != nil {
 		slog.Error("bulk folder import scan failed to load catalogue", "path", path, "error", err)

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -40,6 +40,9 @@ type ManualImportHandler struct {
 	// drain them before the database closes (#1458, #2371). Optional: without
 	// it they run untracked, which is what tests and non-wired callers get.
 	jobs *jobs.Group
+	// trackedCache holds Scan's already-tracked index, rebuilt only when
+	// book_files changes (see trackedFileIndex, #2480).
+	trackedCache trackedFileCache
 }
 
 func NewManualImportHandler(scanner manualImportScanner, downloads *db.DownloadRepo, books *db.BookRepo) *ManualImportHandler {
@@ -487,6 +490,13 @@ type ScanItem struct {
 	DetectedFormat string        `json:"detectedFormat"`
 	Book           *models.Book  `json:"book,omitempty"`
 	Candidates     []models.Book `json:"candidates,omitempty"`
+	// AlreadyImported reports whether this unit is already tracked in
+	// book_files (directly, as a hardlink of a tracked file, or as a
+	// confident catalogue match whose book already has that format on disk).
+	// Such units are excluded by default; includeImported=true surfaces them
+	// instead, labelled, so a corrupt file or one needing a relink can still
+	// be found through this scan (#2480).
+	AlreadyImported bool `json:"alreadyImported"`
 }
 
 // ScanResponse is the result of scanning a folder for importable book units.
@@ -498,6 +508,15 @@ type ScanResponse struct {
 // maxScanEntries caps how many book units a single Scan returns so pointing at
 // an enormous tree can't produce an unbounded response or stall the request.
 const maxScanEntries = 1000
+
+// maxScanRounds bounds how many times Scan re-walks the tree to refill the
+// page after the already-imported filters drop some of a round's candidates
+// (#2480). enumerateImportUnits has no way to resume mid-tree, so each round
+// re-walks from the root; the cap bounds the worst case — a library that has
+// already been entirely re-imported — to a small constant multiple of a
+// single walk's cost, consistent with the existing maxWalkEntries/maxWalkDepth
+// guards.
+const maxScanRounds = 4
 
 // resolveImportFolder validates the user-selected scan folder and returns the
 // symlink-resolved path that is safe for subsequent filesystem operations.
@@ -525,20 +544,57 @@ func (h *ManualImportHandler) resolveImportFolder(ctx context.Context, rawPath s
 	return resolved, 0, ""
 }
 
-// Scan handles GET /api/v1/queue/manual-import/scan?path=...
+// isAlreadyTracked reports whether path (a file or, when isDir, a directory
+// unit) is already present in book_files, either at the exact path (tracked)
+// or as a hardlink of one (trackedFiles, via fileMatchesTracked /
+// directoryMatchesTracked).
+func isAlreadyTracked(path string, isDir bool, tracked map[string]struct{}, trackedFiles []os.FileInfo) bool {
+	if isDir {
+		return directoryMatchesTracked(path, tracked, trackedFiles)
+	}
+	if _, ok := tracked[filepath.Clean(path)]; ok {
+		return true
+	}
+	return fileMatchesTracked(path, trackedFiles)
+}
+
+// Scan handles GET /api/v1/queue/manual-import/scan?path=...&includeImported=...
 // It walks a folder RECURSIVELY (issue #1434), enumerating individual ebook
 // files as units at whatever depth they live while keeping a genuine
 // folder-based audiobook as a single unit, and runs one catalogue-backed batch
 // lookup — matching by embedded EPUB metadata and folder-derived author, not the
 // filename alone — returning a per-unit match list to review and bulk-import. No
 // state is modified.
+//
+// Units already tracked in book_files (directly, via a hardlink, or as a
+// confident match whose book already has that format on disk) are filtered
+// out during the walk itself rather than after enumerateImportUnits' 1000-unit
+// cap — filtering the capped result let an already-imported folder starve the
+// cap and come back empty even though untracked files existed further down
+// the tree (#2480). When the post-lookup format check still drops units from
+// a round, Scan re-walks (bounded by maxScanRounds) to refill the page rather
+// than return a short page while truncated is still true.
+//
+// includeImported=true disables both filters and labels each unit's
+// AlreadyImported status instead of excluding it, so an already-imported file
+// that's corrupt or needs a relink can still be found here.
 func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	path, status, message := h.resolveImportFolder(r.Context(), r.URL.Query().Get("path"))
 	if status != 0 {
 		writeJSON(w, status, map[string]string{"error": message})
 		return
 	}
+	includeImported := r.URL.Query().Get("includeImported") == "true"
 	start := time.Now()
+
+	tracked, trackedFiles, err := h.trackedFileIndex(r.Context(), path)
+	if err != nil {
+		slog.Error("bulk folder import scan failed to load tracked files", "path", path, "error", err)
+		writeServerError(w, r, err)
+		return
+	}
+
+	slog.Info("bulk folder import scan started", "path", path, "includeImported", includeImported)
 
 	// Enumerate importable units by walking the tree RECURSIVELY (issue #1434):
 	// individual ebook files become units at whatever depth they live, while a
@@ -548,105 +604,100 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	// happened to match. A single catalogue-backed batch lookup then matches them
 	// all at once — the per-item full-table scan that stalled large scans past the
 	// server WriteTimeout stays fixed (issue #1473).
-	cands, truncated := enumerateImportUnits(path, maxScanEntries)
+	items := make([]ScanItem, 0, maxScanEntries)
+	matched := 0
+	truncated := false
+	alreadyConsumed := 0
+	roundsRun := 0
 
-	slog.Info("bulk folder import scan started", "path", path, "entries", len(cands), "truncated", truncated)
+	for round := 0; round < maxScanRounds; round++ {
+		remaining := maxScanEntries - len(items)
+		if remaining <= 0 {
+			break
+		}
+		roundsRun++
+		seen := 0
+		skipToOffset := alreadyConsumed
+		roundSkip := func(p string, isDir bool) bool {
+			if !includeImported && isAlreadyTracked(p, isDir, tracked, trackedFiles) {
+				return true
+			}
+			seen++
+			return seen <= skipToOffset
+		}
+		cands, roundTruncated := enumerateImportUnits(path, remaining, roundSkip)
+		truncated = roundTruncated
+		alreadyConsumed += len(cands)
+		if len(cands) == 0 {
+			break
+		}
 
-	paths := make([]string, len(cands))
-	for i, c := range cands {
-		paths[i] = c.path
-	}
-	trackedPaths, err := h.books.ListAllBookFilePaths(r.Context())
-	if err != nil {
-		slog.Error("bulk folder import scan failed to load tracked files", "path", path, "error", err)
-		writeServerError(w, r, err)
-		return
-	}
-	tracked := make(map[string]struct{}, len(trackedPaths))
-	trackedFiles := make([]os.FileInfo, 0, len(trackedPaths))
-	for _, trackedPath := range trackedPaths {
-		cleaned := filepath.Clean(trackedPath)
-		tracked[cleaned] = struct{}{}
-		if info, statErr := os.Stat(cleaned); statErr == nil {
-			trackedFiles = append(trackedFiles, info)
-			if info.IsDir() {
-				_ = filepath.WalkDir(cleaned, func(p string, entry os.DirEntry, walkErr error) error {
-					if walkErr == nil && !entry.IsDir() && (importer.IsEbookFile(p) || importer.IsAudioFile(p)) {
-						if childInfo, childErr := os.Stat(p); childErr == nil {
-							trackedFiles = append(trackedFiles, childInfo)
-						}
-					}
-					return nil
-				})
+		roundPaths := make([]string, len(cands))
+		for i, c := range cands {
+			roundPaths[i] = c.path
+		}
+		results, err := h.scanner.LookupBatchLayout(r.Context(), path, roundPaths)
+		if err != nil {
+			slog.Error("bulk folder import scan failed to load catalogue", "path", path, "error", err)
+			writeServerError(w, r, err)
+			return
+		}
+
+		// Batch the confident matches' book_files lookup into one query instead
+		// of one round trip per match (#2480).
+		bookIDs := make([]int64, 0, len(results))
+		seenBookIDs := make(map[int64]bool, len(results))
+		for _, res := range results {
+			if res.Match == "confident" && res.Book != nil && !seenBookIDs[res.Book.ID] {
+				seenBookIDs[res.Book.ID] = true
+				bookIDs = append(bookIDs, res.Book.ID)
 			}
 		}
-	}
-	filteredCands := cands[:0]
-	for _, c := range cands {
-		alreadyTracked := false
-		if c.isDir {
-			alreadyTracked = directoryMatchesTracked(c.path, tracked, trackedFiles)
-		} else {
-			_, alreadyTracked = tracked[filepath.Clean(c.path)]
-			alreadyTracked = alreadyTracked || fileMatchesTracked(c.path, trackedFiles)
+		filesByBook, err := h.books.ListFilesForBooks(r.Context(), bookIDs)
+		if err != nil {
+			slog.Warn("bulk folder import scan could not verify matched book files; retaining candidates",
+				"path", path, "error", err)
+			filesByBook = map[int64][]models.BookFile{}
 		}
-		if alreadyTracked {
-			continue
-		}
-		filteredCands = append(filteredCands, c)
-	}
-	cands = filteredCands
-	paths = paths[:0]
-	for _, c := range cands {
-		paths = append(paths, c.path)
-	}
-	results, err := h.scanner.LookupBatchLayout(r.Context(), path, paths)
-	if err != nil {
-		slog.Error("bulk folder import scan failed to load catalogue", "path", path, "error", err)
-		writeServerError(w, r, err)
-		return
-	}
-	filteredCands = cands[:0]
-	filteredResults := results[:0]
-	for i, res := range results {
-		if res.Match == "confident" && res.Book != nil {
-			files, filesErr := h.books.ListFiles(r.Context(), res.Book.ID)
-			if filesErr != nil {
-				slog.Warn("bulk folder import scan could not verify matched book files; retaining candidate",
-					"bookID", res.Book.ID, "path", cands[i].path, "error", filesErr)
-			} else if bookHasImportedFormat(res.Book, res.DetectedFormat, files) {
+
+		for i, res := range results {
+			c := cands[i]
+			alreadyImported := isAlreadyTracked(c.path, c.isDir, tracked, trackedFiles)
+			if !alreadyImported && res.Match == "confident" && res.Book != nil &&
+				bookHasImportedFormat(res.Book, res.DetectedFormat, filesByBook[res.Book.ID]) {
+				alreadyImported = true
+			}
+			if alreadyImported && !includeImported {
 				continue
 			}
+			if res.Match == "confident" {
+				matched++
+			}
+			items = append(items, ScanItem{
+				Path:            c.path,
+				Name:            c.name,
+				Match:           res.Match,
+				ParsedTitle:     res.ParsedTitle,
+				ParsedAuthor:    res.ParsedAuthor,
+				DetectedFormat:  res.DetectedFormat,
+				Book:            res.Book,
+				Candidates:      res.Candidates,
+				AlreadyImported: alreadyImported,
+			})
 		}
-		filteredCands = append(filteredCands, cands[i])
-		filteredResults = append(filteredResults, res)
-	}
-	cands = filteredCands
-	results = filteredResults
 
-	resp := ScanResponse{Items: make([]ScanItem, 0, len(cands)), Truncated: truncated}
-	matched := 0
-	for i, c := range cands {
-		res := results[i]
-		if res.Match == "confident" {
-			matched++
+		if !roundTruncated {
+			break // tree exhausted; nothing more to find regardless of round budget
 		}
-		resp.Items = append(resp.Items, ScanItem{
-			Path:           c.path,
-			Name:           c.name,
-			Match:          res.Match,
-			ParsedTitle:    res.ParsedTitle,
-			ParsedAuthor:   res.ParsedAuthor,
-			DetectedFormat: res.DetectedFormat,
-			Book:           res.Book,
-			Candidates:     res.Candidates,
-		})
 	}
+
+	resp := ScanResponse{Items: items, Truncated: truncated}
 	slog.Info("bulk folder import scan complete",
 		"path", path,
 		"duration", time.Since(start),
 		"items", len(resp.Items),
 		"matched", matched,
+		"rounds", roundsRun,
 		"truncated", truncated)
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/manual_import_cache.go
+++ b/internal/api/manual_import_cache.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/vavallee/bindery/internal/importer"
+)
+
+// trackedFileCache holds the manual-import scan's "already tracked" index —
+// the same-path set plus the os.FileInfo values needed for hardlink detection
+// (fileMatchesTracked/directoryMatchesTracked) — rebuilt only when book_files
+// has actually changed, or the scanned root sits on a different device than
+// the index it holds was built for (#2480).
+//
+// Every scan used to re-stat the entire book_files table regardless of the
+// scanned folder's size, which is expensive on network storage (#1473 already
+// hit the same handler's write timeout once). Caching the index keyed on
+// BookFilesVersion turns that into "stat the library once per book_files
+// write, anywhere in the app" instead of "once per scan request".
+type trackedFileCache struct {
+	mu sync.Mutex
+
+	version      int64
+	rootDevID    uint64
+	rootDevKnown bool
+	tracked      map[string]struct{}
+	trackedFiles []os.FileInfo
+}
+
+// trackedFileIndex returns the current already-tracked path set and the
+// os.FileInfo values needed for hardlink detection against scanRoot,
+// rebuilding only when book_files has changed since the last build or
+// scanRoot's device differs from the one the cached index was built for.
+//
+// A tracked path confirmed to sit on a different device than scanRoot
+// (confirmedCrossDevice) can never be a hardlink of anything under scanRoot,
+// so it skips the expensive os.Stat / directory walk that hardlink detection
+// otherwise needs — it still gets the cheap exact-path entry. This targets
+// network-storage setups where the library and a freshly scanned download
+// share live on different mounts (the NFS case called out in review on
+// #2480).
+func (h *ManualImportHandler) trackedFileIndex(ctx context.Context, scanRoot string) (map[string]struct{}, []os.FileInfo, error) {
+	version := h.books.BookFilesVersion()
+	rootDevID, rootDevKnown := deviceID(scanRoot)
+
+	h.trackedCache.mu.Lock()
+	defer h.trackedCache.mu.Unlock()
+
+	c := &h.trackedCache
+	if c.tracked != nil && c.version == version && c.rootDevID == rootDevID && c.rootDevKnown == rootDevKnown {
+		return c.tracked, c.trackedFiles, nil
+	}
+
+	trackedPaths, err := h.books.ListAllBookFilePaths(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	tracked := make(map[string]struct{}, len(trackedPaths))
+	trackedFiles := make([]os.FileInfo, 0, len(trackedPaths))
+	for _, trackedPath := range trackedPaths {
+		cleaned := filepath.Clean(trackedPath)
+		tracked[cleaned] = struct{}{}
+		if confirmedCrossDevice(scanRoot, cleaned) {
+			continue
+		}
+		info, statErr := os.Stat(cleaned) //nolint:gosec // #nosec G304 -- path comes from book_files, populated only by prior imports through this same admin-gated handler
+		if statErr != nil {
+			continue
+		}
+		trackedFiles = append(trackedFiles, info)
+		if !info.IsDir() {
+			continue
+		}
+		_ = filepath.WalkDir(cleaned, func(p string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil || entry.IsDir() || (!importer.IsEbookFile(p) && !importer.IsAudioFile(p)) {
+				return nil
+			}
+			if childInfo, childErr := os.Stat(p); childErr == nil { //nolint:gosec // #nosec G304 -- p is a directory entry beneath a book_files path, same trust boundary as above
+				trackedFiles = append(trackedFiles, childInfo)
+			}
+			return nil
+		})
+	}
+
+	c.version = version
+	c.rootDevID = rootDevID
+	c.rootDevKnown = rootDevKnown
+	c.tracked = tracked
+	c.trackedFiles = trackedFiles
+	return tracked, trackedFiles, nil
+}

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -1192,6 +1192,49 @@ func TestManualImportScan_EnumeratesBookUnits(t *testing.T) {
 	}
 }
 
+func TestManualImportScan_SkipsAlreadyTrackedFiles(t *testing.T) {
+	t.Parallel()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	stub := &stubManualImportScanner{lookupResult: importer.LookupResult{Match: "none"}}
+	h := NewManualImportHandler(stub, downloads, books)
+
+	trackedBook := seedBook(t, authors, books, ctx)
+	root := t.TempDir()
+	tracked := filepath.Join(root, "already-imported.epub")
+	newFile := filepath.Join(root, "new-book.epub")
+	writeTestFile(t, tracked)
+	writeTestFile(t, newFile)
+	if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, tracked); err != nil {
+		t.Fatalf("attach tracked file: %v", err)
+	}
+	h.WithRoots(NewLibraryRoots(nil, root))
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequest(root))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp ScanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].Path != newFile {
+		t.Fatalf("items = %+v, want only the new file %q", resp.Items, newFile)
+	}
+	if stub.lookupBatchCalls != 1 {
+		t.Fatalf("LookupBatch called %d times, want 1", stub.lookupBatchCalls)
+	}
+}
+
 // TestManualImportScan_AllowsConfiguredRootItself reproduces #1373: pasting a
 // configured root ("/books") or an allow-listed download dir ("/downloads")
 // into bulk import must scan it, not 403. Before the fix, ResolveContained

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -1235,6 +1235,33 @@ func TestManualImportScan_SkipsAlreadyTrackedFiles(t *testing.T) {
 	}
 }
 
+func TestManualImportScan_TrackedFilesError(t *testing.T) {
+	t.Parallel()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	books := db.NewBookRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "book.epub"))
+	h.WithRoots(NewLibraryRoots(nil, root))
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequest(root))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body = %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "database is closed") {
+		t.Errorf("body leaked database error: %q", rec.Body.String())
+	}
+}
+
 // TestManualImportScan_AllowsConfiguredRootItself reproduces #1373: pasting a
 // configured root ("/books") or an allow-listed download dir ("/downloads")
 // into bulk import must scan it, not 403. Before the fix, ResolveContained

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -1279,6 +1279,52 @@ func TestManualImportScan_SkipsAlreadyTrackedFiles(t *testing.T) {
 	}
 }
 
+func TestManualImportScan_SkipsCopiedSourceForTrackedBook(t *testing.T) {
+	t.Parallel()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	trackedBook := seedBook(t, authors, books, ctx)
+	root := t.TempDir()
+	source := filepath.Join(root, "Department Q", "7. A Department Q Novel - Caroline Waight, Jussi Adler-Olsen (2024).epub")
+	canonical := filepath.Join(root, "library", "Department Q.epub")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(canonical), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, source)
+	writeTestFile(t, canonical)
+	if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, canonical); err != nil {
+		t.Fatalf("attach tracked file: %v", err)
+	}
+	stub := &stubManualImportScanner{lookupResult: importer.LookupResult{
+		Match: "confident", Book: trackedBook, DetectedFormat: models.MediaTypeEbook,
+	}}
+	h := NewManualImportHandler(stub, downloads, books).WithRoots(NewLibraryRoots(nil, root))
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequest(root))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp ScanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 0 {
+		t.Fatalf("items = %+v, want copied source skipped because the matched format is already tracked", resp.Items)
+	}
+}
+
 func TestManualImportScan_TrackedFilesError(t *testing.T) {
 	t.Parallel()
 	database, err := db.OpenMemory()

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -1192,6 +1192,58 @@ func TestManualImportScan_EnumeratesBookUnits(t *testing.T) {
 	}
 }
 
+func TestFileMatchesTracked_EdgeCases(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	trackedPath := filepath.Join(root, "tracked.epub")
+	otherPath := filepath.Join(root, "other.epub")
+	writeTestFile(t, trackedPath)
+	writeTestFile(t, otherPath)
+	trackedInfo, err := os.Stat(trackedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !fileMatchesTracked(trackedPath, []os.FileInfo{trackedInfo}) {
+		t.Fatal("tracked path should match its own file identity")
+	}
+	if fileMatchesTracked(otherPath, []os.FileInfo{trackedInfo}) {
+		t.Fatal("different file should not match tracked identity")
+	}
+	if fileMatchesTracked(filepath.Join(root, "missing.epub"), []os.FileInfo{trackedInfo}) {
+		t.Fatal("missing path should not match")
+	}
+}
+
+func TestDirectoryMatchesTracked_WalkError(t *testing.T) {
+	t.Parallel()
+	if directoryMatchesTracked(filepath.Join(t.TempDir(), "missing"), nil, nil) {
+		t.Fatal("unreadable or missing directory should not be considered tracked")
+	}
+}
+
+func TestBookHasImportedFormat_EdgeCases(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	present := filepath.Join(root, "book.epub")
+	missing := filepath.Join(root, "missing.epub")
+	writeTestFile(t, present)
+	book := &models.Book{ID: 1}
+
+	if bookHasImportedFormat(nil, models.MediaTypeEbook, nil) {
+		t.Fatal("nil book should not report an imported format")
+	}
+	if bookHasImportedFormat(book, models.MediaTypeEbook, []models.BookFile{{Format: models.MediaTypeAudiobook, Path: present}}) {
+		t.Fatal("different format should not count")
+	}
+	if bookHasImportedFormat(book, models.MediaTypeEbook, []models.BookFile{{Format: models.MediaTypeEbook, Path: missing}}) {
+		t.Fatal("missing file should not count as imported")
+	}
+	if !bookHasImportedFormat(book, models.MediaTypeEbook, []models.BookFile{{Format: models.MediaTypeEbook, Path: present}}) {
+		t.Fatal("present file should count as imported")
+	}
+}
+
 func TestDirectoryMatchesTracked(t *testing.T) {
 	root := t.TempDir()
 	trackedPath := filepath.Join(root, "tracked.epub")

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -1213,7 +1213,14 @@ func TestManualImportScan_SkipsAlreadyTrackedFiles(t *testing.T) {
 	newFile := filepath.Join(root, "new-book.epub")
 	writeTestFile(t, tracked)
 	writeTestFile(t, newFile)
-	if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, tracked); err != nil {
+	canonical := filepath.Join(root, "canonical", "already-imported.epub")
+	if err := os.MkdirAll(filepath.Dir(canonical), 0o755); err != nil {
+		t.Fatalf("mkdir canonical path: %v", err)
+	}
+	if err := os.Link(tracked, canonical); err != nil {
+		t.Fatalf("hard-link tracked file: %v", err)
+	}
+	if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, canonical); err != nil {
 		t.Fatalf("attach tracked file: %v", err)
 	}
 	h.WithRoots(NewLibraryRoots(nil, root))

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -1192,6 +1192,43 @@ func TestManualImportScan_EnumeratesBookUnits(t *testing.T) {
 	}
 }
 
+func TestDirectoryMatchesTracked(t *testing.T) {
+	root := t.TempDir()
+	trackedPath := filepath.Join(root, "tracked.epub")
+	otherTrackedPath := filepath.Join(root, "tracked.mobi")
+	if err := os.WriteFile(trackedPath, []byte("epub"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(otherTrackedPath, []byte("mobi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tracked := map[string]struct{}{
+		filepath.Clean(trackedPath):      {},
+		filepath.Clean(otherTrackedPath): {},
+	}
+	trackedFiles := []os.FileInfo{}
+	for _, path := range []string{trackedPath, otherTrackedPath} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		trackedFiles = append(trackedFiles, info)
+	}
+
+	if !directoryMatchesTracked(root, tracked, trackedFiles) {
+		t.Fatal("fully tracked directory should be skipped")
+	}
+
+	untrackedPath := filepath.Join(root, "new.epub")
+	if err := os.WriteFile(untrackedPath, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if directoryMatchesTracked(root, tracked, trackedFiles) {
+		t.Fatal("directory with an untracked importable file should remain eligible")
+	}
+}
+
 func TestManualImportScan_SkipsAlreadyTrackedFiles(t *testing.T) {
 	t.Parallel()
 	database, err := db.OpenMemory()

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1374,6 +1375,272 @@ func TestManualImportScan_SkipsCopiedSourceForTrackedBook(t *testing.T) {
 	}
 	if len(resp.Items) != 0 {
 		t.Fatalf("items = %+v, want copied source skipped because the matched format is already tracked", resp.Items)
+	}
+}
+
+// scanRequestIncludeImported builds a GET request for the manual-import scan
+// endpoint with includeImported=true, so already-tracked units are surfaced
+// (labelled) instead of excluded (#2480).
+func scanRequestIncludeImported(path string) *http.Request {
+	u := "/api/v1/queue/manual-import/scan?" + url.Values{"path": {path}, "includeImported": {"true"}}.Encode()
+	return httptest.NewRequest(http.MethodGet, u, nil)
+}
+
+// TestManualImportScan_LargeTrackedRegionDoesNotStarveTheCap is the exact
+// repro from the #2480 review: enumerateImportUnits' 1000-unit cap trips
+// entirely within an already-tracked region (walk order is alphabetical, and
+// the tracked files sort first), so filtering the CAPPED result — rather than
+// filtering during the walk itself — comes back empty with truncated=true
+// even though untracked files exist further down the tree. The fix folds the
+// tracked check into the walk so the cap counts only surfaced units.
+func TestManualImportScan_LargeTrackedRegionDoesNotStarveTheCap(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	trackedBook := seedBook(t, authors, books, ctx)
+	stub := &stubManualImportScanner{lookupResult: importer.LookupResult{Match: "none"}}
+	h := NewManualImportHandler(stub, downloads, books)
+	root := t.TempDir()
+
+	const trackedCount = maxScanEntries + 5
+	for i := 0; i < trackedCount; i++ {
+		// "a"-prefixed names sort before the "z"-prefixed new files below, so
+		// the pre-fix walk order hits the cap entirely within the tracked
+		// region before ever reaching a new file.
+		p := filepath.Join(root, fmt.Sprintf("a-tracked-%04d.epub", i))
+		writeTestFile(t, p)
+		if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, p); err != nil {
+			t.Fatalf("track file %d: %v", i, err)
+		}
+	}
+	const newCount = 5
+	newPaths := make([]string, 0, newCount)
+	for i := 0; i < newCount; i++ {
+		p := filepath.Join(root, fmt.Sprintf("z-new-%d.epub", i))
+		writeTestFile(t, p)
+		newPaths = append(newPaths, p)
+	}
+	h.WithRoots(NewLibraryRoots(nil, root))
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequest(root))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp ScanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Truncated {
+		t.Error("truncated = true, want false: every unit was either tracked or one of the returned new files")
+	}
+	if len(resp.Items) != newCount {
+		t.Fatalf("items = %d, want exactly the %d new files; got %+v", len(resp.Items), newCount, resp.Items)
+	}
+	got := map[string]bool{}
+	for _, it := range resp.Items {
+		got[it.Path] = true
+		if it.AlreadyImported {
+			t.Errorf("new file %q should not be labelled AlreadyImported", it.Path)
+		}
+	}
+	for _, p := range newPaths {
+		if !got[p] {
+			t.Errorf("missing expected new file %q in response", p)
+		}
+	}
+}
+
+// TestManualImportScan_RefillsAcrossRoundsWhenFormatFilterEmptiesAPage covers
+// the second, post-lookup already-imported filter (bookHasImportedFormat):
+// when it empties an entire round, Scan re-walks for more rather than
+// returning a short page while truncated is still true (#2480).
+func TestManualImportScan_RefillsAcrossRoundsWhenFormatFilterEmptiesAPage(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	trackedBook := seedBook(t, authors, books, ctx)
+	root := t.TempDir()
+	canonical := filepath.Join(root, "library", "canonical.epub")
+	writeTestFile(t, canonical)
+	if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, canonical); err != nil {
+		t.Fatalf("attach tracked file: %v", err)
+	}
+
+	// Every one of these confidently matches trackedBook, which already has an
+	// ebook file (canonical, above) — so the format filter drops every single
+	// one. One more than maxScanRounds full rounds' worth, so even the last
+	// round hits its own cap (roundTruncated stays true) instead of
+	// exhausting the tree — otherwise the walk would legitimately finish and
+	// correctly report truncated=false.
+	const copyCount = maxScanEntries*maxScanRounds + 1
+	for i := 0; i < copyCount; i++ {
+		writeTestFile(t, filepath.Join(root, "copies", fmt.Sprintf("copy-%04d.epub", i)))
+	}
+	stub := &stubManualImportScanner{lookupResult: importer.LookupResult{
+		Match: "confident", Book: trackedBook, DetectedFormat: models.MediaTypeEbook,
+	}}
+	h := NewManualImportHandler(stub, downloads, books).WithRoots(NewLibraryRoots(nil, root))
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequest(root))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp ScanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 0 {
+		t.Fatalf("items = %+v, want none: every copy matches an already-imported format", resp.Items)
+	}
+	if !resp.Truncated {
+		t.Error("truncated = false, want true: more copies exist beyond the round budget")
+	}
+	// The round budget bounds cost: exactly maxScanRounds batch lookups, not
+	// one massive or unbounded walk.
+	if stub.lookupBatchCalls != maxScanRounds {
+		t.Errorf("LookupBatch called %d times, want exactly maxScanRounds=%d", stub.lookupBatchCalls, maxScanRounds)
+	}
+}
+
+// TestManualImportScan_IncludeImportedSurfacesTrackedUnits verifies
+// includeImported=true disables both already-imported filters and labels the
+// surfaced units instead of dropping them (#2480), so a corrupt already-
+// imported file or one needing a relink can still be found.
+func TestManualImportScan_IncludeImportedSurfacesTrackedUnits(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	trackedBook := seedBook(t, authors, books, ctx)
+	root := t.TempDir()
+
+	// Exact-path tracked file (filter 1).
+	trackedPath := filepath.Join(root, "already-imported.epub")
+	writeTestFile(t, trackedPath)
+	if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, trackedPath); err != nil {
+		t.Fatalf("attach tracked file: %v", err)
+	}
+	// A genuinely new file, for contrast.
+	newPath := filepath.Join(root, "new-book.epub")
+	writeTestFile(t, newPath)
+
+	stub := &stubManualImportScanner{lookupResult: importer.LookupResult{Match: "none"}}
+	h := NewManualImportHandler(stub, downloads, books).WithRoots(NewLibraryRoots(nil, root))
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequestIncludeImported(root))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp ScanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("items = %+v, want both the tracked and the new file surfaced", resp.Items)
+	}
+	byPath := map[string]ScanItem{}
+	for _, it := range resp.Items {
+		byPath[it.Path] = it
+	}
+	if !byPath[trackedPath].AlreadyImported {
+		t.Errorf("tracked file should be labelled AlreadyImported, got %+v", byPath[trackedPath])
+	}
+	if byPath[newPath].AlreadyImported {
+		t.Errorf("new file should not be labelled AlreadyImported, got %+v", byPath[newPath])
+	}
+
+	// Without the toggle, only the new file is returned (existing behavior).
+	rec2 := httptest.NewRecorder()
+	h.Scan(rec2, scanRequest(root))
+	var resp2 ScanResponse
+	if err := json.Unmarshal(rec2.Body.Bytes(), &resp2); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp2.Items) != 1 || resp2.Items[0].Path != newPath {
+		t.Fatalf("without includeImported, items = %+v, want only the new file", resp2.Items)
+	}
+}
+
+// TestManualImportHandler_TrackedFileIndex_CachesUntilBookFilesChange
+// verifies the tracked-file index is rebuilt only when book_files actually
+// changes (#2480): closing the database between two calls that see no
+// intervening write must not error, proving the second call served the
+// cached index rather than re-querying a now-closed DB.
+func TestManualImportHandler_TrackedFileIndex_CachesUntilBookFilesChange(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	trackedBook := seedBook(t, authors, books, ctx)
+	root := t.TempDir()
+	tracked := filepath.Join(root, "tracked.epub")
+	writeTestFile(t, tracked)
+	if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, tracked); err != nil {
+		t.Fatalf("attach tracked file: %v", err)
+	}
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+
+	set1, _, err := h.trackedFileIndex(ctx, root)
+	if err != nil {
+		t.Fatalf("first trackedFileIndex: %v", err)
+	}
+	if _, ok := set1[filepath.Clean(tracked)]; !ok {
+		t.Fatalf("expected %q in the tracked set, got %v", tracked, set1)
+	}
+
+	// Add a second tracked file — the version bump must force a rebuild on
+	// the next call even though we haven't closed the DB yet.
+	tracked2 := filepath.Join(root, "tracked2.epub")
+	writeTestFile(t, tracked2)
+	if err := books.AddBookFile(ctx, trackedBook.ID, models.MediaTypeEbook, tracked2); err != nil {
+		t.Fatalf("attach second tracked file: %v", err)
+	}
+	set2, _, err := h.trackedFileIndex(ctx, root)
+	if err != nil {
+		t.Fatalf("second trackedFileIndex: %v", err)
+	}
+	if _, ok := set2[filepath.Clean(tracked2)]; !ok {
+		t.Fatalf("expected the newly tracked file to appear after a book_files write, got %v", set2)
+	}
+
+	// No further writes: closing the DB must not surface an error on the next
+	// call, since nothing changed and the cache should be reused as-is.
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+	set3, _, err := h.trackedFileIndex(ctx, root)
+	if err != nil {
+		t.Fatalf("third trackedFileIndex should have served the cache without querying the closed DB: %v", err)
+	}
+	if len(set3) != len(set2) {
+		t.Errorf("cached set changed unexpectedly: %v vs %v", set2, set3)
 	}
 }
 

--- a/internal/api/samedevice_unix.go
+++ b/internal/api/samedevice_unix.go
@@ -46,6 +46,56 @@ func nearestExistingDir(p string) string {
 	return ""
 }
 
+// confirmedCrossDevice reports whether a and b are POSITIVELY confirmed to
+// reside on different filesystems by comparing their OS device IDs, walking
+// up to b's nearest existing ancestor when b does not exist yet. It returns
+// false — "not confirmed cross-device" — on any stat error or when the
+// device ID isn't exposed, deliberately erring toward the more expensive but
+// always-correct path rather than skipping a check we can't actually verify.
+// Used by the manual-import scan's tracked-file stat sweep (#2480) to skip
+// hardlink detection only for tracked paths that could never be a hardlink of
+// a scanned candidate; mirrors the same-device gate in hardlinkableReason
+// below (kept separate: that one needs the inverse, "confirmed same", plus
+// per-cause error messages this boolean doesn't carry).
+func confirmedCrossDevice(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	ai, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	bi, err := statExistingDevice(b)
+	if err != nil {
+		return false
+	}
+	aStat, aOK := ai.Sys().(*syscall.Stat_t)
+	bStat, bOK := bi.Sys().(*syscall.Stat_t)
+	if !aOK || !bOK {
+		return false
+	}
+	return aStat.Dev != bStat.Dev
+}
+
+// deviceID returns path's OS device ID as a cache key: two paths returning
+// (id, true) with equal id are stat-confirmed to share a device (compare with
+// confirmedCrossDevice); ok is false when the ID is unknown (stat failed, or
+// the platform doesn't expose one — see the Windows build of this function).
+// Used to key the manual-import scan's tracked-file cache (#2480) by the
+// scanned root's device, since which tracked paths get the expensive
+// hardlink stat/walk during a rebuild depends on that device.
+func deviceID(path string) (uint64, bool) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, false
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return uint64(st.Dev), true
+}
+
 // hardlinkableReason reports whether downloads in a can actually be
 // hard-linked into b and, when they can't, WHY — the generic "will copy
 // instead" banner sent users hunting through mount tables blind (#1427).

--- a/internal/api/samedevice_unix.go
+++ b/internal/api/samedevice_unix.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/vavallee/bindery/internal/importer"
 )
 
 // statExistingDevice stats p, walking up to the nearest existing ancestor
@@ -47,34 +49,27 @@ func nearestExistingDir(p string) string {
 }
 
 // confirmedCrossDevice reports whether a and b are POSITIVELY confirmed to
-// reside on different filesystems by comparing their OS device IDs, walking
-// up to b's nearest existing ancestor when b does not exist yet. It returns
-// false — "not confirmed cross-device" — on any stat error or when the
-// device ID isn't exposed, deliberately erring toward the more expensive but
-// always-correct path rather than skipping a check we can't actually verify.
-// Used by the manual-import scan's tracked-file stat sweep (#2480) to skip
-// hardlink detection only for tracked paths that could never be a hardlink of
-// a scanned candidate; mirrors the same-device gate in hardlinkableReason
-// below (kept separate: that one needs the inverse, "confirmed same", plus
-// per-cause error messages this boolean doesn't carry).
+// reside on different filesystems, walking up to b's nearest existing
+// ancestor when b does not exist yet. It returns false — "not confirmed
+// cross-device" — on any stat error, deliberately erring toward the more
+// expensive but always-correct path rather than skipping a check we can't
+// actually verify. Used by the manual-import scan's tracked-file stat sweep
+// (#2480) to skip hardlink detection only for tracked paths that could never
+// be a hardlink of a scanned candidate. The device comparison itself is
+// importer.SameDevice — this package already depends on internal/importer
+// throughout (manual_import.go, scan_walk.go, books.go, ...), so there is no
+// dependency reason to keep a second copy of that comparison here.
 func confirmedCrossDevice(a, b string) bool {
 	if a == "" || b == "" {
 		return false
 	}
-	ai, err := os.Stat(a)
-	if err != nil {
+	if _, err := os.Stat(a); err != nil {
 		return false
 	}
-	bi, err := statExistingDevice(b)
-	if err != nil {
+	if _, err := statExistingDevice(b); err != nil {
 		return false
 	}
-	aStat, aOK := ai.Sys().(*syscall.Stat_t)
-	bStat, bOK := bi.Sys().(*syscall.Stat_t)
-	if !aOK || !bOK {
-		return false
-	}
-	return aStat.Dev != bStat.Dev
+	return !importer.SameDevice(a, b)
 }
 
 // deviceID returns path's OS device ID as a cache key: two paths returning

--- a/internal/api/samedevice_unix_test.go
+++ b/internal/api/samedevice_unix_test.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+package api
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestConfirmedCrossDevice_SamePathNeverConfirmedCross verifies the
+// conservative default: two paths on the same device (the common case in
+// tests, and for the tracked-file stat sweep's own root) are never falsely
+// reported as confirmed cross-device (#2480).
+func TestConfirmedCrossDevice_SamePathNeverConfirmedCross(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	a := filepath.Join(root, "a.epub")
+	b := filepath.Join(root, "b.epub")
+	writeTestFile(t, a)
+	writeTestFile(t, b)
+
+	if confirmedCrossDevice(a, b) {
+		t.Error("two paths under the same tempdir should share a device")
+	}
+	if confirmedCrossDevice("", b) {
+		t.Error("empty path should not be confirmed cross-device")
+	}
+	if confirmedCrossDevice(a, filepath.Join(root, "missing.epub")) {
+		t.Error("a path whose nearest existing ancestor is still on the same device should not be confirmed cross-device")
+	}
+	if confirmedCrossDevice(filepath.Join(root, "missing-a.epub"), b) {
+		t.Error("stat error on a should report false, not a false positive")
+	}
+}
+
+// TestDeviceID_SameDirSameDevice verifies deviceID reports a usable, stable
+// identity for paths that do share a device, and (false) for a path that
+// doesn't exist — the manual-import scan's cache key (#2480) relies on both.
+func TestDeviceID_SameDirSameDevice(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	a := filepath.Join(root, "a.epub")
+	writeTestFile(t, a)
+
+	aID, aOK := deviceID(a)
+	rootID, rootOK := deviceID(root)
+	if !aOK || !rootOK {
+		t.Fatalf("expected deviceID to resolve for existing paths, got aOK=%v rootOK=%v", aOK, rootOK)
+	}
+	if aID != rootID {
+		t.Errorf("a file and its parent dir should report the same device: %d != %d", aID, rootID)
+	}
+
+	if _, ok := deviceID(filepath.Join(root, "missing.epub")); ok {
+		t.Error("deviceID for a nonexistent path should report ok=false")
+	}
+}

--- a/internal/api/samedevice_windows.go
+++ b/internal/api/samedevice_windows.go
@@ -9,3 +9,21 @@ package api
 func hardlinkableReason(_, _ string) (bool, string) {
 	return false, "hardlink detection is not supported on Windows; imports will copy instead"
 }
+
+// confirmedCrossDevice always returns false on Windows because device-ID
+// comparison via syscall.Stat_t is not available there, so the manual-import
+// scan's cross-device stat skip (#2480) can never positively confirm two
+// paths are on different filesystems — every tracked path still gets the
+// full stat/hardlink check, matching pre-#2480 behavior on this platform.
+func confirmedCrossDevice(_, _ string) bool {
+	return false
+}
+
+// deviceID always reports unknown on Windows, for the same reason as
+// confirmedCrossDevice. The manual-import scan's tracked-file cache (#2480)
+// treats "unknown" as a single shared cache key, which is correct here since
+// confirmedCrossDevice never skips the expensive check on this platform
+// anyway — the built index never actually depends on the scanned root.
+func deviceID(_ string) (uint64, bool) {
+	return 0, false
+}

--- a/internal/api/scan_walk.go
+++ b/internal/api/scan_walk.go
@@ -51,7 +51,15 @@ const (
 //
 // Enumeration stops once `limit` units are collected (truncated=true) or the
 // entry/depth guards trip. Units are returned in a stable, name-sorted order.
-func enumerateImportUnits(root string, limit int) (units []scanUnit, truncated bool) {
+//
+// skip, when non-nil, is consulted for every unit the walk would otherwise
+// emit; a unit it reports true for is dropped without counting toward limit
+// or truncation, so the walk keeps descending past it in search of `limit`
+// units skip accepts. Callers use this to filter out already-tracked units
+// during the walk itself, rather than capping first and filtering the capped
+// result — the latter can starve the cap entirely when most of a large,
+// already-imported folder sits ahead of any new files in walk order.
+func enumerateImportUnits(root string, limit int, skip func(path string, isDir bool) bool) (units []scanUnit, truncated bool) {
 	entriesSeen := 0
 	var walk func(dir string, depth int, isRoot bool)
 	walk = func(dir string, depth int, isRoot bool) {
@@ -86,6 +94,9 @@ func enumerateImportUnits(root string, limit int) (units []scanUnit, truncated b
 		sort.Strings(ebookFiles)
 
 		emit := func(path string, isDir bool) {
+			if skip != nil && skip(path, isDir) {
+				return
+			}
 			if len(units) >= limit {
 				truncated = true
 				return

--- a/internal/api/scan_walk_test.go
+++ b/internal/api/scan_walk_test.go
@@ -129,7 +129,7 @@ func TestEnumerateImportUnits_BoundaryHeuristic(t *testing.T) {
 				writeTestFile(t, filepath.Join(root, filepath.FromSlash(f)))
 			}
 
-			units, truncated := enumerateImportUnits(root, 1000)
+			units, truncated := enumerateImportUnits(root, 1000, nil)
 			if truncated {
 				t.Errorf("unexpected truncation for a small tree")
 			}
@@ -165,12 +165,38 @@ func TestEnumerateImportUnits_Truncates(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		writeTestFile(t, filepath.Join(root, "Author", string(rune('a'+i))+".epub"))
 	}
-	units, truncated := enumerateImportUnits(root, 4)
+	units, truncated := enumerateImportUnits(root, 4, nil)
 	if !truncated {
 		t.Errorf("expected truncated=true when units exceed the limit")
 	}
 	if len(units) != 4 {
 		t.Errorf("units = %d, want exactly the limit of 4", len(units))
+	}
+}
+
+// TestEnumerateImportUnits_SkipDoesNotCountTowardLimitOrTruncation verifies a
+// unit skip rejects is neither collected nor counted toward truncation — the
+// walk keeps descending in search of `limit` units skip accepts (#2480: a
+// large folder of already-tracked files must not starve the cap before any
+// new file is even considered).
+func TestEnumerateImportUnits_SkipDoesNotCountTowardLimitOrTruncation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	for i := 0; i < 20; i++ {
+		writeTestFile(t, filepath.Join(root, "Author", string(rune('a'+i))+".epub"))
+	}
+	writeTestFile(t, filepath.Join(root, "Author", "new.epub"))
+
+	skipAllButNew := func(path string, isDir bool) bool {
+		return filepath.Base(path) != "new.epub"
+	}
+	units, truncated := enumerateImportUnits(root, 4, skipAllButNew)
+	if truncated {
+		t.Errorf("expected truncated=false: only one unit passes skip, well under the limit")
+	}
+	got := unitNames(units)
+	if len(got) != 1 || got[0] != "new.epub" {
+		t.Errorf("units = %v, want just [new.epub]", got)
 	}
 }
 
@@ -192,7 +218,7 @@ func TestEnumerateImportUnits_UnreadableDirSkipped(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
 
-	units, _ := enumerateImportUnits(root, 1000)
+	units, _ := enumerateImportUnits(root, 1000, nil)
 	// The readable book is still enumerated; the locked dir is silently skipped.
 	got := unitNames(units)
 	if len(got) != 1 || got[0] != "book.epub" {

--- a/internal/db/book_files.go
+++ b/internal/db/book_files.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -12,11 +14,23 @@ import (
 // BookFileRepo manages the book_files table.
 type BookFileRepo struct {
 	db *sql.DB
+	// version bumps on every mutation (Add, UpdatePath, DeleteByPath,
+	// DeleteByBook), so callers that cache a derived view of book_files (the
+	// manual-import scan's tracked-file index, #2480) can tell cheaply,
+	// without a query, whether that view is stale.
+	version atomic.Int64
 }
 
 // NewBookFileRepo creates a new BookFileRepo backed by the given database.
 func NewBookFileRepo(db *sql.DB) *BookFileRepo {
 	return &BookFileRepo{db: db}
+}
+
+// Version returns a counter that increments on every book_files mutation made
+// through this repo (the only writer — see the mutating methods below). A
+// cache keyed on this value only needs to rebuild when it changes.
+func (r *BookFileRepo) Version() int64 {
+	return r.version.Load()
 }
 
 // Add inserts a book_files row. Duplicate paths are silently ignored (INSERT OR IGNORE).
@@ -28,6 +42,7 @@ func (r *BookFileRepo) Add(ctx context.Context, bookID int64, format, path strin
 	if err != nil {
 		return fmt.Errorf("book_files add: %w", err)
 	}
+	r.version.Add(1)
 	return nil
 }
 
@@ -49,6 +64,7 @@ func (r *BookFileRepo) UpdatePath(ctx context.Context, id int64, newPath string)
 	if n == 0 {
 		return fmt.Errorf("book_files update path: no row with id %d", id)
 	}
+	r.version.Add(1)
 	return nil
 }
 
@@ -90,12 +106,47 @@ func (r *BookFileRepo) ListByBook(ctx context.Context, bookID int64) ([]models.B
 	return files, rows.Err()
 }
 
+// ListByBooks returns every book_files row for any of the given book IDs, in
+// one query, grouped by book_id. Used by the manual-import scan
+// (ManualImportHandler.Scan, #2480) to replace an N+1 ListByBook call per
+// confident catalogue match with a single round trip. Duplicate IDs collapse
+// naturally (IN ignores repeats); an empty bookIDs returns an empty map.
+func (r *BookFileRepo) ListByBooks(ctx context.Context, bookIDs []int64) (map[int64][]models.BookFile, error) {
+	result := make(map[int64][]models.BookFile, len(bookIDs))
+	if len(bookIDs) == 0 {
+		return result, nil
+	}
+	placeholders := make([]string, len(bookIDs))
+	args := make([]any, len(bookIDs))
+	for i, id := range bookIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := `SELECT id, book_id, format, path, size_bytes, created_at
+		FROM book_files WHERE book_id IN (` + strings.Join(placeholders, ",") + `) ORDER BY id` // #nosec G202 -- placeholders are generated from fixed ? tokens; book IDs remain bound args
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("book_files list by books: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var f models.BookFile
+		if err := rows.Scan(&f.ID, &f.BookID, &f.Format, &f.Path, &f.SizeBytes, &f.CreatedAt); err != nil {
+			return nil, fmt.Errorf("book_files scan: %w", err)
+		}
+		result[f.BookID] = append(result[f.BookID], f)
+	}
+	return result, rows.Err()
+}
+
 // DeleteByBook removes all book_files rows for the given book.
 func (r *BookFileRepo) DeleteByBook(ctx context.Context, bookID int64) error {
 	_, err := r.db.ExecContext(ctx, `DELETE FROM book_files WHERE book_id = ?`, bookID)
 	if err != nil {
 		return fmt.Errorf("book_files delete by book: %w", err)
 	}
+	r.version.Add(1)
 	return nil
 }
 
@@ -114,6 +165,7 @@ func (r *BookFileRepo) DeleteByPath(ctx context.Context, path string) (int64, er
 	if _, err := r.db.ExecContext(ctx, `DELETE FROM book_files WHERE path = ?`, path); err != nil {
 		return 0, fmt.Errorf("book_files delete by path: %w", err)
 	}
+	r.version.Add(1)
 	return bookID, nil
 }
 

--- a/internal/db/book_files_test.go
+++ b/internal/db/book_files_test.go
@@ -224,6 +224,132 @@ func TestBookRepo_MigrationBackfill(t *testing.T) {
 	}
 }
 
+// TestBookFileRepo_ListByBooks verifies the batch lookup groups rows by
+// book_id in one query (#2480: replaces an N+1 ListByBook-per-book call in
+// the manual-import scan's confident-match format check).
+func TestBookFileRepo_ListByBooks(t *testing.T) {
+	database, author, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+	files := NewBookFileRepo(database)
+
+	_ = repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, "/lib/one.epub")
+
+	b2 := &models.Book{
+		ForeignID: "OL-LB-B2", AuthorID: author.ID,
+		Title: "Second Book", SortTitle: "Second Book",
+		Status: models.BookStatusWanted, Monitored: true,
+	}
+	if err := repo.Create(ctx, b2); err != nil {
+		t.Fatalf("create b2: %v", err)
+	}
+	_ = repo.AddBookFile(ctx, b2.ID, models.MediaTypeEbook, "/lib/two.epub")
+	_ = repo.AddBookFile(ctx, b2.ID, models.MediaTypeAudiobook, "/lib/two.m4b")
+
+	// A third book with no files at all should simply be absent from the map.
+	b3 := &models.Book{
+		ForeignID: "OL-LB-B3", AuthorID: author.ID,
+		Title: "Third Book", SortTitle: "Third Book",
+		Status: models.BookStatusWanted, Monitored: true,
+	}
+	if err := repo.Create(ctx, b3); err != nil {
+		t.Fatalf("create b3: %v", err)
+	}
+
+	got, err := files.ListByBooks(ctx, []int64{book.ID, b2.ID, b3.ID})
+	if err != nil {
+		t.Fatalf("ListByBooks: %v", err)
+	}
+	if len(got[book.ID]) != 1 || got[book.ID][0].Path != "/lib/one.epub" {
+		t.Errorf("book1 files = %+v, want just one.epub", got[book.ID])
+	}
+	if len(got[b2.ID]) != 2 {
+		t.Errorf("book2 files = %+v, want 2 rows", got[b2.ID])
+	}
+	if _, ok := got[b3.ID]; ok {
+		t.Errorf("book3 has no files and should be absent from the map, got %+v", got[b3.ID])
+	}
+
+	empty, err := files.ListByBooks(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListByBooks(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("ListByBooks(nil) = %+v, want empty map", empty)
+	}
+}
+
+// TestBookFileRepo_Version verifies the version counter bumps on every
+// mutating method and is stable across pure reads (#2480: lets a cache
+// derived from book_files know cheaply, without a query, when it must
+// rebuild). Exercises BookFileRepo's own methods directly rather than going
+// through BookRepo, which owns a separate BookFileRepo instance (and so a
+// separate counter) internally.
+func TestBookFileRepo_Version(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	files := NewBookFileRepo(database)
+
+	v0 := files.Version()
+
+	if err := files.Add(ctx, book.ID, models.MediaTypeEbook, "/lib/v.epub"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	v1 := files.Version()
+	if v1 == v0 {
+		t.Errorf("Version did not change after Add: %d", v1)
+	}
+
+	if _, err := files.ListByBook(ctx, book.ID); err != nil {
+		t.Fatalf("ListByBook: %v", err)
+	}
+	if files.Version() != v1 {
+		t.Errorf("Version changed on a pure read: %d -> %d", v1, files.Version())
+	}
+
+	if _, err := files.DeleteByPath(ctx, "/lib/v.epub"); err != nil {
+		t.Fatalf("DeleteByPath: %v", err)
+	}
+	v2 := files.Version()
+	if v2 == v1 {
+		t.Errorf("Version did not change after DeleteByPath: %d", v2)
+	}
+
+	_ = files.Add(ctx, book.ID, models.MediaTypeEbook, "/lib/v2.epub")
+	if err := files.DeleteByBook(ctx, book.ID); err != nil {
+		t.Fatalf("DeleteByBook: %v", err)
+	}
+	if files.Version() == v2 {
+		t.Errorf("Version did not change after DeleteByBook")
+	}
+}
+
+// TestBookRepo_BookFilesVersion verifies BookRepo.BookFilesVersion reflects
+// mutations made through BookRepo's own AddBookFile/RemoveBookFile methods
+// (#2480), which is the path ManualImportHandler's cache actually observes.
+func TestBookRepo_BookFilesVersion(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	v0 := repo.BookFilesVersion()
+
+	if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, "/lib/bv.epub"); err != nil {
+		t.Fatalf("AddBookFile: %v", err)
+	}
+	v1 := repo.BookFilesVersion()
+	if v1 == v0 {
+		t.Errorf("BookFilesVersion did not change after AddBookFile: %d", v1)
+	}
+
+	if _, err := repo.RemoveBookFile(ctx, "/lib/bv.epub"); err != nil {
+		t.Fatalf("RemoveBookFile: %v", err)
+	}
+	if repo.BookFilesVersion() == v1 {
+		t.Errorf("BookFilesVersion did not change after RemoveBookFile")
+	}
+}
+
 // TestBookRepo_RemoveBookFile_StatusFlips verifies removing the last file
 // flips the book back to "wanted".
 func TestBookRepo_RemoveBookFile_StatusFlips(t *testing.T) {

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -109,6 +109,13 @@ func NewBookRepo(db *sql.DB) *BookRepo {
 	return r
 }
 
+// ListAllFilePaths returns every path currently tracked by a book. It is used
+// by the manual folder importer to avoid presenting already-imported files as
+// new candidates.
+func (r *BookRepo) ListAllFilePaths(ctx context.Context) ([]string, error) {
+	return r.files.ListAllPaths(ctx)
+}
+
 // WithTx returns a clone of this repo whose tx-aware methods (the ones
 // rolled into calibre.Rollback's single transaction) route through tx
 // instead of the bare *sql.DB. Methods outside that set keep using *sql.DB

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -109,13 +109,6 @@ func NewBookRepo(db *sql.DB) *BookRepo {
 	return r
 }
 
-// ListAllFilePaths returns every path currently tracked by a book. It is used
-// by the manual folder importer to avoid presenting already-imported files as
-// new candidates.
-func (r *BookRepo) ListAllFilePaths(ctx context.Context) ([]string, error) {
-	return r.files.ListAllPaths(ctx)
-}
-
 // WithTx returns a clone of this repo whose tx-aware methods (the ones
 // rolled into calibre.Rollback's single transaction) route through tx
 // instead of the bare *sql.DB. Methods outside that set keep using *sql.DB

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -749,6 +749,21 @@ func (r *BookRepo) ListAllBookFilePaths(ctx context.Context) ([]string, error) {
 	return r.files.ListAllPaths(ctx)
 }
 
+// BookFilesVersion returns a counter that increments on every book_files
+// mutation. A cheap atomic load — no query — so a cache derived from
+// book_files (the manual-import scan's tracked-file index, #2480) can tell
+// whether it needs to rebuild.
+func (r *BookRepo) BookFilesVersion() int64 {
+	return r.files.Version()
+}
+
+// ListFilesForBooks returns every book_files row for the given book IDs in a
+// single query, grouped by book_id. Replaces an N+1 ListFiles-per-book call
+// (the manual-import scan's confident-match format check, #2480).
+func (r *BookRepo) ListFilesForBooks(ctx context.Context, bookIDs []int64) (map[int64][]models.BookFile, error) {
+	return r.files.ListByBooks(ctx, bookIDs)
+}
+
 // ListBookFiles returns the book_files rows for a single book.
 func (r *BookRepo) ListBookFiles(ctx context.Context, bookID int64) ([]models.BookFile, error) {
 	return r.files.ListByBook(ctx, bookID)

--- a/internal/importer/samedevice_unix.go
+++ b/internal/importer/samedevice_unix.go
@@ -27,11 +27,13 @@ func statExisting(p string) (os.FileInfo, error) {
 	}
 }
 
-// sameDevice reports whether a and b reside on the same filesystem by
+// SameDevice reports whether a and b reside on the same filesystem by
 // comparing their OS device IDs. When b does not exist, its nearest existing
 // ancestor directory is used so that not-yet-created destination paths are
-// handled correctly. Returns false on any stat error.
-func sameDevice(a, b string) bool {
+// handled correctly. Returns false on any stat error. Exported for reuse by
+// internal/api's manual-import scan (#2480), which already depends on this
+// package elsewhere in the same handler.
+func SameDevice(a, b string) bool {
 	if a == "" || b == "" {
 		return false
 	}
@@ -73,7 +75,7 @@ func nearestExistingDir(p string) string {
 }
 
 // hardlinkable reports whether a hardlink import from src into dst would
-// actually succeed. Matching device IDs (sameDevice) are necessary but NOT
+// actually succeed. Matching device IDs (SameDevice) are necessary but NOT
 // sufficient: two separate bind mounts — or Unraid /mnt/user shares — report
 // the same st_dev yet os.Link across them fails with EXDEV ("invalid
 // cross-device link"). So after the cheap same-device gate it confirms with a
@@ -82,7 +84,7 @@ func nearestExistingDir(p string) string {
 // read-only download dir), it trusts the same-device result rather than
 // reporting a false negative.
 func hardlinkable(src, dst string) bool {
-	if !sameDevice(src, dst) {
+	if !SameDevice(src, dst) {
 		return false
 	}
 	srcDir := nearestExistingDir(src)

--- a/internal/importer/samedevice_windows.go
+++ b/internal/importer/samedevice_windows.go
@@ -2,13 +2,13 @@
 
 package importer
 
-// sameDevice always returns false on Windows because device-ID comparison
+// SameDevice always returns false on Windows because device-ID comparison
 // via syscall.Stat_t is not available. importMode will fall back to "copy".
-func sameDevice(_, _ string) bool {
+func SameDevice(_, _ string) bool {
 	return false
 }
 
-// hardlinkable mirrors sameDevice on Windows: device comparison is unavailable,
+// hardlinkable mirrors SameDevice on Windows: device comparison is unavailable,
 // so the auto import mode falls back to "copy" rather than risk a failing
 // hardlink.
 func hardlinkable(_, _ string) bool {

--- a/web/src/api/queue.ts
+++ b/web/src/api/queue.ts
@@ -41,6 +41,11 @@ export interface ScanItem {
   detectedFormat: string
   book?: Book
   candidates?: Book[]
+  // alreadyImported is true when this unit is already tracked in the library
+  // (directly, via a hardlink, or as a confident match whose book already has
+  // this format). Normally such units are excluded; includeImported surfaces
+  // them instead, labelled (#2480).
+  alreadyImported: boolean
 }
 
 export interface FolderScanResponse {
@@ -145,8 +150,12 @@ export const queueApi = {
   manualImport: (data: { path: string; bookId: number; format?: string }) =>
     request<Download>('/queue/manual-import', { method: 'POST', body: JSON.stringify(data) }),
   // Bulk folder import: scan a folder for book units, then import the selected ones.
-  scanFolder: (path: string) =>
-    request<FolderScanResponse>(`/queue/manual-import/scan?path=${encodeURIComponent(path)}`),
+  // includeImported (default off) surfaces already-imported units instead of
+  // excluding them, labelled via ScanItem.alreadyImported (#2480).
+  scanFolder: (path: string, opts?: { includeImported?: boolean }) => {
+    const qs = opts?.includeImported ? '&includeImported=true' : ''
+    return request<FolderScanResponse>(`/queue/manual-import/scan?path=${encodeURIComponent(path)}${qs}`)
+  },
   batchImport: (items: BatchImportItem[]) =>
     request<BatchImportResponse>('/queue/manual-import/batch', { method: 'POST', body: JSON.stringify(items) }),
 

--- a/web/src/components/useFolderScan.test.tsx
+++ b/web/src/components/useFolderScan.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, fireEvent } from '@testing-library/react'
+import { useFolderScan } from './useFolderScan'
+
+vi.mock('../api/client', () => ({
+  api: { scanFolder: vi.fn() },
+}))
+
+import { api } from '../api/client'
+const mockScan = api.scanFolder as ReturnType<typeof vi.fn>
+
+// Harness renders the hook's state as text/attributes so assertions don't
+// need to reach into React internals, and exposes its actions as buttons.
+function Harness({ onItems }: { onItems?: (items: { path: string }[]) => void }) {
+  const fs = useFolderScan(onItems as never)
+  return (
+    <div>
+      <input aria-label="path" value={fs.path} onChange={e => fs.setPath(e.target.value)} />
+      <button onClick={fs.scan}>scan</button>
+      <button onClick={() => fs.toggleShowImported(!fs.showImported)}>toggle</button>
+      <button onClick={fs.clear}>clear</button>
+      <div data-testid="scanning">{String(fs.scanning)}</div>
+      <div data-testid="truncated">{String(fs.truncated)}</div>
+      <div data-testid="showImported">{String(fs.showImported)}</div>
+      <div data-testid="error">{fs.error ?? ''}</div>
+      <div data-testid="items">{fs.items ? fs.items.map(i => i.path).join(',') : 'null'}</div>
+    </div>
+  )
+}
+
+describe('useFolderScan', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('does nothing when scanning an empty path', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByText('scan'))
+    expect(mockScan).not.toHaveBeenCalled()
+  })
+
+  it('scans with includeImported=false by default and reports items/truncated', async () => {
+    mockScan.mockResolvedValue({ items: [{ path: '/dl/a.epub' }], truncated: false })
+    render(<Harness />)
+    fireEvent.change(screen.getByLabelText('path'), { target: { value: '/dl' } })
+    await act(async () => { fireEvent.click(screen.getByText('scan')) })
+
+    expect(mockScan).toHaveBeenCalledWith('/dl', { includeImported: false })
+    expect(screen.getByTestId('items').textContent).toBe('/dl/a.epub')
+    expect(screen.getByTestId('truncated').textContent).toBe('false')
+  })
+
+  it('invokes onItems with the fetched items on a successful scan', async () => {
+    mockScan.mockResolvedValue({ items: [{ path: '/dl/a.epub' }], truncated: false })
+    const onItems = vi.fn()
+    render(<Harness onItems={onItems} />)
+    fireEvent.change(screen.getByLabelText('path'), { target: { value: '/dl' } })
+    await act(async () => { fireEvent.click(screen.getByText('scan')) })
+
+    expect(onItems).toHaveBeenCalledWith([{ path: '/dl/a.epub' }])
+  })
+
+  it('sets error and leaves items null when the scan fails', async () => {
+    mockScan.mockRejectedValue(new Error('boom'))
+    render(<Harness />)
+    fireEvent.change(screen.getByLabelText('path'), { target: { value: '/dl' } })
+    await act(async () => { fireEvent.click(screen.getByText('scan')) })
+
+    expect(screen.getByTestId('error').textContent).toBe('boom')
+    expect(screen.getByTestId('items').textContent).toBe('null')
+  })
+
+  it('toggling on re-scans with includeImported=true only once items exist', async () => {
+    render(<Harness />)
+    fireEvent.change(screen.getByLabelText('path'), { target: { value: '/dl' } })
+
+    // No prior scan yet: toggling just flips the flag, no fetch.
+    fireEvent.click(screen.getByText('toggle'))
+    expect(screen.getByTestId('showImported').textContent).toBe('true')
+    expect(mockScan).not.toHaveBeenCalled()
+
+    mockScan.mockResolvedValue({ items: [{ path: '/dl/a.epub' }], truncated: false })
+    await act(async () => { fireEvent.click(screen.getByText('scan')) })
+    expect(mockScan).toHaveBeenCalledWith('/dl', { includeImported: true })
+
+    // Now that items exist, toggling again re-scans.
+    mockScan.mockClear()
+    mockScan.mockResolvedValue({ items: [], truncated: false })
+    await act(async () => { fireEvent.click(screen.getByText('toggle')) })
+    expect(mockScan).toHaveBeenCalledWith('/dl', { includeImported: false })
+  })
+
+  // The bug this hook fixes: a stale truncated=true from a previous scan must
+  // not survive into a later scan that isn't truncated (#2480).
+  it('clears a stale truncated flag once a later scan reports untruncated', async () => {
+    mockScan.mockResolvedValue({ items: [], truncated: true })
+    render(<Harness />)
+    fireEvent.change(screen.getByLabelText('path'), { target: { value: '/dl' } })
+    await act(async () => { fireEvent.click(screen.getByText('scan')) })
+    expect(screen.getByTestId('truncated').textContent).toBe('true')
+
+    mockScan.mockResolvedValue({ items: [], truncated: false })
+    await act(async () => { fireEvent.click(screen.getByText('scan')) })
+    expect(screen.getByTestId('truncated').textContent).toBe('false')
+  })
+
+  it('clear() drops items, truncated, and error together', async () => {
+    mockScan.mockResolvedValue({ items: [{ path: '/dl/a.epub' }], truncated: true })
+    render(<Harness />)
+    fireEvent.change(screen.getByLabelText('path'), { target: { value: '/dl' } })
+    await act(async () => { fireEvent.click(screen.getByText('scan')) })
+    expect(screen.getByTestId('items').textContent).toBe('/dl/a.epub')
+
+    fireEvent.click(screen.getByText('clear'))
+    expect(screen.getByTestId('items').textContent).toBe('null')
+    expect(screen.getByTestId('truncated').textContent).toBe('false')
+    expect(screen.getByTestId('error').textContent).toBe('')
+  })
+})

--- a/web/src/components/useFolderScan.ts
+++ b/web/src/components/useFolderScan.ts
@@ -1,0 +1,68 @@
+import { useCallback, useState } from 'react'
+import { api } from '../api/client'
+import type { ScanItem } from '../api/client'
+
+export interface UseFolderScanResult {
+  path: string
+  setPath: (p: string) => void
+  scanning: boolean
+  items: ScanItem[] | null
+  truncated: boolean
+  showImported: boolean
+  error: string | null
+  scan: () => void
+  toggleShowImported: (checked: boolean) => void
+  clear: () => void
+}
+
+/**
+ * useFolderScan drives the bulk-folder-import scan (#2480) shared by the
+ * Settings > Import "Bulk folder import" section and the /import wizard page:
+ * the path input, the scan request (with the includeImported toggle,
+ * default off), and the resulting items/truncated/error state. Each page
+ * still builds its own per-unit resolution state (selection, format, chosen
+ * book) from the fetched items via the optional onItems callback.
+ */
+export function useFolderScan(onItems?: (items: ScanItem[]) => void): UseFolderScanResult {
+  const [path, setPath] = useState('')
+  const [scanning, setScanning] = useState(false)
+  const [items, setItems] = useState<ScanItem[] | null>(null)
+  const [truncated, setTruncated] = useState(false)
+  const [showImported, setShowImported] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // clear drops the previous scan's results (items AND truncated together —
+  // leaving truncated set with no items to explain it is a stale banner with
+  // nothing beneath it) without touching path or showImported.
+  const clear = useCallback(() => {
+    setItems(null)
+    setTruncated(false)
+    setError(null)
+  }, [])
+
+  const runScan = useCallback(async (includeImported: boolean) => {
+    const p = path.trim()
+    if (!p) return
+    setScanning(true)
+    clear()
+    try {
+      const r = await api.scanFolder(p, { includeImported })
+      setItems(r.items)
+      setTruncated(r.truncated)
+      onItems?.(r.items)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Scan failed')
+    } finally {
+      setScanning(false)
+    }
+  }, [path, clear, onItems])
+
+  const scan = useCallback(() => { void runScan(showImported) }, [runScan, showImported])
+
+  const toggleShowImported = useCallback((checked: boolean) => {
+    setShowImported(checked)
+    if (items) void runScan(checked)
+  }, [items, runScan])
+
+  return { path, setPath, scanning, items, truncated, showImported, error, scan, toggleShowImported, clear }
+}

--- a/web/src/pages/ManualImportPage.test.tsx
+++ b/web/src/pages/ManualImportPage.test.tsx
@@ -287,4 +287,49 @@ describe('ManualImportPage', () => {
     await waitFor(() => expect(screen.getByText('manualImport.empty')).toBeInTheDocument())
     expect(screen.getByText('manualImport.truncated')).toBeInTheDocument()
   })
+
+  it('clears a stale truncation banner once a later scan reports untruncated', async () => {
+    mockScan.mockResolvedValue({ truncated: true, items: [] })
+    render(<ManualImportPage />)
+    fireEvent.change(screen.getByPlaceholderText('manualImport.pathPlaceholder'), { target: { value: '/dl' } })
+    fireEvent.click(screen.getByText('manualImport.scan'))
+    await waitFor(() => expect(screen.getByText('manualImport.truncated')).toBeInTheDocument())
+
+    // A second scan (e.g. after narrowing the folder) that is NOT truncated
+    // must not leave the earlier banner showing.
+    mockScan.mockResolvedValue({ truncated: false, items: [] })
+    fireEvent.click(screen.getByText('manualImport.scan'))
+    await waitFor(() => expect(screen.queryByText('manualImport.truncated')).not.toBeInTheDocument())
+  })
+
+  it('does not let "select all" re-select an already-imported unit', async () => {
+    await scan()
+    mockScan.mockClear()
+    mockScan.mockResolvedValue({
+      truncated: false,
+      items: [{
+        path: '/dl/Already Imported', name: 'Already Imported', match: 'confident',
+        parsedTitle: 'Already Imported', parsedAuthor: '', detectedFormat: 'ebook',
+        book: { id: 33, title: 'Already Imported' } as never, alreadyImported: true,
+      }],
+    })
+    fireEvent.click(screen.getByLabelText('manualImport.showImported'))
+    await screen.findByText('Already Imported')
+
+    // Starts unchecked and the per-row Import button starts disabled — the
+    // whole point of not preselecting an already-imported match.
+    const rowCheckbox = screen.getByLabelText('manualImport.selectUnit name=Already Imported') as HTMLInputElement
+    expect(rowCheckbox.checked).toBe(false)
+    const importButtons = screen.getAllByText('manualImport.import') as HTMLButtonElement[]
+    expect(importButtons[importButtons.length - 1].disabled).toBe(true)
+
+    // "Select all matched" must not silently sweep it in.
+    fireEvent.click(screen.getByLabelText('manualImport.selectAll'))
+    expect(rowCheckbox.checked).toBe(false)
+
+    // Checking it by hand is still how you'd deliberately re-import it.
+    fireEvent.click(rowCheckbox)
+    expect(rowCheckbox.checked).toBe(true)
+    expect(importButtons[importButtons.length - 1].disabled).toBe(false)
+  })
 })

--- a/web/src/pages/ManualImportPage.test.tsx
+++ b/web/src/pages/ManualImportPage.test.tsx
@@ -49,6 +49,7 @@ function scanResult(): FolderScanResponse {
         path: '/dl/Confident Book', name: 'Confident Book', match: 'confident',
         parsedTitle: 'Confident Book', parsedAuthor: 'A. Writer', detectedFormat: 'ebook',
         book: { id: 11, title: 'Confident Book', author: { authorName: 'A. Writer' } } as never,
+        alreadyImported: false,
       },
       {
         path: '/dl/Maybe Book', name: 'Maybe Book', match: 'ambiguous',
@@ -57,10 +58,12 @@ function scanResult(): FolderScanResponse {
           { id: 21, title: 'Maybe Book (1)', author: { authorName: 'X' } } as never,
           { id: 22, title: 'Maybe Book (2)', author: { authorName: 'Y' } } as never,
         ],
+        alreadyImported: false,
       },
       {
         path: '/dl/Orphan', name: 'Orphan', match: 'none',
         parsedTitle: 'Orphan', parsedAuthor: '', detectedFormat: 'audiobook',
+        alreadyImported: false,
       },
     ],
   }
@@ -84,7 +87,7 @@ describe('ManualImportPage', () => {
 
   it('renders scan results grouped by match status', async () => {
     await scan()
-    expect(mockScan).toHaveBeenCalledWith('/dl')
+    expect(mockScan).toHaveBeenCalledWith('/dl', { includeImported: false })
 
     // One heading per non-empty group (plus a badge per row using the same key).
     expect(screen.getAllByText(/manualImport\.group\.confident/).length).toBeGreaterThan(0)
@@ -255,5 +258,33 @@ describe('ManualImportPage', () => {
     expect(addBtn.disabled).toBe(true)
     fireEvent.click(addBtn)
     expect(mockAddBook).not.toHaveBeenCalled()
+  })
+
+  it('re-scans with includeImported when "show already imported" is toggled on', async () => {
+    await scan()
+    mockScan.mockClear()
+    mockScan.mockResolvedValue({
+      truncated: false,
+      items: [{
+        path: '/dl/Already Imported', name: 'Already Imported', match: 'confident',
+        parsedTitle: 'Already Imported', parsedAuthor: '', detectedFormat: 'ebook',
+        book: { id: 33, title: 'Already Imported' } as never, alreadyImported: true,
+      }],
+    })
+
+    fireEvent.click(screen.getByLabelText('manualImport.showImported'))
+
+    expect(mockScan).toHaveBeenCalledWith('/dl', { includeImported: true })
+    await waitFor(() => expect(screen.getByText('manualImport.alreadyImported')).toBeInTheDocument())
+  })
+
+  it('shows the truncation banner even when filtering leaves no items (#2480)', async () => {
+    mockScan.mockResolvedValue({ truncated: true, items: [] })
+    render(<ManualImportPage />)
+    fireEvent.change(screen.getByPlaceholderText('manualImport.pathPlaceholder'), { target: { value: '/dl' } })
+    fireEvent.click(screen.getByText('manualImport.scan'))
+
+    await waitFor(() => expect(screen.getByText('manualImport.empty')).toBeInTheDocument())
+    expect(screen.getByText('manualImport.truncated')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/ManualImportPage.tsx
+++ b/web/src/pages/ManualImportPage.tsx
@@ -4,6 +4,7 @@ import { api } from '../api/client'
 import { resolveBookQuery } from '../api/booklookup'
 import type { BatchImportItem, BatchImportResult, Book, ScanItem } from '../api/client'
 import { btn, btnSize } from '../components/buttons'
+import { useFolderScan } from '../components/useFolderScan'
 
 // ManualImportPage is the manual-import wizard (#1236). It scans a folder with
 // the recursive bulk-import scan (#1434), groups the discovered units by match
@@ -44,53 +45,31 @@ function groupHeading(match: ScanItem['match']): string {
 
 export default function ManualImportPage() {
   const { t } = useTranslation()
-  const [path, setPath] = useState('')
-  const [scanning, setScanning] = useState(false)
-  const [items, setItems] = useState<ScanItem[] | null>(null)
-  const [truncated, setTruncated] = useState(false)
-  const [showImported, setShowImported] = useState(false)
   const [rows, setRows] = useState<Record<string, RowState>>({})
   const [results, setResults] = useState<Record<string, BatchImportResult>>({})
   const [importingPaths, setImportingPaths] = useState<Set<string>>(() => new Set())
-  const [scanError, setScanError] = useState('')
   const [importError, setImportError] = useState('')
+
+  const folderScan = useFolderScan(scanned => {
+    setResults({})
+    const init: Record<string, RowState> = {}
+    for (const it of scanned) {
+      const chosen = it.match === 'confident' && it.book ? it.book : null
+      init[it.path] = { chosen, format: it.detectedFormat || '', selected: Boolean(chosen) && !it.alreadyImported }
+    }
+    setRows(init)
+  })
+  const { path, setPath, scanning, items, truncated, showImported, error: scanError, toggleShowImported } = folderScan
 
   useEffect(() => {
     document.title = 'Manual Import · Bindery'
     return () => { document.title = 'Bindery' }
   }, [])
 
-  const runScan = async (includeImported: boolean) => {
-    const p = path.trim()
-    if (!p) return
-    setScanning(true)
-    setScanError('')
-    setImportError('')
-    setItems(null)
-    setResults({})
-    try {
-      const r = await api.scanFolder(p, { includeImported })
-      setItems(r.items)
-      setTruncated(r.truncated)
-      const init: Record<string, RowState> = {}
-      for (const it of r.items) {
-        const chosen = it.match === 'confident' && it.book ? it.book : null
-        init[it.path] = { chosen, format: it.detectedFormat || '', selected: Boolean(chosen) && !it.alreadyImported }
-      }
-      setRows(init)
-    } catch (e) {
-      setScanError(e instanceof Error ? e.message : 'Scan failed')
-    } finally {
-      setScanning(false)
-    }
-  }
-
-  const handleScan = () => runScan(showImported)
-
-  const toggleShowImported = (checked: boolean) => {
-    setShowImported(checked)
-    if (items) runScan(checked)
-  }
+  // A scan attempt (fresh or re-triggered by the toggle) supersedes whatever
+  // the last import attempt reported.
+  const handleScan = () => { setImportError(''); folderScan.scan() }
+  const handleToggleShowImported = (checked: boolean) => { setImportError(''); toggleShowImported(checked) }
 
   const patchRow = (unitPath: string, patch: Partial<RowState>) =>
     setRows(prev => ({ ...prev, [unitPath]: { ...prev[unitPath], ...patch } }))
@@ -149,8 +128,11 @@ export default function ManualImportPage() {
   const toggleSelectAll = () => {
     if (!items) return
     // Resolved, not-yet-imported units only — a `none` unit with no book can't
-    // be selected.
+    // be selected. Already-imported units are deliberately left out of "select
+    // all" too: they start unchecked so a bulk action can't silently re-import
+    // them, and a bulk toggle re-including them here would defeat that (#2480).
     const resolvable = items
+      .filter(it => !it.alreadyImported)
       .map(it => it.path)
       .filter(p => rows[p]?.chosen && !results[p]?.accepted)
     const turnOn = !resolvable.every(p => rows[p]?.selected)
@@ -201,7 +183,7 @@ export default function ManualImportPage() {
         <input
           type="checkbox"
           checked={showImported}
-          onChange={e => toggleShowImported(e.target.checked)}
+          onChange={e => handleToggleShowImported(e.target.checked)}
           disabled={scanning}
           className="rounded border-slate-400 dark:border-zinc-600 text-emerald-600 focus:ring-emerald-500 focus:ring-offset-0"
         />
@@ -404,7 +386,7 @@ function ImportRow({ item, row, result, importing, onPick, onToggle, onFormat, o
           <button
             type="button"
             onClick={onImport}
-            disabled={!chosen || importing || Boolean(accepted)}
+            disabled={!chosen || !row?.selected || importing || Boolean(accepted)}
             className={`${btn.secondary} ${btnSize.sm}`}
           >
             {importing ? t('manualImport.importing', 'Importing…') : t('manualImport.import', 'Import')}

--- a/web/src/pages/ManualImportPage.tsx
+++ b/web/src/pages/ManualImportPage.tsx
@@ -152,9 +152,21 @@ export default function ManualImportPage() {
   return (
     <div>
       <div className="mb-6">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
-          {t('manualImport.title', 'Manual Import')}
-        </h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
+            {t('manualImport.title', 'Manual Import')}
+          </h2>
+          <label className="ml-auto flex items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showImported}
+              onChange={e => handleToggleShowImported(e.target.checked)}
+              disabled={scanning}
+              className="rounded border-slate-400 dark:border-zinc-600 text-emerald-600 focus:ring-emerald-500 focus:ring-offset-0"
+            />
+            {t('manualImport.showImported', 'Show already imported')}
+          </label>
+        </div>
         <p className="mt-1 text-sm text-slate-600 dark:text-zinc-400">
           {t('manualImport.description', 'Scan a folder of files already on disk, match each book to your library, and import them. A file with no match can be added from a metadata search.')}
         </p>
@@ -178,17 +190,6 @@ export default function ManualImportPage() {
           {scanning ? t('manualImport.scanning', 'Scanning…') : t('manualImport.scan', 'Scan folder')}
         </button>
       </div>
-
-      <label className="mb-4 flex w-fit cursor-pointer select-none items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400">
-        <input
-          type="checkbox"
-          checked={showImported}
-          onChange={e => handleToggleShowImported(e.target.checked)}
-          disabled={scanning}
-          className="rounded border-slate-400 dark:border-zinc-600 text-emerald-600 focus:ring-emerald-500 focus:ring-offset-0"
-        />
-        {t('manualImport.showImported', 'Show already imported')}
-      </label>
 
       {scanError && (
         <p className="mb-4 text-sm text-red-600 dark:text-red-400">{scanError}</p>

--- a/web/src/pages/ManualImportPage.tsx
+++ b/web/src/pages/ManualImportPage.tsx
@@ -48,6 +48,7 @@ export default function ManualImportPage() {
   const [scanning, setScanning] = useState(false)
   const [items, setItems] = useState<ScanItem[] | null>(null)
   const [truncated, setTruncated] = useState(false)
+  const [showImported, setShowImported] = useState(false)
   const [rows, setRows] = useState<Record<string, RowState>>({})
   const [results, setResults] = useState<Record<string, BatchImportResult>>({})
   const [importingPaths, setImportingPaths] = useState<Set<string>>(() => new Set())
@@ -59,7 +60,7 @@ export default function ManualImportPage() {
     return () => { document.title = 'Bindery' }
   }, [])
 
-  const handleScan = async () => {
+  const runScan = async (includeImported: boolean) => {
     const p = path.trim()
     if (!p) return
     setScanning(true)
@@ -68,13 +69,13 @@ export default function ManualImportPage() {
     setItems(null)
     setResults({})
     try {
-      const r = await api.scanFolder(p)
+      const r = await api.scanFolder(p, { includeImported })
       setItems(r.items)
       setTruncated(r.truncated)
       const init: Record<string, RowState> = {}
       for (const it of r.items) {
         const chosen = it.match === 'confident' && it.book ? it.book : null
-        init[it.path] = { chosen, format: it.detectedFormat || '', selected: Boolean(chosen) }
+        init[it.path] = { chosen, format: it.detectedFormat || '', selected: Boolean(chosen) && !it.alreadyImported }
       }
       setRows(init)
     } catch (e) {
@@ -82,6 +83,13 @@ export default function ManualImportPage() {
     } finally {
       setScanning(false)
     }
+  }
+
+  const handleScan = () => runScan(showImported)
+
+  const toggleShowImported = (checked: boolean) => {
+    setShowImported(checked)
+    if (items) runScan(checked)
   }
 
   const patchRow = (unitPath: string, patch: Partial<RowState>) =>
@@ -189,8 +197,25 @@ export default function ManualImportPage() {
         </button>
       </div>
 
+      <label className="mb-4 flex w-fit cursor-pointer select-none items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400">
+        <input
+          type="checkbox"
+          checked={showImported}
+          onChange={e => toggleShowImported(e.target.checked)}
+          disabled={scanning}
+          className="rounded border-slate-400 dark:border-zinc-600 text-emerald-600 focus:ring-emerald-500 focus:ring-offset-0"
+        />
+        {t('manualImport.showImported', 'Show already imported')}
+      </label>
+
       {scanError && (
         <p className="mb-4 text-sm text-red-600 dark:text-red-400">{scanError}</p>
+      )}
+
+      {truncated && (
+        <p className="mb-3 text-xs text-amber-700 dark:text-amber-400">
+          {t('manualImport.truncated', 'Showing the first 1000 units; narrow the folder to see the rest.')}
+        </p>
       )}
 
       {items && items.length === 0 && (
@@ -201,12 +226,6 @@ export default function ManualImportPage() {
 
       {items && items.length > 0 && (
         <>
-          {truncated && (
-            <p className="mb-3 text-xs text-amber-700 dark:text-amber-400">
-              {t('manualImport.truncated', 'Showing the first 1000 units; narrow the folder to see the rest.')}
-            </p>
-          )}
-
           {/* Select-all / bulk import bar */}
           <div className="sticky top-16 z-10 mb-4 flex flex-wrap items-center gap-3 rounded-md border border-slate-200 dark:border-zinc-800 bg-slate-100 dark:bg-zinc-900 px-3 py-2">
             <label className="inline-flex items-center gap-2 text-sm">
@@ -306,6 +325,11 @@ function ImportRow({ item, row, result, importing, onPick, onToggle, onFormat, o
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400">
               {item.detectedFormat}
             </span>
+            {item.alreadyImported && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-sky-100 dark:bg-sky-950 text-sky-700 dark:text-sky-400">
+                {t('manualImport.alreadyImported', 'already imported')}
+              </span>
+            )}
           </div>
           {/* Full source path so the user can tell which file each row refers to;
               the basename alone is ambiguous across folders (#1435). */}

--- a/web/src/pages/settings/FolderScanSection.test.tsx
+++ b/web/src/pages/settings/FolderScanSection.test.tsx
@@ -137,4 +137,18 @@ describe('FolderScanSection', () => {
     await waitFor(() => expect(screen.getByText('settings.import.bulkEmpty')).toBeInTheDocument())
     expect(screen.getByText('settings.import.bulkTruncated')).toBeInTheDocument()
   })
+
+  it('clears a stale truncation banner once a later scan reports untruncated', async () => {
+    mockScan.mockResolvedValue({ truncated: true, items: [] })
+    render(<FolderScanSection />)
+    fireEvent.change(screen.getByPlaceholderText('settings.import.bulkPathPlaceholder'), {
+      target: { value: '/dl' },
+    })
+    fireEvent.click(screen.getByText('settings.import.bulkScan'))
+    await waitFor(() => expect(screen.getByText('settings.import.bulkTruncated')).toBeInTheDocument())
+
+    mockScan.mockResolvedValue({ truncated: false, items: [] })
+    fireEvent.click(screen.getByText('settings.import.bulkScan'))
+    await waitFor(() => expect(screen.queryByText('settings.import.bulkTruncated')).not.toBeInTheDocument())
+  })
 })

--- a/web/src/pages/settings/FolderScanSection.test.tsx
+++ b/web/src/pages/settings/FolderScanSection.test.tsx
@@ -39,6 +39,7 @@ function scanResult(): FolderScanResponse {
         path: '/dl/Confident Book', name: 'Confident Book', match: 'confident',
         parsedTitle: 'Confident Book', parsedAuthor: 'A. Writer', detectedFormat: 'ebook',
         book: { id: 11, title: 'Confident Book', author: { authorName: 'A. Writer' } } as never,
+        alreadyImported: false,
       },
       {
         path: '/dl/Maybe Book', name: 'Maybe Book', match: 'ambiguous',
@@ -47,10 +48,12 @@ function scanResult(): FolderScanResponse {
           { id: 21, title: 'Maybe Book (1)', author: { authorName: 'X' } } as never,
           { id: 22, title: 'Maybe Book (2)', author: { authorName: 'Y' } } as never,
         ],
+        alreadyImported: false,
       },
       {
         path: '/dl/Orphan', name: 'Orphan', match: 'none',
         parsedTitle: 'Orphan', parsedAuthor: '', detectedFormat: 'audiobook',
+        alreadyImported: false,
       },
     ],
   }
@@ -71,12 +74,13 @@ describe('FolderScanSection', () => {
 
   it('pre-selects only confident matches and imports them', async () => {
     await scan()
-    expect(mockScan).toHaveBeenCalledWith('/dl')
+    expect(mockScan).toHaveBeenCalledWith('/dl', { includeImported: false })
 
+    // checkboxes[0] is the "show already imported" toggle, above the item list.
     const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
-    expect(checkboxes[0].checked).toBe(true)  // confident
-    expect(checkboxes[1].checked).toBe(false) // ambiguous, no pick yet
-    expect(checkboxes[2].disabled).toBe(true) // none, not selectable
+    expect(checkboxes[1].checked).toBe(true)  // confident
+    expect(checkboxes[2].checked).toBe(false) // ambiguous, no pick yet
+    expect(checkboxes[3].disabled).toBe(true) // none, not selectable
 
     // Import button reflects 1 selected (the confident one).
     expect(screen.getByText(/settings\.import\.bulkImport count=1/)).toBeInTheDocument()
@@ -102,5 +106,35 @@ describe('FolderScanSection', () => {
       { path: '/dl/Confident Book', bookId: 11, format: 'ebook' },
       { path: '/dl/Maybe Book', bookId: 22, format: 'ebook' },
     ])
+  })
+
+  it('re-scans with includeImported when "show already imported" is toggled on', async () => {
+    await scan()
+    mockScan.mockClear()
+    mockScan.mockResolvedValue({
+      truncated: false,
+      items: [{
+        path: '/dl/Already Imported', name: 'Already Imported', match: 'confident',
+        parsedTitle: 'Already Imported', parsedAuthor: '', detectedFormat: 'ebook',
+        book: { id: 33, title: 'Already Imported' } as never, alreadyImported: true,
+      }],
+    })
+
+    fireEvent.click(screen.getByLabelText('settings.import.bulkShowImported'))
+
+    expect(mockScan).toHaveBeenCalledWith('/dl', { includeImported: true })
+    await waitFor(() => expect(screen.getByText('settings.import.bulkAlreadyImported')).toBeInTheDocument())
+  })
+
+  it('shows the truncation banner even when filtering leaves no items (#2480)', async () => {
+    mockScan.mockResolvedValue({ truncated: true, items: [] })
+    render(<FolderScanSection />)
+    fireEvent.change(screen.getByPlaceholderText('settings.import.bulkPathPlaceholder'), {
+      target: { value: '/dl' },
+    })
+    fireEvent.click(screen.getByText('settings.import.bulkScan'))
+
+    await waitFor(() => expect(screen.getByText('settings.import.bulkEmpty')).toBeInTheDocument())
+    expect(screen.getByText('settings.import.bulkTruncated')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/settings/ImportTab.tsx
+++ b/web/src/pages/settings/ImportTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, BatchImportItem, BatchImportResponse, Book, HardcoverList, ImportList, ImportListSyncProgress, ManagedUser, ManualImportLookup, ScanItem } from '../../api/client'
+import { useFolderScan } from '../../components/useFolderScan'
 import { inputCls } from './formStyles'
 import GoodreadsImportSection from './GoodreadsImportSection'
 
@@ -275,44 +276,23 @@ interface ScanRowState {
 // first); unmatched units are listed but cannot be selected. Exported for tests.
 export function FolderScanSection() {
   const { t } = useTranslation()
-  const [path, setPath] = useState('')
-  const [scanning, setScanning] = useState(false)
-  const [items, setItems] = useState<ScanItem[] | null>(null)
-  const [truncated, setTruncated] = useState(false)
-  const [showImported, setShowImported] = useState(false)
   const [rows, setRows] = useState<ScanRowState[]>([])
   const [importing, setImporting] = useState(false)
   const [summary, setSummary] = useState<BatchImportResponse | null>(null)
-  const [err, setErr] = useState<string | null>(null)
+  const [importErr, setImportErr] = useState<string | null>(null)
 
-  const runScan = async (includeImported: boolean) => {
-    if (!path.trim()) return
-    setScanning(true)
-    setErr(null)
-    setItems(null)
-    setSummary(null)
-    try {
-      const r = await api.scanFolder(path.trim(), { includeImported })
-      setItems(r.items)
-      setTruncated(r.truncated)
-      setRows(r.items.map(it => ({
-        include: it.match === 'confident' && !it.alreadyImported,
-        bookId: it.match === 'confident' && it.book ? it.book.id : null,
-        format: it.detectedFormat || '',
-      })))
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : 'Scan failed')
-    } finally {
-      setScanning(false)
-    }
-  }
+  const folderScan = useFolderScan(items => setRows(items.map(it => ({
+    include: it.match === 'confident' && !it.alreadyImported,
+    bookId: it.match === 'confident' && it.book ? it.book.id : null,
+    format: it.detectedFormat || '',
+  }))))
+  const { path, setPath, scanning, items, truncated, showImported, scan, toggleShowImported } = folderScan
 
-  const handleScan = () => runScan(showImported)
-
-  const toggleShowImported = (checked: boolean) => {
-    setShowImported(checked)
-    if (items) runScan(checked)
-  }
+  // A scan attempt (fresh or re-triggered by the toggle) supersedes whatever
+  // the last import attempt reported.
+  const handleScan = () => { setSummary(null); setImportErr(null); scan() }
+  const handleToggleShowImported = (checked: boolean) => { setSummary(null); setImportErr(null); toggleShowImported(checked) }
+  const err = folderScan.error ?? importErr
 
   const patchRow = (i: number, patch: Partial<ScanRowState>) =>
     setRows(prev => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
@@ -327,12 +307,12 @@ export function FolderScanSection() {
     })
     if (batch.length === 0) return
     setImporting(true)
-    setErr(null)
+    setImportErr(null)
     try {
       const res = await api.batchImport(batch)
       setSummary(res)
     } catch (e) {
-      setErr(e instanceof Error ? e.message : 'Import failed')
+      setImportErr(e instanceof Error ? e.message : 'Import failed')
     } finally {
       setImporting(false)
     }
@@ -359,7 +339,7 @@ export function FolderScanSection() {
           className={inputCls + ' flex-1'}
           placeholder={t('settings.import.bulkPathPlaceholder', '/downloads/books')}
           value={path}
-          onChange={e => { setPath(e.target.value); setItems(null); setSummary(null) }}
+          onChange={e => { setPath(e.target.value); folderScan.clear(); setSummary(null) }}
           onKeyDown={e => { if (e.key === 'Enter') handleScan() }}
         />
         <button
@@ -375,7 +355,7 @@ export function FolderScanSection() {
         <input
           type="checkbox"
           checked={showImported}
-          onChange={e => toggleShowImported(e.target.checked)}
+          onChange={e => handleToggleShowImported(e.target.checked)}
           disabled={scanning}
           className="rounded border-slate-400 dark:border-zinc-600 text-emerald-600 focus:ring-emerald-500 focus:ring-offset-0"
         />

--- a/web/src/pages/settings/ImportTab.tsx
+++ b/web/src/pages/settings/ImportTab.tsx
@@ -279,23 +279,24 @@ export function FolderScanSection() {
   const [scanning, setScanning] = useState(false)
   const [items, setItems] = useState<ScanItem[] | null>(null)
   const [truncated, setTruncated] = useState(false)
+  const [showImported, setShowImported] = useState(false)
   const [rows, setRows] = useState<ScanRowState[]>([])
   const [importing, setImporting] = useState(false)
   const [summary, setSummary] = useState<BatchImportResponse | null>(null)
   const [err, setErr] = useState<string | null>(null)
 
-  const handleScan = async () => {
+  const runScan = async (includeImported: boolean) => {
     if (!path.trim()) return
     setScanning(true)
     setErr(null)
     setItems(null)
     setSummary(null)
     try {
-      const r = await api.scanFolder(path.trim())
+      const r = await api.scanFolder(path.trim(), { includeImported })
       setItems(r.items)
       setTruncated(r.truncated)
       setRows(r.items.map(it => ({
-        include: it.match === 'confident',
+        include: it.match === 'confident' && !it.alreadyImported,
         bookId: it.match === 'confident' && it.book ? it.book.id : null,
         format: it.detectedFormat || '',
       })))
@@ -304,6 +305,13 @@ export function FolderScanSection() {
     } finally {
       setScanning(false)
     }
+  }
+
+  const handleScan = () => runScan(showImported)
+
+  const toggleShowImported = (checked: boolean) => {
+    setShowImported(checked)
+    if (items) runScan(checked)
   }
 
   const patchRow = (i: number, patch: Partial<ScanRowState>) =>
@@ -346,7 +354,7 @@ export function FolderScanSection() {
         {t('settings.import.bulkDescription', 'Scan a folder (e.g. your download directory) and import every book it can match to your library in one go. Matching is against books already in your library, so add the authors first. Unmatched items are listed but skipped.')}
       </p>
 
-      <div className="flex gap-2 mb-3">
+      <div className="flex gap-2 mb-2">
         <input
           className={inputCls + ' flex-1'}
           placeholder={t('settings.import.bulkPathPlaceholder', '/downloads/books')}
@@ -363,15 +371,27 @@ export function FolderScanSection() {
         </button>
       </div>
 
+      <label className="flex items-center gap-1.5 mb-3 text-xs text-slate-600 dark:text-zinc-400 cursor-pointer select-none w-fit">
+        <input
+          type="checkbox"
+          checked={showImported}
+          onChange={e => toggleShowImported(e.target.checked)}
+          disabled={scanning}
+          className="rounded border-slate-400 dark:border-zinc-600 text-emerald-600 focus:ring-emerald-500 focus:ring-offset-0"
+        />
+        {t('settings.import.bulkShowImported', 'Show already imported')}
+      </label>
+
+      {truncated && (
+        <p className="text-xs text-amber-700 dark:text-amber-400 mb-2">{t('settings.import.bulkTruncated', 'Showing the first 1000 items; narrow the folder to see the rest.')}</p>
+      )}
+
       {items && items.length === 0 && (
         <p className="text-sm text-slate-500 dark:text-zinc-600">{t('settings.import.bulkEmpty', 'No book files or folders found here.')}</p>
       )}
 
       {items && items.length > 0 && !summary && (
         <div className="space-y-2">
-          {truncated && (
-            <p className="text-xs text-amber-700 dark:text-amber-400">{t('settings.import.bulkTruncated', 'Showing the first 1000 items; narrow the folder to see the rest.')}</p>
-          )}
           <div className="border border-slate-200 dark:border-zinc-800 rounded divide-y divide-slate-200 dark:divide-zinc-800 max-h-96 overflow-auto">
             {items.map((it, i) => {
               const row = rows[i]
@@ -391,6 +411,11 @@ export function FolderScanSection() {
                       <span className="font-medium truncate">{it.name}</span>
                       {matchBadge(it.match)}
                       <span className="text-[10px] px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400 rounded">{it.detectedFormat}</span>
+                      {it.alreadyImported && (
+                        <span className="text-[10px] px-1.5 py-0.5 bg-sky-100 dark:bg-sky-950 text-sky-700 dark:text-sky-400 rounded">
+                          {t('settings.import.bulkAlreadyImported', 'already imported')}
+                        </span>
+                      )}
                     </div>
                     {/* Full source path so the user can tell which file a match
                         (or the ambiguous picker below) refers to — the basename


### PR DESCRIPTION
## Summary
- skip files already present in `book_files` during manual folder-import scans
- only new/untracked files reach catalogue matching and the import wizard
- document the default behavior

## Motivation
Re-scanning a library folder currently presents already-imported files again. Files whose names no longer match catalogue metadata can appear as unmatched, forcing manual re-selection. Folder import should default to new/unmatched files.

## Testing
- `go test ./internal/db ./internal/importer ./internal/api` via Go 1.26.6 container
- Result: all three packages passed
- Added `TestManualImportScan_SkipsAlreadyTrackedFiles`

Related: #1292