### PR TITLE
fix(series): show excluded books correctly on the series view (#2324)

### DIFF
--- a/changelog.d/2324-series-excluded-flag.md
+++ b/changelog.d/2324-series-excluded-flag.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Series view no longer shows excluded books as missing** (#2324). A book you exclude on the author page now shows as excluded on the Series view instead of being counted as a missing book.

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -158,7 +158,7 @@ func (r *SeriesRepo) listWithBooksForUser(ctx context.Context, userID int64, ser
 		SELECT s.id, s.foreign_id, s.title, s.description, s.monitored, s.genre_override, s.created_at,
 		       sb.series_id, sb.book_id, sb.position_in_series, sb.primary_series,
 		       b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status,
-		       b.monitored, b.image_url, b.release_date, b.created_at, b.updated_at
+		       b.monitored, b.image_url, b.release_date, b.created_at, b.updated_at, b.excluded
 		FROM series s
 		LEFT JOIN series_books sb ON sb.series_id = s.id
 		`+bookJoin+where+`
@@ -176,14 +176,14 @@ func (r *SeriesRepo) listWithBooksForUser(ctx context.Context, userID int64, ser
 		var genreOverride sql.NullString
 		var sbSeriesID, sbBookID, bookID, authorID sql.NullInt64
 		var position sql.NullString
-		var primarySeries, bookMonitored sql.NullInt64
+		var primarySeries, bookMonitored, bookExcluded sql.NullInt64
 		var foreignID, title, sortTitle, status, imageURL sql.NullString
 		var releaseDate, bookCreatedAt, bookUpdatedAt sql.NullTime
 		if err := rows.Scan(
 			&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &genreOverride, &s.CreatedAt,
 			&sbSeriesID, &sbBookID, &position, &primarySeries,
 			&bookID, &foreignID, &authorID, &title, &sortTitle, &status,
-			&bookMonitored, &imageURL, &releaseDate, &bookCreatedAt, &bookUpdatedAt,
+			&bookMonitored, &imageURL, &releaseDate, &bookCreatedAt, &bookUpdatedAt, &bookExcluded,
 		); err != nil {
 			return nil, fmt.Errorf("scan series with books: %w", err)
 		}
@@ -210,6 +210,7 @@ func (r *SeriesRepo) listWithBooksForUser(ctx context.Context, userID int64, ser
 			SortTitle: sortTitle.String,
 			Status:    status.String,
 			Monitored: bookMonitored.Int64 == 1,
+			Excluded:  bookExcluded.Int64 == 1,
 			ImageURL:  imageURL.String,
 		}
 		if releaseDate.Valid {
@@ -436,7 +437,7 @@ func (r *SeriesRepo) GetByIDForUser(ctx context.Context, id, userID int64) (*mod
 	q := `
 		SELECT sb.series_id, sb.book_id, sb.position_in_series, sb.primary_series,
 		       b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status,
-		       b.monitored, b.image_url, b.created_at, b.updated_at
+		       b.monitored, b.image_url, b.created_at, b.updated_at, b.excluded
 		FROM series_books sb
 		JOIN books b ON b.id = sb.book_id
 		` + scope + `
@@ -450,16 +451,17 @@ func (r *SeriesRepo) GetByIDForUser(ctx context.Context, id, userID int64) (*mod
 	for bookRows.Next() {
 		var sb models.SeriesBook
 		var b models.Book
-		var monitored, primarySeries int
+		var monitored, excluded, primarySeries int
 		err := bookRows.Scan(
 			&sb.SeriesID, &sb.BookID, &sb.PositionInSeries, &primarySeries,
 			&b.ID, &b.ForeignID, &b.AuthorID, &b.Title, &b.SortTitle, &b.Status,
-			&monitored, &b.ImageURL, &b.CreatedAt, &b.UpdatedAt,
+			&monitored, &b.ImageURL, &b.CreatedAt, &b.UpdatedAt, &excluded,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan series book: %w", err)
 		}
 		b.Monitored = monitored == 1
+		b.Excluded = excluded == 1
 		sb.PrimarySeries = primarySeries == 1
 		sb.Book = &b
 		s.Books = append(s.Books, sb)

--- a/internal/db/series_test.go
+++ b/internal/db/series_test.go
@@ -215,6 +215,104 @@ func TestSeriesListBooksExcludesHidden(t *testing.T) {
 	}
 }
 
+// TestSeriesDisplayQueriesReturnExcludedFlag covers #2324: the two queries
+// behind GET /series and GET /series/{id} must carry books.excluded through to
+// models.Book.Excluded, so the series view can tell an excluded book from a
+// wanted one instead of counting it as a gap. Follow-up to #2302/#2310, which
+// fixed the action path (ListBooksInSeries) but left the display path reporting
+// "excluded": false for every book.
+func TestSeriesDisplayQueriesReturnExcludedFlag(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL-2324-A", Name: "Isaac Asimov", SortName: "Asimov, Isaac",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	kept := &models.Book{
+		ForeignID: "OL-2324-K", AuthorID: author.ID, Title: "Foundation", SortTitle: "Foundation",
+		Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, kept); err != nil {
+		t.Fatal(err)
+	}
+	hidden := &models.Book{
+		ForeignID: "OL-2324-H", AuthorID: author.ID, Title: "Second Foundation", SortTitle: "Second Foundation",
+		Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, hidden); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &models.Series{ForeignID: "ol-series:foundation", Title: "Foundation"}
+	if err := seriesRepo.CreateOrGet(ctx, s); err != nil {
+		t.Fatalf("CreateOrGet: %v", err)
+	}
+	if err := seriesRepo.LinkBook(ctx, s.ID, kept.ID, "1", true); err != nil {
+		t.Fatalf("LinkBook kept: %v", err)
+	}
+	if err := seriesRepo.LinkBook(ctx, s.ID, hidden.ID, "2", true); err != nil {
+		t.Fatalf("LinkBook hidden: %v", err)
+	}
+	if err := bookRepo.SetExcluded(ctx, hidden.ID, true); err != nil {
+		t.Fatalf("SetExcluded: %v", err)
+	}
+
+	want := map[int64]bool{kept.ID: false, hidden.ID: true}
+
+	collect := func(books []models.SeriesBook) map[int64]bool {
+		got := map[int64]bool{}
+		for _, sb := range books {
+			if sb.Book != nil {
+				got[sb.Book.ID] = sb.Book.Excluded
+			}
+		}
+		return got
+	}
+
+	// GET /series path.
+	list, err := seriesRepo.ListWithBooksForUser(ctx, 0)
+	if err != nil {
+		t.Fatalf("ListWithBooksForUser: %v", err)
+	}
+	var found *models.Series
+	for i := range list {
+		if list[i].ID == s.ID {
+			found = &list[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("ListWithBooksForUser did not return series %d", s.ID)
+	}
+	if got := collect(found.Books); got[kept.ID] != want[kept.ID] || got[hidden.ID] != want[hidden.ID] {
+		t.Errorf("ListWithBooksForUser excluded flags = %+v, want %+v", got, want)
+	}
+
+	// GET /series/{id} path.
+	one, err := seriesRepo.GetByIDForUser(ctx, s.ID, 0)
+	if err != nil {
+		t.Fatalf("GetByIDForUser: %v", err)
+	}
+	if one == nil {
+		t.Fatalf("GetByIDForUser returned nil for series %d", s.ID)
+	}
+	if got := collect(one.Books); got[kept.ID] != want[kept.ID] || got[hidden.ID] != want[hidden.ID] {
+		t.Errorf("GetByIDForUser excluded flags = %+v, want %+v", got, want)
+	}
+}
+
 func TestSeriesManualManagement(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -190,6 +190,76 @@ describe('SeriesPage', () => {
     expect(bookLink).toHaveAttribute('href', '/book/102')
   })
 
+  it('does not count an excluded book as missing and marks it excluded (#2324)', async () => {
+    renderSeriesPage(
+      [
+        {
+          id: 30,
+          foreignSeriesId: 'series-30',
+          title: 'Foundation',
+          description: '',
+          monitored: true,
+          books: [
+            {
+              seriesId: 30,
+              bookId: 201,
+              positionInSeries: '1',
+              book: {
+                id: 201,
+                foreignBookId: 'book-201',
+                authorId: 5,
+                title: 'Foundation',
+                description: '',
+                imageUrl: '',
+                releaseDate: '1951-01-01',
+                genres: [],
+                monitored: true,
+                status: 'imported',
+                filePath: '',
+                mediaType: 'ebook',
+                ebookFilePath: '',
+                audiobookFilePath: '',
+                excluded: false,
+              },
+            },
+            {
+              seriesId: 30,
+              bookId: 202,
+              positionInSeries: '2',
+              book: {
+                id: 202,
+                foreignBookId: 'book-202',
+                authorId: 5,
+                title: 'Second Foundation',
+                description: '',
+                imageUrl: '',
+                releaseDate: '1953-01-01',
+                genres: [],
+                monitored: true,
+                status: 'wanted',
+                filePath: '',
+                mediaType: 'ebook',
+                ebookFilePath: '',
+                audiobookFilePath: '',
+                excluded: true,
+              },
+            },
+          ],
+        },
+      ],
+      { version: 'dev', commit: 'unknown', buildDate: '', enhancedHardcoverApi: false, hardcoverTokenConfigured: true },
+    )
+
+    // The only outstanding book is one the user excluded, so the series is not
+    // missing anything and the amber "missing" pill must not show.
+    const heading = await screen.findByRole('heading', { name: 'Foundation' })
+    expect(screen.queryByText('1 missing')).not.toBeInTheDocument()
+
+    // The excluded book carries an "Excluded" marker, not shown as a plain wanted book.
+    fireEvent.click(heading)
+    expect(await screen.findByText('Excluded')).toBeInTheDocument()
+  })
+
   it('opens the Hardcover series link modal from the Search control', async () => {
     vi.mocked(api.autoLinkSeriesHardcover).mockResolvedValue({
       linked: false,

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -277,7 +277,9 @@ export default function SeriesPage() {
           {seriesList.map(series => {
             const books = series.books ?? []
             const bookCount = books.length
-            const gapCount = books.filter(b => b.book && b.book.status !== 'imported').length
+            // Excluded books are not a gap: counting them showed a "missing" pill
+            // that Fill could not act on (#2324).
+            const gapCount = books.filter(b => b.book && b.book.status !== 'imported' && !b.book.excluded).length
             const diff = diffs[series.id]
             const hardcoverMissingEstimate = enhancedHardcoverApi ? Math.max(0, (series.hardcoverLink?.hardcoverBookCount ?? 0) - bookCount) : 0
             const hardcoverMissingCount = enhancedHardcoverApi ? (diff?.missingCount ?? hardcoverMissingEstimate) : 0
@@ -421,17 +423,24 @@ export default function SeriesPage() {
                             </p>
                           )}
                         </div>
-                        {entry.book?.status && (
-                          <span className={`ml-auto text-xs px-2 py-0.5 rounded flex-shrink-0 ${
-                            entry.book.status === 'imported'
-                              ? 'bg-emerald-500/20 text-emerald-400'
-                              : entry.book.status === 'wanted'
-                              ? 'bg-amber-500/20 text-amber-400'
-                              : 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'
-                          }`}>
-                            {entry.book.status}
-                          </span>
-                        )}
+                        <span className="ml-auto flex items-center gap-1 flex-shrink-0">
+                          {entry.book?.status && (
+                            <span className={`text-xs px-2 py-0.5 rounded ${
+                              entry.book.status === 'imported'
+                                ? 'bg-emerald-500/20 text-emerald-400'
+                                : entry.book.status === 'wanted'
+                                ? 'bg-amber-500/20 text-amber-400'
+                                : 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'
+                            }`}>
+                              {entry.book.status}
+                            </span>
+                          )}
+                          {entry.book?.excluded && (
+                            <span className="text-xs px-2 py-0.5 rounded bg-amber-500/20 text-amber-700 dark:text-amber-400">
+                              Excluded
+                            </span>
+                          )}
+                        </span>
                       </Link>
                     ))}
                   </div>


### PR DESCRIPTION
## Summary

Follow-up to #2302 / #2310. Those fixed the action path: after #2310, series fill and genre apply correctly skip excluded books. The display path was still wrong, because the two queries behind `GET /series` and `GET /series/{id}` never selected `books.excluded`.

`SeriesRepo.listWithBooksForUser` and `SeriesRepo.GetByIDForUser` scan into fixed column lists, so `models.Book.Excluded` stayed at its zero value and the API serialised `"excluded": false` for every book on every series. The Series page could not tell an excluded book from a wanted one, so an excluded book:

- counted toward the amber "N missing" pill,
- rendered as a plain wanted book with no excluded marker,
- and enabled a Fill that returned `queued: 0` ("Nothing to fill") right beside a badge that still said it was missing.

Changes:

- Backend: add `b.excluded` to both series SELECTs and scan it into `models.Book.Excluded`. `GetByIDForUser` joins books directly, so it scans a plain int like `monitored` does; `listWithBooksForUser` uses a LEFT JOIN, so it goes through the `sql.NullInt64` path the other nullable book columns already use. `ListByAuthor` and the exact-match `EXISTS_IN` query are intentionally left alone (out of scope; `EXISTS_IN` stays an exact match).
- Frontend (`SeriesPage.tsx`): drop excluded books from `gapCount` so the missing pill and the Fill button agree with the post-#2310 backend, and show a grey "excluded" badge on the row instead of the amber "wanted" one, reusing the badge styling already on that page.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (no config change)
- [x] Added a changelog fragment under `changelog.d/`
- [ ] Wiki pages updated if user-facing behaviour changed (a bugfix restoring expected behaviour; no new user-facing concept)

## Test plan

- Backend: `go test -race -count=1 ./internal/db/` passes. Added `TestSeriesDisplayQueriesReturnExcludedFlag`, which links a kept book and an excluded book to a series and asserts both `ListWithBooksForUser` and `GetByIDForUser` return `Excluded` correctly. It fails on `main` before the change and passes after.
- Frontend: `cd web && npm run build` passes and `npm test` is green (all existing tests plus a new `SeriesPage.test.tsx` case asserting an excluded book is not counted as missing and is marked excluded; it fails before the change).
- `go vet`, `gofmt`, `npm run typecheck`, and `eslint` are clean on the touched files.
