### PR TITLE
feat(book): allow deleting an individual tracked file

### DIFF
--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -638,6 +638,10 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	id := existing.ID
 
 	if path := r.URL.Query().Get("path"); path != "" {
+		if r.URL.Query().Get("delete") == "true" {
+			h.deleteTrackedBookFile(w, r, id, path)
+			return
+		}
 		h.deregisterBookFile(w, r, id, path)
 		return
 	}
@@ -734,6 +738,57 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	writeJSON(w, http.StatusOK, book)
+}
+
+// deleteTrackedBookFile removes exactly one tracked book_files row and its
+// on-disk payload. Unlike the format-scoped delete, an ebook never sweeps
+// same-stem siblings.
+func (h *BookHandler) deleteTrackedBookFile(w http.ResponseWriter, r *http.Request, id int64, requested string) {
+	files, err := h.books.ListFiles(r.Context(), id)
+	if err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+	want := filepath.Clean(requested)
+	var target *models.BookFile
+	for i := range files {
+		if filepath.Clean(files[i].Path) == want {
+			target = &files[i]
+			break
+		}
+	}
+	if target == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "path is not tracked against this book"})
+		return
+	}
+
+	if _, err := safeRemoveBookPathExact(r.Context(), h.roots, h.books, id, target.Path, target.Format, "id", id); err != nil {
+		slog.Error("failed to remove individual book file", "id", id, "path", target.Path, "error", err)
+		writeServerError(w, r, err)
+		return
+	}
+	if _, err := h.books.RemoveBookFile(r.Context(), target.Path); err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+
+	book, err := h.books.GetByID(r.Context(), id)
+	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	h.attachBookFiles(r.Context(), book)
+	cleanBookDescription(book)
+	if h.history != nil {
+		data, marshalErr := json.Marshal(map[string]any{"paths": []string{target.Path}, "individual": true})
+		if marshalErr == nil {
+			_ = h.history.Create(r.Context(), &models.HistoryEvent{
+				BookID: &book.ID, EventType: models.HistoryEventBookFileDeleted,
+				SourceTitle: book.Title, Data: string(data),
+			})
+		}
+	}
 	writeJSON(w, http.StatusOK, book)
 }
 

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -687,6 +687,55 @@ func TestBookUpdate_RejectsRetiredDownloadStatuses(t *testing.T) {
 	}
 }
 
+// TestBookDeleteFile_IndividualPath removes only the selected tracked row and
+// leaves a sibling file untouched.
+func TestBookDeleteFile_IndividualPath(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+	tmp := t.TempDir()
+	first := filepath.Join(tmp, "first.epub")
+	second := filepath.Join(tmp, "second.epub")
+	for _, p := range []string{first, second} {
+		if err := os.WriteFile(p, []byte(p), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	book := &models.Book{
+		ForeignID: "B-INDIVIDUAL", AuthorID: author.ID, Title: "Individual", SortTitle: "individual",
+		Status: models.BookStatusImported, Genres: []string{}, MediaType: models.MediaTypeEbook,
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{first, second} {
+		if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, p); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := withURLParam(httptest.NewRequest(http.MethodDelete,
+		"/api/v1/book/"+strconv.FormatInt(book.ID, 10)+"/file?path="+url.QueryEscape(first)+"&delete=true", nil),
+		"id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.DeleteFile(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(first); !os.IsNotExist(err) {
+		t.Errorf("selected file should be deleted, stat err=%v", err)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Errorf("sibling file must survive, stat err=%v", err)
+	}
+	files, err := books.ListFiles(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0].Path != second {
+		t.Errorf("expected only sibling row to remain, got %+v", files)
+	}
+}
+
 // TestBookDeleteFile_FormatScopedKeepsSibling is the #715 finding 2 data-loss
 // guard: deleting ?format=ebook must leave the same-stem audiobook on disk.
 func TestBookDeleteFile_FormatScopedKeepsSibling(t *testing.T) {

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -736,6 +736,27 @@ func TestBookDeleteFile_IndividualPath(t *testing.T) {
 	}
 }
 
+func TestBookDeleteFile_IndividualPathRequiresTrackedRow(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+	book := &models.Book{
+		ForeignID: "B-INDIVIDUAL-MISSING", AuthorID: author.ID, Title: "Missing", SortTitle: "missing",
+		Status: models.BookStatusImported, Genres: []string{}, MediaType: models.MediaTypeEbook,
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	req := withURLParam(httptest.NewRequest(http.MethodDelete,
+		"/api/v1/book/"+strconv.FormatInt(book.ID, 10)+"/file?path=%2Flibrary%2Fmissing.epub&delete=true", nil),
+		"id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.DeleteFile(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for an untracked path, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 // TestBookDeleteFile_FormatScopedKeepsSibling is the #715 finding 2 data-loss
 // guard: deleting ?format=ebook must leave the same-stem audiobook on disk.
 func TestBookDeleteFile_FormatScopedKeepsSibling(t *testing.T) {

--- a/internal/api/path_safety.go
+++ b/internal/api/path_safety.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -288,6 +289,47 @@ func safeRemoveBookPath(ctx context.Context, roots *LibraryRoots, owner bookFile
 		return true, nil
 	}
 	return false, removeBookPathScoped(p, format, ownedByOther)
+}
+
+// safeRemoveBookPathExact is the single-row variant of safeRemoveBookPath.
+// Unlike the format-scoped delete, it never sweeps same-stem siblings. A
+// directory remains a unit because audiobook book_files rows represent the
+// complete bundle, but files beside a targeted ebook are left untouched.
+func safeRemoveBookPathExact(ctx context.Context, roots *LibraryRoots, owner bookFileOwner, excludeBookID int64, p, format string, logFields ...any) (skipped bool, err error) {
+	if !roots.Contains(ctx, p) {
+		fields := append([]any{"path", p, "operation", "book_file_delete"}, logFields...)
+		slog.Warn("path containment: refusing to delete file outside configured library roots", fields...)
+		return true, nil
+	}
+	ownedByOther := func(path string) bool {
+		if owner == nil {
+			return false
+		}
+		otherOwns, ownErr := owner.PathOwnedByOtherBook(ctx, path, excludeBookID)
+		if ownErr != nil {
+			fields := append([]any{"path", path, "operation", "book_file_delete", "error", ownErr}, logFields...)
+			slog.Warn("path ownership: could not verify book_files ownership; skipping disk delete", fields...)
+			return true
+		}
+		return otherOwns
+	}
+	if ownedByOther(p) {
+		return true, nil
+	}
+	info, statErr := os.Stat(p)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, statErr
+	}
+	if info.IsDir() {
+		return false, removeBookDirScoped(p, format, ownedByOther)
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) { // #nosec G304 G703 -- p is gated by the configured library roots above
+		return false, err
+	}
+	return false, nil
 }
 
 // bookFileOwner reports whether an on-disk path is still registered in

--- a/internal/api/path_safety_test.go
+++ b/internal/api/path_safety_test.go
@@ -367,3 +367,65 @@ func TestSafeRemoveBookPath_SiblingOwnedByAnotherBook(t *testing.T) {
 		t.Error("a sibling another book tracks must survive the stem sweep")
 	}
 }
+
+func TestSafeRemoveBookPathExact_DeletesOnlyTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := mustWrite(t, filepath.Join(dir, "Book.epub"))
+	sibling := mustWrite(t, filepath.Join(dir, "Book.mobi"))
+
+	skipped, err := safeRemoveBookPathExact(context.Background(), nil, nil, 1, target, "ebook")
+	if err != nil || skipped {
+		t.Fatalf("safeRemoveBookPathExact = skipped %v, err %v; want false, nil", skipped, err)
+	}
+	if exists(target) {
+		t.Error("target should be removed")
+	}
+	if !exists(sibling) {
+		t.Error("exact deletion must leave sibling untouched")
+	}
+}
+
+func TestSafeRemoveBookPathExact_SafetyBranches(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	outside := mustWrite(t, filepath.Join(t.TempDir(), "outside.epub"))
+	roots := NewLibraryRoots(nil, root)
+
+	if skipped, err := safeRemoveBookPathExact(ctx, roots, nil, 1, outside, "ebook"); err != nil || !skipped {
+		t.Errorf("outside path = skipped %v, err %v; want true, nil", skipped, err)
+	}
+
+	target := mustWrite(t, filepath.Join(root, "owned.epub"))
+	if skipped, err := safeRemoveBookPathExact(ctx, nil, stubOwner{err: os.ErrPermission}, 1, target, "ebook"); err != nil || !skipped {
+		t.Errorf("ownership error = skipped %v, err %v; want true, nil", skipped, err)
+	}
+	if !exists(target) {
+		t.Error("ownership failure must preserve the file")
+	}
+
+	other := mustWrite(t, filepath.Join(root, "other.epub"))
+	if skipped, err := safeRemoveBookPathExact(ctx, nil, stubOwner{owned: map[string]bool{other: true}}, 1, other, "ebook"); err != nil || !skipped {
+		t.Errorf("other owner = skipped %v, err %v; want true, nil", skipped, err)
+	}
+	if !exists(other) {
+		t.Error("a file owned by another book must survive")
+	}
+
+	missing := filepath.Join(root, "missing.epub")
+	if skipped, err := safeRemoveBookPathExact(ctx, nil, nil, 1, missing, "ebook"); err != nil || skipped {
+		t.Errorf("missing path = skipped %v, err %v; want false, nil", skipped, err)
+	}
+}
+
+func TestSafeRemoveBookPathExact_AudiobookDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "Book")
+	mustWrite(t, filepath.Join(dir, "Book.m4b"))
+
+	skipped, err := safeRemoveBookPathExact(context.Background(), nil, nil, 1, dir, "audiobook")
+	if err != nil || skipped {
+		t.Fatalf("safeRemoveBookPathExact = skipped %v, err %v; want false, nil", skipped, err)
+	}
+	if exists(dir) {
+		t.Error("audiobook directory should be removed when no sibling format remains")
+	}
+}

--- a/internal/db/book_files_test.go
+++ b/internal/db/book_files_test.go
@@ -224,6 +224,31 @@ func TestBookRepo_MigrationBackfill(t *testing.T) {
 	}
 }
 
+// TestBookRepo_RemoveBookFile_KeepsImportedWithSibling verifies removing one
+// of multiple files in a format does not make the book wanted.
+func TestBookRepo_RemoveBookFile_KeepsImportedWithSibling(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	for _, path := range []string{"/lib/first.epub", "/lib/second.epub"} {
+		if err := repo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, path); err != nil {
+			t.Fatalf("AddBookFile: %v", err)
+		}
+	}
+	if _, err := repo.RemoveBookFile(ctx, "/lib/first.epub"); err != nil {
+		t.Fatalf("RemoveBookFile: %v", err)
+	}
+
+	got, _ := repo.GetByID(ctx, book.ID)
+	if got.Status != models.BookStatusImported {
+		t.Errorf("status should remain imported while a sibling remains, got %q", got.Status)
+	}
+	if got.EbookFilePath != "/lib/second.epub" {
+		t.Errorf("EbookFilePath should point to the surviving file, got %q", got.EbookFilePath)
+	}
+}
+
 // TestBookRepo_RemoveBookFile_StatusFlips verifies removing the last file
 // flips the book back to "wanted".
 func TestBookRepo_RemoveBookFile_StatusFlips(t *testing.T) {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1264,7 +1264,7 @@
     "deleteFilesBody": "Permanently delete {{count}} file(s) from disk:",
     "deleteFilesConfirm": "Delete from disk",
     "deleteFilesSiblingNote": "Any sibling file with the same name in the same format is also removed.",
-    "deleteFilesStatusNote": "The book record stays and flips back to “wanted”.",
+    "deleteFilesStatusNote": "If this was the last file for a monitored format, the book returns to “wanted”.",
     "deleteAllFiles": {
       "button": "Delete all files",
       "hint": "Delete every file on this book, both formats"

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1264,7 +1264,7 @@
     "deleteFilesBody": "Permanently delete {{count}} file(s) from disk:",
     "deleteFilesConfirm": "Delete from disk",
     "deleteFilesSiblingNote": "Any sibling file with the same name in the same format is also removed.",
-    "deleteFilesStatusNote": "If this was the last file for a monitored format, the book returns to “wanted”.",
+    "deleteFilesStatusNote": "If this was the last file for a monitored format, an imported book returns to “wanted”.",
     "deleteAllFiles": {
       "button": "Delete all files",
       "hint": "Delete every file on this book, both formats"

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1302,6 +1302,8 @@
     "excludeHint": "Exclude this book from searches and the Wanted page",
     "unexcludeHint": "Un-exclude this book from searches and the Wanted page",
     "deleteFile": "Delete file",
+    "deleteThisFile": "Delete this file",
+    "deleteThisFileHint": "Permanently delete only this file from disk",
     "deletingFile": "Deleting…",
     "fixMatch": {
       "button": "Fix match",

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -544,6 +544,27 @@ describe('BookDetailPage — file section actions', () => {
     )
   })
 
+  it('deletes one tracked row by path without deleting siblings', async () => {
+    vi.mocked(api.getBook).mockResolvedValue(
+      makeBook({
+        bookFiles: [
+          makeFile({ id: 1, format: 'ebook', path: '/library/keep.epub' }),
+          makeFile({ id: 2, format: 'ebook', path: '/library/delete.epub' }),
+        ],
+      }),
+    )
+    renderBookDetailPage()
+    const group = within(await screen.findByTestId('file-group-ebook'))
+    fireEvent.click(group.getByRole('button', { name: 'More actions for delete.epub' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Delete this file' }))
+    expect(await screen.findByText('Delete this file')).toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('checkbox'))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete from disk' }))
+    await waitFor(() =>
+      expect(api.deleteBookFile).toHaveBeenCalledWith(42, '?path=%2Flibrary%2Fdelete.epub&delete=true'),
+    )
+  })
+
   // Legacy rows predate migration 028 and have no book_files entry, so
   // deregister would 404 against a path the server cannot resolve.
   it('disables deregister for untracked legacy rows', async () => {

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -883,6 +883,14 @@ export default function BookDetailPage() {
                                   onSelect: () => setFixMatchRow(row),
                                 },
                                 {
+                                  label: t('bookDetail.deregister.button'),
+                                  title: row.tracked
+                                    ? t('bookDetail.deregister.hint')
+                                    : t('bookDetail.deregister.untracked'),
+                                  disabled: !row.tracked || deletingFile || deregistering || deletingBook,
+                                  onSelect: () => setDeregisterTarget(row),
+                                },
+                                {
                                   label: t('bookDetail.deleteThisFile', 'Delete this file'),
                                   title: t('bookDetail.deleteThisFileHint', 'Permanently delete only this file from disk'),
                                   danger: true,
@@ -891,14 +899,6 @@ export default function BookDetailPage() {
                                     singlePath: row.path,
                                     paths: [row.path],
                                   }),
-                                },
-                                {
-                                  label: t('bookDetail.deregister.button'),
-                                  title: row.tracked
-                                    ? t('bookDetail.deregister.hint')
-                                    : t('bookDetail.deregister.untracked'),
-                                  disabled: !row.tracked || deletingFile || deregistering || deletingBook,
-                                  onSelect: () => setDeregisterTarget(row),
                                 },
                               ]}
                             />

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -275,7 +275,7 @@ export default function BookDetailPage() {
   // book; `paths` is exactly what the dialog shows, so the confirmation and
   // the request can never disagree.
   const [deleteTarget, setDeleteTarget] = useState<
-    { format?: 'ebook' | 'audiobook'; paths: string[] } | null
+    { format?: 'ebook' | 'audiobook'; paths: string[]; singlePath?: string } | null
   >(null)
   // The pending DB-only deregistration (#1692).
   const [deregisterTarget, setDeregisterTarget] = useState<FileRow | null>(null)
@@ -411,7 +411,9 @@ export default function BookDetailPage() {
     setDeletingFile(true)
     setError(null)
     try {
-      const params = deleteTarget.format ? `?format=${deleteTarget.format}` : ''
+      const params = deleteTarget.singlePath
+        ? `?path=${encodeURIComponent(deleteTarget.singlePath)}&delete=true`
+        : deleteTarget.format ? `?format=${deleteTarget.format}` : ''
       const updated = await api.deleteBookFile(book.id, params)
       setBook(updated)
       setDeleteTarget(null)
@@ -881,6 +883,16 @@ export default function BookDetailPage() {
                                   onSelect: () => setFixMatchRow(row),
                                 },
                                 {
+                                  label: t('bookDetail.deleteThisFile', 'Delete this file'),
+                                  title: t('bookDetail.deleteThisFileHint', 'Permanently delete only this file from disk'),
+                                  danger: true,
+                                  disabled: !row.tracked || deletingFile || deregistering || deletingBook,
+                                  onSelect: () => setDeleteTarget({
+                                    singlePath: row.path,
+                                    paths: [row.path],
+                                  }),
+                                },
+                                {
                                   label: t('bookDetail.deregister.button'),
                                   title: row.tracked
                                     ? t('bookDetail.deregister.hint')
@@ -1196,9 +1208,11 @@ export default function BookDetailPage() {
           type while a format-less DELETE removed every file on the book. */}
       {deleteTarget && (
         <ConfirmDialog
-          title={deleteTarget.format
-            ? t('bookDetail.deleteFilesTitle', { format: t(`common.${deleteTarget.format}`) })
-            : t('bookDetail.deleteAllFiles.button')}
+          title={deleteTarget.singlePath
+            ? t('bookDetail.deleteThisFile', 'Delete this file')
+            : deleteTarget.format
+              ? t('bookDetail.deleteFilesTitle', { format: t(`common.${deleteTarget.format}`) })
+              : t('bookDetail.deleteAllFiles.button')}
           body={
             <div className="space-y-2">
               <p>{t('bookDetail.deleteFilesBody', { count: deleteTarget.paths.length })}</p>
@@ -1209,7 +1223,7 @@ export default function BookDetailPage() {
                   </li>
                 ))}
               </ul>
-              <p>{t('bookDetail.deleteFilesSiblingNote')}</p>
+              {!deleteTarget.singlePath && <p>{t('bookDetail.deleteFilesSiblingNote')}</p>}
               <p>{t('bookDetail.deleteFilesStatusNote')}</p>
             </div>
           }


### PR DESCRIPTION
## Summary

Closes #2485.

Add a destructive **Delete this file** action to each tracked file's More menu on the book detail page. The action is placed below **Forget this file**, deletes only the selected tracked file, removes its `book_files` row, refreshes the book state, and records a history event.

The implementation preserves configured-root and cross-book ownership safety checks, keeps audiobook directory-backed entries atomic, and leaves format-level deletion and DB-only forgetting unchanged. Status remains `imported` when another file for the monitored format survives; an imported book returns to `wanted` only when the last required file for a monitored format is removed.

## Checklist

- [x] Commits signed off with `git commit -s` — see [Sign your work](../CONTRIBUTING.md#sign-your-work-dco)
- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (not applicable)
- [ ] Added a changelog fragment under `changelog.d/` (not added; maintainer/release process)
- [ ] Wiki pages updated if user-facing behaviour changed (not needed for this focused UI action)

## Test plan

- [x] `go test -count=1 ./internal/api ./internal/importer ./internal/db`
- [x] `npm test -- --run src/pages/BookDetailPage.test.tsx` (62 tests passed)
- [x] `npm run lint` (0 errors; existing warnings only)
- [x] `git diff --check`

<!-- Only lint, validate (Go), and Security Summary are required to merge.
     Other security scans are advisory; a red Container Scan is often a base-image
     CVE unrelated to your change — mention it and a maintainer will confirm. -->
