### PR TITLE
fix(books): search the format a book gains after it was imported (#1634)

### DIFF
--- a/changelog.d/1634-search-the-missing-format.md
+++ b/changelog.d/1634-search-the-missing-format.md
@@ -1,0 +1,2 @@
+### Fixed
+- **A book that gains a second format is searched for it again** (#1634) — a book you already owned as an ebook could be widened to dual-format by Hardcover list sync or edition hydration. The book kept its "imported" status, so the Wanted page, the scheduled search sweep and the author bulk search all treated it as complete and the newly monitored format was never searched. Widening now reopens the book as wanted, and an upgrade repairs any book already left in that state.

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -664,17 +664,11 @@ func (h *BulkHandler) setBookMediaType(ctx context.Context, id int64, mediaType 
 // tracked in the downloads table and never on books.status (#2374). The
 // media-type change is the reason to search again anyway, so flipping it
 // back to 'wanted' is the right answer even mid-download.
+//
+// The rule itself now lives on models.Book so the callers that widen a book
+// outside this package can apply it too (#1634).
 func reevaluateBookStatus(b *models.Book) {
-	if b.Status == models.BookStatusSkipped {
-		return
-	}
-	if b.NeedsEbook() || b.NeedsAudiobook() {
-		b.Status = models.BookStatusWanted
-		return
-	}
-	if b.EbookFilePath != "" || b.AudiobookFilePath != "" {
-		b.Status = models.BookStatusImported
-	}
+	b.ReevaluateStatus()
 }
 
 // setAuthorBooksMediaType applies the given media type to every book in an

--- a/internal/bookhydrate/hardcover.go
+++ b/internal/bookhydrate/hardcover.go
@@ -218,6 +218,13 @@ func deriveAudiobookMetadataFromEdition(book *models.Book, edition models.Editio
 			book.MediaType = models.MediaTypeBoth
 			changed = true
 		}
+		if changed {
+			// The promotion adds a monitored format with no file behind it. If
+			// status stays 'imported' the gap is invisible to the wanted page,
+			// the scheduled sweep and the author bulk search, all of which
+			// select on status alone (#1634).
+			book.ReevaluateStatus()
+		}
 	}
 
 	if book.Language == "" {

--- a/internal/bookhydrate/hardcover_status_test.go
+++ b/internal/bookhydrate/hardcover_status_test.go
@@ -1,0 +1,63 @@
+package bookhydrate
+
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// Promoting an owned ebook to 'both' adds a monitored format with nothing
+// behind it. Status must follow, or the row keeps saying 'imported' and the
+// wanted page, the scheduled sweep and the author bulk search never see the
+// gap (#1634).
+func TestDeriveAudiobookMetadata_PromotionReevaluatesStatus(t *testing.T) {
+	book := &models.Book{
+		Title:         "Owned Ebook",
+		MediaType:     models.MediaTypeEbook,
+		EbookFilePath: "/library/owned.epub",
+		Status:        models.BookStatusImported,
+	}
+
+	if changed := deriveAudiobookMetadataFromEdition(book, models.Edition{}, false); !changed {
+		t.Fatal("expected the promotion to report a change")
+	}
+	if book.MediaType != models.MediaTypeBoth {
+		t.Fatalf("mediaType = %q, want both", book.MediaType)
+	}
+	if book.Status != models.BookStatusWanted {
+		t.Errorf("status = %q, want wanted: the audiobook slot is now monitored and empty", book.Status)
+	}
+}
+
+// A book the user has skipped stays skipped: that is a decision, not a
+// derived state.
+func TestDeriveAudiobookMetadata_PromotionLeavesSkippedAlone(t *testing.T) {
+	book := &models.Book{
+		Title:         "Skipped Ebook",
+		MediaType:     models.MediaTypeEbook,
+		EbookFilePath: "/library/skipped.epub",
+		Status:        models.BookStatusSkipped,
+	}
+	deriveAudiobookMetadataFromEdition(book, models.Edition{}, false)
+	if book.Status != models.BookStatusSkipped {
+		t.Errorf("status = %q, want skipped untouched", book.Status)
+	}
+}
+
+// A pinned media type blocks the promotion entirely, so there is nothing to
+// reevaluate and status must not move (#1732).
+func TestDeriveAudiobookMetadata_PinnedLeavesStatusAlone(t *testing.T) {
+	book := &models.Book{
+		Title:         "Pinned Ebook",
+		MediaType:     models.MediaTypeEbook,
+		EbookFilePath: "/library/pinned.epub",
+		Status:        models.BookStatusImported,
+	}
+	deriveAudiobookMetadataFromEdition(book, models.Edition{}, true)
+	if book.MediaType != models.MediaTypeEbook {
+		t.Fatalf("mediaType = %q, want ebook: pinned must block the promotion", book.MediaType)
+	}
+	if book.Status != models.BookStatusImported {
+		t.Errorf("status = %q, want imported untouched", book.Status)
+	}
+}

--- a/internal/db/migration_084_test.go
+++ b/internal/db/migration_084_test.go
@@ -1,0 +1,135 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestMigrate084BackfillsStatusForUnsatisfiedFormats covers #1634. A book that
+// was imported as a single format and later widened to 'both' by Hardcover list
+// sync or edition hydration kept status 'imported' while gaining a monitored
+// format with no file. Every consumer of the wanted set selects on status
+// alone, so the gap was never searched. Migration 084 repairs the rows that
+// already exist; the widening sites now call ReevaluateStatus themselves.
+func TestMigrate084BackfillsStatusForUnsatisfiedFormats(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authors := NewAuthorRepo(database)
+	author := &models.Author{
+		ForeignID: "OL:migration-084", Name: "Migration Author",
+		SortName: "Author, Migration", MetadataProvider: "openlibrary",
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	books := NewBookRepo(database)
+
+	// create seeds a book and forces status/media_type straight into the
+	// columns, the shape a widened row is left in.
+	create := func(foreignID, mediaType, status string) int64 {
+		t.Helper()
+		b := &models.Book{
+			ForeignID: foreignID, AuthorID: author.ID, Title: foreignID, SortTitle: foreignID,
+			Status: models.BookStatusWanted, Genres: []string{},
+			MetadataProvider: "openlibrary", Monitored: true,
+		}
+		if err := books.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := database.ExecContext(ctx,
+			`UPDATE books SET status = ?, media_type = ? WHERE id = ?`, status, mediaType, b.ID); err != nil {
+			t.Fatalf("seed %s: %v", foreignID, err)
+		}
+		return b.ID
+	}
+
+	// Widened after import: ebook on disk, audiobook slot empty, still 'imported'.
+	widened := create("B-WIDENED", models.MediaTypeBoth, models.BookStatusImported)
+	if err := books.AddBookFile(ctx, widened, models.MediaTypeEbook, "/library/widened.epub"); err != nil {
+		t.Fatal(err)
+	}
+	// AddBookFile runs refreshBookStatus, which leaves an already-'imported' row
+	// alone only when nothing is needed. Force the stuck value back afterwards.
+	if _, err := database.ExecContext(ctx,
+		`UPDATE books SET status = ? WHERE id = ?`, models.BookStatusImported, widened); err != nil {
+		t.Fatal(err)
+	}
+
+	// Genuinely complete dual-format book: both files present, must stay imported.
+	complete := create("B-COMPLETE", models.MediaTypeBoth, models.BookStatusImported)
+	if err := books.AddBookFile(ctx, complete, models.MediaTypeEbook, "/library/complete.epub"); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, complete, models.MediaTypeAudiobook, "/library/complete.m4b"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx,
+		`UPDATE books SET status = ? WHERE id = ?`, models.BookStatusImported, complete); err != nil {
+		t.Fatal(err)
+	}
+
+	// Migration 028 shape: book_files row exists, scalar column never written.
+	// The effective-path fallback must see the file and leave the row alone.
+	legacy := create("B-LEGACY", models.MediaTypeEbook, models.BookStatusImported)
+	if err := books.AddBookFile(ctx, legacy, models.MediaTypeEbook, "/library/legacy.epub"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx,
+		`UPDATE books SET status = ?, ebook_file_path = '' WHERE id = ?`,
+		models.BookStatusImported, legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	// Skipped encodes a user decision and must survive untouched.
+	skipped := create("B-SKIPPED", models.MediaTypeBoth, models.BookStatusSkipped)
+
+	v084 := migrationVersionForTest(t, "084_backfill_status_for_unsatisfied_formats.sql")
+	rerun := func() {
+		t.Helper()
+		if _, err := database.ExecContext(ctx, `DELETE FROM schema_migrations WHERE version = ?`, v084); err != nil {
+			t.Fatalf("clear migration 084 marker: %v", err)
+		}
+		if err := migrate(database); err != nil {
+			t.Fatalf("rerun migration 084: %v", err)
+		}
+	}
+	rerun()
+
+	rawStatus := func(id int64) string {
+		t.Helper()
+		var s string
+		if err := database.QueryRowContext(ctx, `SELECT status FROM books WHERE id = ?`, id).Scan(&s); err != nil {
+			t.Fatalf("read status %d: %v", id, err)
+		}
+		return s
+	}
+
+	if got := rawStatus(widened); got != models.BookStatusWanted {
+		t.Errorf("widened row = %q, want wanted (this is the #1634 repair)", got)
+	}
+	if got := rawStatus(complete); got != models.BookStatusImported {
+		t.Errorf("complete dual-format row = %q, want imported untouched", got)
+	}
+	if got := rawStatus(legacy); got != models.BookStatusImported {
+		t.Errorf("migration-028-shaped row = %q, want imported: its file is in book_files", got)
+	}
+	if got := rawStatus(skipped); got != models.BookStatusSkipped {
+		t.Errorf("skipped row = %q, want skipped untouched", got)
+	}
+
+	// Idempotent: a second run changes nothing.
+	rerun()
+	if got := rawStatus(complete); got != models.BookStatusImported {
+		t.Errorf("second run changed the complete row to %q", got)
+	}
+	if got := rawStatus(widened); got != models.BookStatusWanted {
+		t.Errorf("second run changed the repaired row to %q", got)
+	}
+}

--- a/internal/db/migrations/084_backfill_status_for_unsatisfied_formats.sql
+++ b/internal/db/migrations/084_backfill_status_for_unsatisfied_formats.sql
@@ -1,0 +1,51 @@
+-- +migrate Up
+-- Repair books stuck at 'imported' while a monitored format has no file (#1634).
+--
+-- books.status is derived from media_type plus the on-disk paths, and
+-- refreshBookStatus keeps it correct on every book_files write. Nothing kept it
+-- correct when media_type changed on its own. A single-format book that was
+-- already imported and then widened to 'both' by Hardcover list sync or by
+-- edition hydration kept status 'imported' while gaining a monitored format
+-- with nothing behind it.
+--
+-- That state is invisible rather than merely wrong. The wanted page
+-- (ListByStatusAndUser), the scheduled sweep (wantedSearchQueue) and the author
+-- bulk search all select on status alone, so the missing format is never
+-- searched and the library row looks entirely normal. #2096 fixed one producer
+-- of the state in v1.32.2 (author refresh) but shipped no repair, and its
+-- reporter had 29 books widened in a single run before that.
+--
+-- The predicate is the same one models.Book.ReevaluateStatus applies, using the
+-- same effective-path expression as bookColumns: the stored column first, then
+-- the first book_files row for the format. The fallback matters because
+-- migration 028 leaves books whose book_files row exists while the scalar
+-- column is still empty; reading the column alone would move those rows to
+-- 'wanted' when their file is present.
+--
+-- 'skipped' is left alone, it encodes a user decision. 'wanted' rows are
+-- already correct. Excluded books are included: status is a fact about the
+-- book, and the sweep skips excluded rows on its own.
+--
+-- Idempotent: after the update the matched rows are 'wanted', so a second run
+-- matches nothing.
+UPDATE books
+SET status = 'wanted', updated_at = CURRENT_TIMESTAMP
+WHERE status = 'imported'
+  AND (
+        (media_type IN ('ebook', 'both')
+         AND COALESCE(NULLIF(ebook_file_path, ''),
+                      (SELECT path FROM book_files
+                       WHERE book_id = books.id AND format = 'ebook'
+                       ORDER BY id LIMIT 1),
+                      '') = '')
+     OR (media_type IN ('audiobook', 'both')
+         AND COALESCE(NULLIF(audiobook_file_path, ''),
+                      (SELECT path FROM book_files
+                       WHERE book_id = books.id AND format = 'audiobook'
+                       ORDER BY id LIMIT 1),
+                      '') = '')
+      );
+
+-- +migrate Down
+-- Irreversible: a row this rewrote is indistinguishable from a book that was
+-- already 'wanted' with the same missing format.

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -513,6 +513,12 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 		if existing != nil {
 			if shouldWidenMediaType(existing.MediaType, effectiveMediaType) {
 				existing.MediaType = models.MediaTypeBoth
+				// Widening creates a real gap on an owned book: the audiobook
+				// slot is now monitored and empty. Without this the row keeps
+				// status 'imported' and never enters the wanted set, so the
+				// format this sync just decided it wants is never searched
+				// (#1634).
+				existing.ReevaluateStatus()
 				// The ebook-pinned pass clears the audiobook ASIN. Preserve the
 				// audio identifier when the complementary pass supplies it.
 				if (effectiveMediaType == models.MediaTypeAudiobook || effectiveMediaType == models.MediaTypeBoth) && book.ASIN != "" {

--- a/internal/hardcoverlistsyncer/syncer_widen_status_test.go
+++ b/internal/hardcoverlistsyncer/syncer_widen_status_test.go
@@ -1,0 +1,89 @@
+package hardcoverlistsyncer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// A complementary audiobook list widening a book the user already owns as an
+// ebook creates a genuine gap: the audiobook slot becomes monitored with
+// nothing behind it. The row must leave 'imported', or the wanted page, the
+// scheduled sweep and the author bulk search all skip it forever and the
+// format this sync just asked for is never searched (#1634).
+func TestSyncOne_WideningAnImportedBookReopensItAsWanted(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+
+	ebookList := testImportList("Ebooks", "hardcover", true)
+	ebookList.URL = "ebooks"
+	ebookList.MediaType = models.MediaTypeEbook
+	if err := repo.Create(ctx, &ebookList); err != nil {
+		t.Fatalf("seed ebook list: %v", err)
+	}
+	audiobookList := testImportList("Audiobooks", "hardcover", true)
+	audiobookList.URL = "audiobooks"
+	audiobookList.MediaType = models.MediaTypeAudiobook
+	if err := repo.Create(ctx, &audiobookList); err != nil {
+		t.Fatalf("seed audiobook list: %v", err)
+	}
+
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{
+				{ID: 1, Slug: ebookList.URL, Name: ebookList.Name},
+				{ID: 2, Slug: audiobookList.URL, Name: audiobookList.Name},
+			},
+			books: []models.Book{{
+				ForeignID:        "hc:owned-ebook",
+				Title:            "Owned Ebook",
+				MetadataProvider: "hardcover",
+				MediaType:        models.MediaTypeBoth,
+				Author: &models.Author{
+					ForeignID:        "hc:owned-author",
+					Name:             "Owned Author",
+					MetadataProvider: "hardcover",
+				},
+			}},
+		}
+	})
+
+	if err := s.SyncOne(ctx, ebookList.ID); err != nil {
+		t.Fatalf("sync ebook list: %v", err)
+	}
+	tracked, err := s.books.GetByForeignID(ctx, "hc:owned-ebook")
+	if err != nil || tracked == nil {
+		t.Fatalf("book not created: %v", err)
+	}
+
+	// The user then imports the ebook. AddBookFile derives the status, so the
+	// book is legitimately 'imported' for its declared single format.
+	if err := s.books.AddBookFile(ctx, tracked.ID, models.MediaTypeEbook, "/library/owned.epub"); err != nil {
+		t.Fatalf("import the ebook: %v", err)
+	}
+	before, _ := s.books.GetByForeignID(ctx, "hc:owned-ebook")
+	if before.Status != models.BookStatusImported || before.MediaType != models.MediaTypeEbook {
+		t.Fatalf("precondition: book = %q/%q, want imported ebook", before.Status, before.MediaType)
+	}
+
+	// The complementary audiobook list now widens it to 'both'.
+	if err := s.SyncOne(ctx, audiobookList.ID); err != nil {
+		t.Fatalf("sync audiobook list: %v", err)
+	}
+
+	got, err := s.books.GetByForeignID(ctx, "hc:owned-ebook")
+	if err != nil || got == nil {
+		t.Fatalf("widened book not found: %v", err)
+	}
+	if got.MediaType != models.MediaTypeBoth {
+		t.Fatalf("mediaType = %q, want both", got.MediaType)
+	}
+	if got.AudiobookFilePath != "" {
+		t.Fatalf("audiobook path = %q, want empty: nothing imported it", got.AudiobookFilePath)
+	}
+	if got.Status != models.BookStatusWanted {
+		t.Errorf("status = %q, want wanted: the audiobook slot is monitored and empty", got.Status)
+	}
+}

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -156,6 +156,33 @@ func (b *Book) WantsAudiobook() bool {
 	return b.MediaType == MediaTypeAudiobook || b.MediaType == MediaTypeBoth
 }
 
+// ReevaluateStatus recomputes the wanted/imported boundary from the formats
+// this book still needs. Call it after anything changes MediaType, because
+// status is derived from media_type and the on-disk paths together: widening
+// an owned ebook to 'both' creates a real gap, and leaving status at
+// 'imported' hides that gap from every consumer that selects by status. The
+// wanted page, the scheduled sweep and the author bulk search all read
+// books.status and nothing else, so a stale value there means the missing
+// format is never searched (#1634).
+//
+// The book_files write path already does this inside refreshBookStatus. This
+// is the same rule for the callers that change media_type without touching
+// book_files.
+//
+// 'skipped' is left alone: it encodes a user decision, not a derived state.
+func (b *Book) ReevaluateStatus() {
+	if b.Status == BookStatusSkipped {
+		return
+	}
+	if b.NeedsEbook() || b.NeedsAudiobook() {
+		b.Status = BookStatusWanted
+		return
+	}
+	if b.EbookFilePath != "" || b.AudiobookFilePath != "" {
+		b.Status = BookStatusImported
+	}
+}
+
 // HasFileForCurrentFormat reports whether the book already holds a file for the
 // format it is currently set to, i.e. the user owns it as it stands.
 //

--- a/internal/models/book_reevaluate_status_test.go
+++ b/internal/models/book_reevaluate_status_test.go
@@ -1,0 +1,61 @@
+package models
+
+import "testing"
+
+// ReevaluateStatus is the rule the book_files write path already applies inside
+// refreshBookStatus, lifted onto the model so the callers that change MediaType
+// without touching book_files can apply it too (#1634).
+func TestBookReevaluateStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		book    Book
+		want    string
+		wantWhy string
+	}{
+		{
+			name:    "owned ebook widened to both becomes wanted",
+			book:    Book{MediaType: MediaTypeBoth, EbookFilePath: "/l/a.epub", Status: BookStatusImported},
+			want:    BookStatusWanted,
+			wantWhy: "the audiobook slot is monitored and empty",
+		},
+		{
+			name:    "both formats on disk stays imported",
+			book:    Book{MediaType: MediaTypeBoth, EbookFilePath: "/l/a.epub", AudiobookFilePath: "/l/a.m4b", Status: BookStatusImported},
+			want:    BookStatusImported,
+			wantWhy: "nothing is missing",
+		},
+		{
+			name:    "narrowed to a format already on disk becomes imported",
+			book:    Book{MediaType: MediaTypeEbook, EbookFilePath: "/l/a.epub", Status: BookStatusWanted},
+			want:    BookStatusImported,
+			wantWhy: "the declared format is satisfied",
+		},
+		{
+			name:    "skipped is a user decision and survives",
+			book:    Book{MediaType: MediaTypeBoth, EbookFilePath: "/l/a.epub", Status: BookStatusSkipped},
+			want:    BookStatusSkipped,
+			wantWhy: "skipped is never derived",
+		},
+		{
+			name:    "wanted book with no files anywhere stays wanted",
+			book:    Book{MediaType: MediaTypeEbook, Status: BookStatusWanted},
+			want:    BookStatusWanted,
+			wantWhy: "nothing is on disk",
+		},
+		{
+			name:    "imported book whose only file vanished becomes wanted",
+			book:    Book{MediaType: MediaTypeEbook, Status: BookStatusImported},
+			want:    BookStatusWanted,
+			wantWhy: "the declared format has no path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := tt.book
+			b.ReevaluateStatus()
+			if b.Status != tt.want {
+				t.Errorf("status = %q, want %q: %s", b.Status, tt.want, tt.wantWhy)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`books.status` is derived from `media_type` plus the on-disk paths. `refreshBookStatus` keeps it correct on every `book_files` write. Nothing kept it correct when `media_type` changed on its own.

So a book you already owned as an ebook, widened to `both`, keeps status `imported` while gaining a monitored format with nothing behind it. The Wanted page (`ListByStatusAndUser`), the scheduled sweep (`wantedSearchQueue`) and the author bulk search all select on status alone, so that format is never searched. The library row looks completely normal throughout.

## Correcting the issue

SturmB's original reproduction, a book created as `media_type=both` whose ebook then imports, **does not reproduce** and has not since #343. `refreshBookStatus` at `internal/db/books.go:846` leaves that book `wanted`. I ran it:

```
after ebook import: status="wanted" mediaType="both" ebook="/library/dual.epub" audio="" NeedsAudiobook=true
ListByStatus(wanted) contains the book:           true
ListByStatusAndUser(wanted, 0) contains the book: true
```

The status-only reads the issue names are real code, but they are not what strands the book, so those three call sites need no change. The compound case flagged in the issue thread is the one that reproduces:

```
step 1, ebook imported:  status="imported" mediaType="ebook"
step 2, widened to both: status="imported" NeedsAudiobook=true
RESULT in wanted set: false
```

## The fix

`reevaluateBookStatus` in `internal/api/bulk.go` was already the correct rule, wired to the four user-initiated media-type edits and to none of the automated widening sites. It moves to `models.Book.ReevaluateStatus` so packages outside `internal/api` can apply it; the api helper delegates, so its existing callers and tests are unchanged.

Two unguarded producers now call it:

- `internal/hardcoverlistsyncer/syncer.go:516` — a complementary list supplying the other format
- `internal/bookhydrate/hardcover.go:221` — edition hydration promoting an ebook for an audio-looking edition

Author refresh was the third. #2198 guarded it in v1.32.2 but shipped no repair, and #2096's reporter had 29 books widened in a single run before that. **Migration 084** repairs rows already stranded, using the same effective-path expression as `bookColumns` (stored column first, then the first `book_files` row) so a migration-028-shaped book whose file is present is not wrongly reopened. `skipped` is untouched.

## Fail-before evidence

Each by disabling only the fix under test:

| | failure |
|---|---|
| migration 084 | `widened row = "imported", want wanted` |
| bookhydrate | `status = "imported", want wanted` |
| hardcoverlistsyncer | `status = "imported", want wanted` |

The migration test also covers a complete dual-format book, a migration-028-shaped row, a skipped row, and a second run for idempotency.

## Checks

```
ok  internal/models             0.003s
ok  internal/bookhydrate        1.488s
ok  internal/hardcoverlistsyncer 4.661s
ok  internal/db                30.980s
ok  internal/api               133.492s
ok  internal/scheduler           9.492s
```

`go build ./...`, `go vet ./...` and `gofmt -l` all clean.

Closes #1634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP