### PR TITLE
fix: three defects found reviewing the release before tagging

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1033,6 +1033,14 @@ func (s *Scanner) failDownloadThatNeverArrived(
 	if !sourceListIsComplete || seenSourceIDs[dl.ID] {
 		return
 	}
+	// No recorded source id means absence from the client's list proves
+	// nothing: every poller skips such a row before it reaches seenSourceIDs,
+	// so it is unseen because it was never looked up, not because it is
+	// missing. qBittorrent backfills the hash from a listing match; Deluge and
+	// rTorrent simply continue. Failing on that would kill a healthy download.
+	if dl.TorrentID == nil && dl.SABnzbdNzoID == nil {
+		return
+	}
 	since := dl.AddedAt
 	if dl.GrabbedAt != nil {
 		since = *dl.GrabbedAt

--- a/internal/importer/scanner_never_arrived_test.go
+++ b/internal/importer/scanner_never_arrived_test.go
@@ -116,3 +116,38 @@ func TestNeverArrived_LeavesARecentGrabAlone(t *testing.T) {
 		t.Errorf("status = %q, want %q: a grab inside the grace period was failed early", got.Status, models.StateDownloading)
 	}
 }
+
+// A download with no recorded source id is unseen because no poller looked it
+// up, not because the client is missing it. Deluge and rTorrent skip such a row
+// before seenSourceIDs, and qBittorrent backfills the hash from a listing
+// match, so failing on absence here would kill a healthy download.
+func TestNeverArrived_LeavesADownloadWithNoRecordedHashAlone(t *testing.T) {
+	s, dlRepo, database, client, ctx := newNeverArrivedFixture(t)
+
+	dl := &models.Download{
+		GUID:             "guid-2505-nohash",
+		Title:            "a book whose hash was never recorded",
+		NZBURL:           "magnet:?xt=urn:btih:whatever",
+		Status:           models.StateDownloading,
+		Protocol:         "torrent",
+		DownloadClientID: &client.ID,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatalf("create download: %v", err)
+	}
+	if _, err := database.ExecContext(ctx, "UPDATE downloads SET added_at=? WHERE id=?",
+		time.Now().Add(-2*neverArrivedGrace).UTC(), dl.ID); err != nil {
+		t.Fatalf("back-date: %v", err)
+	}
+
+	s.checkQbittorrentDownloads(ctx, client)
+
+	got, err := dlRepo.GetByID(ctx, dl.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Status != models.StateDownloading {
+		t.Errorf("status = %q, want %q: a download with no recorded hash was failed on absence it was never checked for",
+			got.Status, models.StateDownloading)
+	}
+}

--- a/internal/metadata/hardcover/series.go
+++ b/internal/metadata/hardcover/series.go
@@ -16,6 +16,13 @@ const seriesIDPrefix = "hc-series:"
 
 // seriesCatalogQuery fetches a series and the books filed under it.
 //
+// The compilation filter is written as an _or with _is_null rather than a bare
+// _eq: false, because in Hasura an _eq never matches a null. A book whose
+// compilation column is unset would otherwise drop out of every series catalog
+// silently, which is a worse failure than the one this filter is here to fix.
+// Same reasoning as canonical_id above it and authorContributionFilter in
+// client.go.
+//
 // Omnibus editions are excluded here rather than filtered after the fact:
 // Hardcover files a box set under the position of the first book it contains,
 // so "Harry Potter Collection #1-6", "Harry Potter Boxed Set" and "The Harry
@@ -39,7 +46,10 @@ const seriesCatalogQuery = `query GetBooksBySeries($seriesId: Int!) {
 				where: {
 					book: {
 						canonical_id: {_is_null: true}
-						compilation: {_eq: false}
+						_or: [
+							{compilation: {_eq: false}}
+							{compilation: {_is_null: true}}
+						]
 					}
 				}
 			) {

--- a/internal/metadata/hardcover/series_positions_test.go
+++ b/internal/metadata/hardcover/series_positions_test.go
@@ -91,8 +91,11 @@ func TestCollapseSeriesPositionsPreservesOrder(t *testing.T) {
 // them under the position of the first book they contain and there is no way
 // to tell one from a volume once it has arrived.
 func TestSeriesCatalogQueryExcludesCompilations(t *testing.T) {
-	if !strings.Contains(seriesCatalogQuery, "compilation: {_eq: false}") {
+	if !strings.Contains(seriesCatalogQuery, "{compilation: {_eq: false}}") {
 		t.Error("GetBooksBySeries no longer excludes compilations")
+	}
+	if !strings.Contains(seriesCatalogQuery, "{compilation: {_is_null: true}}") {
+		t.Error("the compilation filter dropped its null arm: an _eq never matches a null in Hasura, so a book with the column unset would vanish from every series catalog")
 	}
 	if !strings.Contains(seriesCatalogQuery, "users_count: desc_nulls_last") {
 		t.Error("GetBooksBySeries no longer orders competing entries by reader count")

--- a/internal/textutil/author.go
+++ b/internal/textutil/author.go
@@ -51,12 +51,20 @@ func NormalizeAuthorName(name string) string {
 			}
 			b.WriteRune(unicode.ToLower(r))
 			spacePending = false
-		case unicode.Is(unicode.Mn, r):
-			// A mark stripLatinGreekMarks chose to keep, so it belongs to a
-			// script where the mark is part of the letter. It joins the word
-			// rather than breaking it, which is what the default arm would do.
+		case unicode.Is(unicode.Mn, r) && !spacePending && b.Len() > 0:
+			// A mark stripLatinGreekMarks chose to keep, sitting directly on
+			// the letter just written, so it belongs to a script where the mark
+			// is part of that letter. It joins the word rather than breaking
+			// it, which is what the default arm would do.
 			b.WriteRune(r)
-			spacePending = false
+		case unicode.Is(unicode.Mn, r):
+			// The same kind of mark, but floating: it follows a separator or
+			// opens the string, so there is no letter for it to belong to.
+			// Writing it here would swallow the pending boundary and glue two
+			// name tokens into one ("Tanaka ゙Suzuki" keyed as one word), which
+			// is the opposite of what #2452 is for. Dropped, and the boundary
+			// is kept.
+			continue
 		default:
 			spacePending = true
 		}

--- a/internal/textutil/author_test.go
+++ b/internal/textutil/author_test.go
@@ -212,3 +212,31 @@ func TestNormalizeAuthorName_StillFoldsLatinAndGreek(t *testing.T) {
 		}
 	}
 }
+
+// A mark that follows a separator has no letter to belong to. Attaching it
+// anyway swallowed the boundary and glued two name tokens into one key, which
+// is the opposite of what #2452 is for.
+func TestNormalizeAuthorName_FloatingMarkKeepsTheWordBoundary(t *testing.T) {
+	cases := map[string]string{
+		"Tanaka ゙Suzuki": "tanaka suzuki",
+		"abc ́def":       "abc def",
+		"Ono ́ Yoko":     "ono yoko",
+		"゙abc":           "abc",
+	}
+	for in, want := range cases {
+		if got := NormalizeAuthorName(in); got != want {
+			t.Errorf("NormalizeAuthorName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The mark still attaches when it sits on the letter before it, which is the
+// whole point of the change: ズ must not key as ス.
+func TestNormalizeAuthorName_AttachedMarkStillCounts(t *testing.T) {
+	if NormalizeAuthorName("ズ") == NormalizeAuthorName("ス") {
+		t.Error("ズ and ス share one identity key again")
+	}
+	if got, want := NormalizeAuthorName("ハード"), "ハード"; got != want {
+		t.Errorf("NormalizeAuthorName(ハード) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Found doing a read-through of everything merged today before pushing the v1.35.0 tag. All three are in code that landed today, two of them mine.

## 1. `NormalizeAuthorName` lost a word boundary

#2452 gave the `Mn` arm a `WriteRune` so a kept mark joins its word rather than falling through to the separator arm. A mark that *follows a separator* has no letter to join, and took the pending boundary with it:

```
"Tanaka ゙Suzuki"  ->  "tanaka゙suzuki"     (previously "tanaka suzuki")
"abc ́def"         ->  "abćdef"
```

Two name tokens merging into one identity key is the same class of failure #2452 exists to fix, just in the other direction. The mark now attaches only when it sits directly on a letter already written; floating, it is dropped and the boundary stands. ズ still does not key as ス.

## 2. `failDownloadThatNeverArrived` could fail a healthy download

From #2505. It reads absence from `seenSourceIDs` as "the client does not have this", but every poller skips a row with no recorded source id *before* it reaches that map: `checkDelugeDownloads` and `checkRtorrentDownloads` `continue` on `dl.TorrentID == nil`, and qBittorrent's no-hash branch does the same once the listing match fails. Such a row is unseen because nothing looked it up, not because it is missing, and it would have been failed after ten minutes.

Now left alone unless it carries a torrent hash or an nzo id. Fail before:

```
--- FAIL: TestNeverArrived_LeavesADownloadWithNoRecordedHashAlone
    status = "failed", want "downloading": a download with no recorded hash was
    failed on absence it was never checked for
```

## 3. The Hardcover compilation filter could drop books

From #2497. `compilation: {_eq: false}` never matches a null in Hasura, so any book with that column unset would vanish from every series catalog.

I raised exactly this on the PR and approved it anyway, on the strength of the live API check. That was the wrong call for something going straight into a public release: the live check covers the series that were looked at, not the column's nullability. Written as an `_or` with `_is_null` it behaves identically when the column is non-null and cannot drop a row when it is, which is what `canonical_id` directly above it and `authorContributionFilter` in `client.go` already do.

@totza2010 for visibility, this is a one line change on top of your PR, not a problem with the fix itself.

## Tests

Green: `internal/textutil`, `internal/normdrift`, `internal/metadata/hardcover`, `internal/importer`, `internal/api`, `internal/db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP