### PR TITLE
refactor(web): one pagination envelope instead of two identical ones (#1000)

### DIFF
--- a/web/src/api/abs.ts
+++ b/web/src/api/abs.ts
@@ -1,5 +1,5 @@
 import { request } from './core'
-import type { PaginatedResponse } from './common'
+import type { Page } from './common'
 
 export interface ABSConfig {
   featureEnabled: boolean
@@ -225,7 +225,7 @@ export const absApi = {
     const q = new URLSearchParams()
     if (params?.limit) q.set('limit', String(params.limit))
     if (params?.offset) q.set('offset', String(params.offset))
-    return request<PaginatedResponse<ABSReviewItem>>(`/abs/review${q.toString() ? `?${q.toString()}` : ''}`)
+    return request<Page<ABSReviewItem>>(`/abs/review${q.toString() ? `?${q.toString()}` : ''}`)
   },
   approveAbsReviewItem: (id: number) => request<ABSReviewItem>(`/abs/review/${id}/approve`, { method: 'POST' }),
   resolveAbsReviewAuthor: (id: number, data: { foreignAuthorId: string; authorName: string; applyTo?: 'same_author' }) =>
@@ -239,7 +239,7 @@ export const absApi = {
     const q = new URLSearchParams()
     if (params?.limit) q.set('limit', String(params.limit))
     if (params?.offset) q.set('offset', String(params.offset))
-    return request<PaginatedResponse<ABSMetadataConflict>>(`/abs/conflicts${q.toString() ? `?${q.toString()}` : ''}`)
+    return request<Page<ABSMetadataConflict>>(`/abs/conflicts${q.toString() ? `?${q.toString()}` : ''}`)
   },
   resolveAbsConflict: (id: number, source: 'abs' | 'upstream') =>
     request<ABSMetadataConflict>(`/abs/conflicts/${id}/resolve`, { method: 'POST', body: JSON.stringify({ source }) }),

--- a/web/src/api/common.ts
+++ b/web/src/api/common.ts
@@ -1,18 +1,11 @@
-// Shared cross-domain types: the pagination envelopes used by several List
-// endpoints, and BookRef (the minimal book+author projection embedded in
+// Shared cross-domain types: the pagination envelope used by every List
+// endpoint, and BookRef (the minimal book+author projection embedded in
 // queue/pending/history/download items).
 
-export interface PaginatedResponse<T> {
-  items: T[]
-  total: number
-  limit: number
-  offset: number
-}
-
-// Page<T> is the envelope returned by the paginated List endpoints introduced
-// in PR #902 (GET /book, /author, /history). Shape matches PaginatedResponse
-// above and the two will likely be unified later; kept distinct for now so
-// the diff stays scoped to the three new endpoints.
+// Page<T> is the envelope returned by every paginated List endpoint
+// (GET /book, /author, /history, /abs/review, /abs/conflicts). It was briefly
+// duplicated as PaginatedResponse<T> when PR #902 added the first three; the
+// two declarations were identical and are now one (#1000).
 export interface Page<T> {
   items: T[]
   total: number


### PR DESCRIPTION
## What

`web/src/api/common.ts` declared `Page<T>` and `PaginatedResponse<T>` with the same four fields. PR #902 added `Page<T>` for the three new paginated List endpoints and left the old one alone to keep that diff scoped, with a comment saying the two would be unified later. This does it.

- `PaginatedResponse<T>` deleted.
- `/abs/review` and `/abs/conflicts` in `web/src/api/abs.ts` now use `Page<T>`.

## Why it is safe

The two interfaces were structurally identical, so TypeScript already treated them as the same type. Every call site resolves to the shape it already had. There are no other references in the tree, tests included.

## Checks

- `npm run typecheck` clean
- `npm run lint` 0 errors (6 pre-existing warnings, all in files this PR does not touch)
- `npm test` 840 passed across 76 files
- `npm run build` green

No changelog fragment: internal type dedup with no user-facing effect.

Closes #1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP