### PR TITLE
fix(indexer): reject conflicting release title and author evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Clean-room Go rewrite, modern React UI, MIT-licensed, actively developed.
 
 **Search & downloads**
 - Newznab + Torznab indexers queried in parallel, deduplicated, then composite-ranked by format quality, edition tags (RETAIL / UNABRIDGED / ABRIDGED), year match, grab count, size, and ISBN exact-match bonus.
-- Smart matching — four-tier query fallback (`t=book` → `surname+title` → `author+title` → title), word-boundary keyword matching, contiguous-phrase requirement for multi-word titles, dual-author-anchor for ambiguous short titles, subtitle-aware (`Title: Subtitle`).
+- Smart matching — four-tier query fallback (`t=book` → `surname+title` → `author+title` → title), word-boundary keyword matching, ordered title words with numeric qualifiers preserved, rejection of conflicting trailing author credits, dual-author-anchor for ambiguous short titles, subtitle-aware (`Title: Subtitle`). Title-only releases remain supported.
 - SABnzbd, NZBGet, qBittorrent, Transmission, Deluge, rTorrent/ruTorrent — with **Use SSL** and **URL Base** for reverse-proxy subpaths.
 - Auto-grab sweep every 12h, immediate search on add or `wanted` flip, plus interactive per-book search and "Search all wanted" per author. Global kill-switch pauses auto-grab without losing your monitored list.
 - Quality profiles covering every format release parsing recognises (EPUB, MOBI, AZW3, PDF, plus AZW, DJVU, CBR, CBZ, FB2, LIT, RTF, TXT and the audio containers M4B, M4A, FLAC, MP3, OGG), language filter, regex-based custom formats, delay profiles, blocklist (consulted on every search; one-click add from History), and failure visibility in Queue and History.

--- a/changelog.d/release-title-identity.md
+++ b/changelog.d/release-title-identity.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Wrong-book grabs** — keep numbers and word order when matching book titles, reject extra meaningful words inserted into the title, and reject conflicting trailing author credits while retaining title-only releases.

--- a/changelog.d/release-title-identity.md
+++ b/changelog.d/release-title-identity.md
@@ -1,2 +1,2 @@
 ### Fixed
-- **Wrong-book grabs** — keep numbers and word order when matching book titles, reject extra meaningful words inserted into the title, and reject conflicting trailing author credits while retaining title-only releases.
+- **Wrong-book grabs** (#2502) — keep numbers and word order when matching book titles, reject extra meaningful words inserted into the title, and reject conflicting trailing author credits while retaining title-only releases.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -2,6 +2,21 @@
 
 Solutions to recurring problems, organised by symptom. Add new entries here as patterns come up in support.
 
+## A release names a different book or author
+
+Release matching rejects extra meaningful words inside a requested title and
+preserves its numbers: `12 More Rules for Life` cannot satisfy `12 Rules for Life`,
+even when both name the same author. An explicit trailing `by Author` or
+`Title - Author` credit that conflicts with the requested author is also rejected.
+Title-only releases, connecting words, file-format labels and narrator credits
+remain supported. Unrecognised trailing text can be conservatively rejected;
+inspect the release's title and author rather than relying only on shared words.
+
+These checks use the release name. They do not verify the contents of a download
+or repair an existing incorrect import. If a previously imported file is another
+book, use **Fix Match** to assign it to the correct book before requesting a
+replacement for the original.
+
 ## Bindery will not start after upgrading: "foreign_key_check found N violation(s)"
 
 ```

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -792,6 +792,8 @@ func filterRelevant(results []newznab.SearchResult, title, author string, aliase
 	title = stripPossessivePrefix(title, author)
 	fullKws := newznab.SigWords(title)
 	primaryKws := newznab.SigWords(primaryTitle(title))
+	fullIdentity := titleIdentityWords(title)
+	primaryIdentity := titleIdentityWords(primaryTitle(title))
 	authorKws := newznab.SigWords(author)
 
 	authorTokenSets := latinAliasTokenSets(author, aliases)
@@ -818,13 +820,20 @@ func filterRelevant(results []newznab.SearchResult, title, author string, aliase
 	filtered := make([]newznab.SearchResult, 0, len(results))
 	for i, r := range results {
 		n := normTitles[i]
+		if conflictingTitleAuthor(r.Title, title, authorTokenSets) ||
+			conflictingTitleAuthor(r.Title, primaryTitle(title), authorTokenSets) {
+			continue
+		}
+		// Only insignificant connecting words may separate title keywords.
+		// Author corroboration cannot make inserted title words disappear.
+		identity := strings.Join(titleIdentityWords(r.Title), " ")
 
 		// allowFallback=true: each result gets phrase match first, then keyword
 		// fallback if the phrase fails. No batch-level gate.
-		fullOK := tryMatch(n, fullKws)
+		fullOK := tryMatch(n, fullKws) && (len(fullIdentity) < 2 || ContainsPhrase(identity, fullIdentity))
 		primaryOK := false
 		if !fullOK && len(primaryKws) > 0 && !sameKws(primaryKws, fullKws) {
-			primaryOK = tryMatch(n, primaryKws)
+			primaryOK = tryMatch(n, primaryKws) && (len(primaryIdentity) < 2 || ContainsPhrase(identity, primaryIdentity))
 		}
 		if fullOK || primaryOK {
 			filtered = append(filtered, r)

--- a/internal/indexer/title_identity.go
+++ b/internal/indexer/title_identity.go
@@ -25,7 +25,7 @@ func conflictingTitleAuthor(release, title string, authorSets [][]string) bool {
 	normalizedTitle := NormalizeRelease(title)
 	normalizedRelease := NormalizeRelease(release)
 	var attribution string
-	if before, after, ok := strings.Cut(normalizedRelease, " by "); ok && before == normalizedTitle {
+	if after, ok := strings.CutPrefix(normalizedRelease, normalizedTitle+" by "); ok {
 		attribution = after
 	} else {
 		for _, separator := range []string{" - ", " – ", " — "} {

--- a/internal/indexer/title_identity.go
+++ b/internal/indexer/title_identity.go
@@ -1,0 +1,61 @@
+package indexer
+
+import (
+	"strings"
+
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+)
+
+// titleIdentityWords keeps numbers as well as significant words: dropping "12"
+// lets "12 More Rules for Life" satisfy "12 Rules for Life".
+func titleIdentityWords(s string) []string {
+	var words []string
+	for _, word := range strings.Fields(NormalizeRelease(s)) {
+		if isAllDigits(word) || len(newznab.SigWords(word)) != 0 {
+			words = append(words, word)
+		}
+	}
+	return words
+}
+
+// conflictingTitleAuthor recognises explicit trailing attribution only when
+// the left side names the requested title. Title-only releases remain valid;
+// release metadata and narrator credits are not treated as authors.
+func conflictingTitleAuthor(release, title string, authorSets [][]string) bool {
+	normalizedTitle := NormalizeRelease(title)
+	normalizedRelease := NormalizeRelease(release)
+	var attribution string
+	if before, after, ok := strings.Cut(normalizedRelease, " by "); ok && before == normalizedTitle {
+		attribution = after
+	} else {
+		for _, separator := range []string{" - ", " – ", " — "} {
+			before, after, ok := strings.Cut(release, separator)
+			if ok && NormalizeRelease(before) == normalizedTitle {
+				attribution = NormalizeRelease(after)
+				break
+			}
+		}
+	}
+	if attribution == "" {
+		return false
+	}
+	words := newznab.SigWords(attribution)
+	if len(words) == 0 || benignTrailingToken(words[0], nil) {
+		return false
+	}
+	knownAuthor := false
+	for _, tokens := range authorSets {
+		if len(tokens) == 0 {
+			continue
+		}
+		knownAuthor = true
+		if authorMatchesRelease(attribution, tokens) {
+			return false
+		}
+		// A surname-only credit is not evidence of a conflicting author.
+		if words[0] == tokens[len(tokens)-1] && (len(words) == 1 || benignTrailingToken(words[1], nil)) {
+			return false
+		}
+	}
+	return knownAuthor
+}

--- a/internal/indexer/title_identity_test.go
+++ b/internal/indexer/title_identity_test.go
@@ -1,0 +1,62 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+)
+
+// These releases were auto-grabbed and imported as three different books.
+func TestFilterRelevantConflictingBookIdentity(t *testing.T) {
+	cases := []struct{ title, author, release string }{
+		{"Power down", "Ben Coes", "The Power of Writing It Down by Allison Fallon EPUB"},
+		{"12 Rules for Life", "Jordan B. Peterson", "Beyond Order: 12 More Rules for Life by Jordan B. Peterson EPUB"},
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat - Edward Luttwak"},
+	}
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			got := filterRelevant([]newznab.SearchResult{{Title: c.release}}, c.title, c.author, nil)
+			if len(got) != 0 {
+				t.Fatalf("wrong release accepted: %q for %q by %s", c.release, c.title, c.author)
+			}
+		})
+	}
+}
+
+func TestFilterRelevantIdentityCompatibility(t *testing.T) {
+	cases := []struct {
+		title, author, release string
+		want                   bool
+	}{
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat - Ben Coes", true},
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat by Ben Coes EPUB", true},
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat by Coes EPUB", true},
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat EPUB", true},
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat - Unabridged MP3", true},
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat - narrated by John Doe", true},
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat — Edward Luttwak", false},
+		{"Coup d'Etat", "Ben Coes", "Coup D'Etat by Edward Luttwak EPUB", false},
+		{"Coup d'Etat", "", "Coup D'Etat - Edward Luttwak", true},
+		{"Power Down", "Ben Coes", "Power Down by Ben Coes EPUB", true},
+		{"Power Down", "Ben Coes", "Ben Coes - Power Down EPUB", true},
+		{"Power Down", "Ben Coes", "Power Down EPUB", true},
+		{"Power Down", "Ben Coes", "The Power of Writing It Down by Ben Coes EPUB", false},
+		{"12 Rules for Life", "Jordan B. Peterson", "12 Rules for Life by Jordan B. Peterson EPUB", true},
+		{"12 Rules for Life", "Jordan B. Peterson", "Jordan B Peterson - 12 Rules for Life EPUB", true},
+		{"12 Rules for Life", "Jordan B. Peterson", "12 Rules for Life EPUB", true},
+		{"12 Rules for Life: An Antidote to Chaos", "Jordan B. Peterson", "12 Rules for Life EPUB", true},
+		{"12 Rules for Life: An Antidote to Chaos", "Jordan B. Peterson", "12 More Rules for Life by Jordan B. Peterson EPUB", false},
+		{"The Lord of the Rings", "J.R.R. Tolkien", "The Lord of the Rings EPUB", true},
+		{"The Lord of the Rings", "J.R.R. Tolkien", "Lord Rings EPUB", true},
+		{"The Lord of the Rings", "J.R.R. Tolkien", "The Lord of the Rings by J. R. R. Tolkien EPUB", true},
+		{"Death by Black Hole", "Neil deGrasse Tyson", "Death by Black Hole EPUB", true},
+	}
+	for _, c := range cases {
+		t.Run(c.release, func(t *testing.T) {
+			got := filterRelevant(toResults(c.release), c.title, c.author, nil)
+			if (len(got) == 1) != c.want {
+				t.Fatalf("filterRelevant(%q, %q, %q): kept=%v, want %v", c.release, c.title, c.author, len(got) == 1, c.want)
+			}
+		})
+	}
+}

--- a/internal/indexer/title_identity_test.go
+++ b/internal/indexer/title_identity_test.go
@@ -50,6 +50,8 @@ func TestFilterRelevantIdentityCompatibility(t *testing.T) {
 		{"The Lord of the Rings", "J.R.R. Tolkien", "Lord Rings EPUB", true},
 		{"The Lord of the Rings", "J.R.R. Tolkien", "The Lord of the Rings by J. R. R. Tolkien EPUB", true},
 		{"Death by Black Hole", "Neil deGrasse Tyson", "Death by Black Hole EPUB", true},
+		{"Death by Black Hole", "Neil deGrasse Tyson", "Death by Black Hole by Neil deGrasse Tyson EPUB", true},
+		{"Death by Black Hole", "Neil deGrasse Tyson", "Death by Black Hole by Edward Luttwak EPUB", false},
 	}
 	for _, c := range cases {
 		t.Run(c.release, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Bindery can auto-grab and import a different book when a release contains the requested title's keywords or an exact title followed by a conflicting author. This PR adds two release-selection guards and regression tests for three observed wrong-book imports.

Refs #1539 and #1731. Their merged fixes are present in the affected revision; these examples remain reproducible on upstream `main` at `80ee1d286d5d3177b100020d1dd8acee5835d62c`.

## Bug and minimal reproduction

Observed in a Docker deployment at `e03640872ca02f12226fcdde7b8f14ca5b3f9b0a`. Downloaded EPUB title/author metadata confirmed each mismatch, but the files were imported under the requested book's identity.

| Requested book | Incorrect release accepted by `filterRelevant` |
| --- | --- |
| Power down — Ben Coes | `The Power of Writing It Down by Allison Fallon EPUB` |
| 12 Rules for Life — Jordan B. Peterson | `Beyond Order: 12 More Rules for Life by Jordan B. Peterson EPUB` |
| Coup d'Etat — Ben Coes | `Coup D'Etat - Edward Luttwak` |

The smallest case needs no database, indexer credentials, downloader, or book file. In an `internal/indexer` package test:

```go
got := filterRelevant(
    []newznab.SearchResult{{Title: "Coup D'Etat - Edward Luttwak"}},
    "Coup d'Etat", "Ben Coes", nil,
)
if len(got) != 0 {
    t.Fatal("accepted the same title by a different author")
}
```

Run the committed three-case regression with:

```sh
go test ./internal/indexer -run '^TestFilterRelevantConflictingBookIdentity$' -count=1
```

With only the regression test copied onto the upstream baseline, all three cases fail: one incorrect release is retained in each case. With this proposed fix, all three pass.

## Suggested fix

- Preserve numeric title tokens and require significant title words to remain contiguous after removing existing insignificant connecting words. Keyword fallback and author corroboration must not ignore meaningful words inserted inside the requested title, such as `Writing` or `More`.
- Reject a trailing `by Author` or `Title - Author` attribution when the title matches but the credit conflicts with all known author token sets. Preserve matching or surname-only credits, known release metadata, narrator labels, and releases without author attribution. Parse `by Author` after the complete requested title, so a title such as `Death by Black Hole` cannot hide a conflicting trailing author.

Compatibility tests cover legitimate title-only releases, author prefixes, initials, subtitles, connecting words, punctuation, and narrator metadata. Existing indexer tests also pass.

This is deliberately conservative: unfamiliar text after a title/dash can be rejected as a conflicting credit. The attribution guard only handles the explicit trailing layouts above; it is not a general author parser. This PR changes release selection only. Validating downloaded content before import and repairing existing incorrect imports remain separate work.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added: three observed failures and 24 compatibility cases
- [x] Deployment documentation reviewed; no environment, configuration, or upgrade-path changes
- [x] Added a changelog fragment under `changelog.d/`
- [x] Updated README and troubleshooting wiki for the matching behavior and limits

## Follow-up verification (2026-09-09)

- Reproduced an additional attribution case: `Death by Black Hole by Edward Luttwak EPUB` was retained for Neil deGrasse Tyson's title. The new rejection assertion failed before the fix and passes after it; a matching-author case also passes.
- `GOTOOLCHAIN=go1.26.6 go test ./internal/indexer/...` — pass.
- `GOTOOLCHAIN=go1.26.6 go vet ./internal/indexer/...` — pass.
- `GOTOOLCHAIN=go1.26.6 go test -race -timeout=15m ./internal/indexer/... ./internal/scheduler/...` — pass.
- Indexer tests also pass in a temporary combined tree with upstream `main` at `a0a362a`; the PR merges without conflicts. No base-branch merge was added to the PR history.
- `git diff --check` — clean.

The original PR head's upstream CI completed successfully before this follow-up. The historical checks below were run for the original implementation; full backend, frontend, lint, and vulnerability suites were not repeated for this small follow-up.

## Original implementation test plan

- [x] Baseline: all three real-world rejection assertions fail on upstream `80ee1d2`
- [x] `go test -timeout=15m ./cmd/... ./internal/...` — all backend packages pass (Go 1.27.0)
- [x] `go test -race -timeout=15m ./internal/indexer/... ./internal/scheduler/...` — pass (Go 1.27.0)
- [x] `GOTOOLCHAIN=go1.26.6 go test ./internal/indexer/...` — pass using CI's Go version
- [x] `go vet ./...` — pass
- [x] `GOTOOLCHAIN=go1.26.6 go build ./...` — pass
- [x] golangci-lint v2.11.4 with Go 1.26.6 — zero issues
- [x] Repository-pinned govulncheck with Go 1.26.6 — no reachable vulnerabilities; one unused required-module advisory reported
- [x] Changed Go files formatted; `git diff --check` clean

Full `make check`, all-package race shards, and frontend checks were not run locally; `web/` is unchanged. Upstream CI is separate from these local results.

## Hosted CI follow-up

The new-head `licenses` job failed during **Install go-licenses**, before the
license comparison: `sum.golang.org` returned an HTTP/2 `INTERNAL_ERROR` while
verifying a tool dependency. The unconditional failure-diagnostic step printed
a stale-license message, but its regeneration produced no diff stat.

Job: https://github.com/vavallee/bindery/actions/runs/34378508131/job/102557260336

A job rerun request was refused with HTTP 403 (`Must have admin rights to
Repository`). A maintainer rerun is needed; no license or workflow files were
changed for this network failure. Other new-head checks are still completing.
