### PR TITLE
chore(release): correct the v1.35.0 entry and pull request counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 **Search and author identity, largely rebuilt. Read the two warnings below before upgrading.**
 
-Forty one entries from twenty one merged pull requests, and most of them are one
-piece of work. Bindery had four separate ideas about what makes two pieces of
+Forty three entries from twenty three merged pull requests, and most of them are
+one piece of work. Bindery had four separate ideas about what makes two pieces of
 text the same, and they disagreed with each other. Library search folded only the 26 ASCII
 letters, so `muller` never found *Müller*. There are now three alphabets, one
 each for search, identity and comparison, and the differences between them are


### PR DESCRIPTION
The v1.35.0 preamble opens with a count of what is in the section. It was written before #2489 and #2491 were folded in, so it reads "Forty one entries from twenty one merged pull requests" against an actual 43 entries.

Counted from the section on `main` at 80ee1d28: 1 Added, 11 Changed, 29 Fixed, 1 Removed, 1 Security.

The pull request figure goes 21 to 23 on the same arithmetic. #2488 also merged into this range but shipped no changelog fragment, so it adds no entry and is not counted.

Text only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP