### PR TITLE
fix(series): fill matches a book held under another provider's id (#2524)

### DIFF
--- a/changelog.d/2524-fill-alternate-ids.md
+++ b/changelog.d/2524-fill-alternate-ids.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Series fill no longer re-adds a book you already have under another provider's id** (#2524) — filling gaps matched a catalogue entry against a book's primary identifier only, so a work already in the library under, say, its OpenLibrary identity was treated as missing and queued for download again. It now also checks the alternate identifiers Bindery records for each book, which is what catches translations and foreign editions where the titles do not match either. Thanks magrhino for the report.

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -1571,7 +1571,11 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *
 	if book.ForeignID == "" {
 		book.ForeignID = "hc:" + catalogBook.ProviderID
 	}
-	if existing, err := h.books.GetByForeignID(ctx, book.ForeignID); err != nil {
+	// GetByAnyForeignID, not GetByForeignID: a book the library already holds
+	// under a different provider's id carries that id in book_identifiers
+	// (#1705), and matching only the primary column made Fill create a second
+	// row for the same work and queue it for download. Raised in #2524.
+	if existing, err := h.books.GetByAnyForeignID(ctx, book.ForeignID); err != nil {
 		return nil, err
 	} else if existing != nil {
 		if existing.Excluded {

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -2044,6 +2044,97 @@ func TestSeriesFillSkipsExcludedHardcoverForeignIDMatch(t *testing.T) {
 	}
 }
 
+// TestSeriesFillMatchesASavedAlternateForeignID covers the identity half of
+// #2524: a book the library already holds under a different provider's id
+// carries that id in book_identifiers (#1705). Fill matched only the primary
+// foreign_id column, so the same work came back as a second row and got queued
+// for download.
+func TestSeriesFillMatchesASavedAlternateForeignID(t *testing.T) {
+	catalog := stormlightCatalog()
+	searcher := newMockBookSearcher()
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	ctx := context.Background()
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "hc:brandon-sanderson",
+		Name:             "Brandon Sanderson",
+		SortName:         "Sanderson, Brandon",
+		MetadataProvider: "hardcover",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	// The library holds the book under its OpenLibrary identity, with the
+	// Hardcover id recorded as an alternate. The stored title is the German
+	// edition's, so the title-similarity fallback cannot rescue this: the
+	// saved identifier is the only thing that says these are one work, which
+	// is the case #2524 is about.
+	book := &models.Book{
+		ForeignID:        "ol:OL1W",
+		AuthorID:         author.ID,
+		Title:            "Der Weg der Koenige",
+		SortTitle:        "Weg der Koenige, Der",
+		Status:           models.BookStatusImported,
+		Genres:           []string{},
+		MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.UpsertBookIdentifier(ctx, book.ID, "hc:the-way-of-kings"); err != nil {
+		t.Fatal(err)
+	}
+
+	body := bytes.NewBufferString(`{"foreignBookId":"hc:the-way-of-kings","providerId":"101","position":"1"}`)
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", body), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response["queued"] != 0 {
+		t.Fatalf("an already-held book must not be queued, got %+v", response)
+	}
+	searcher.assertNoCall(t, 50*time.Millisecond)
+
+	// Exactly one book row, and it is the one already in the library, now
+	// linked into the series.
+	all, err := bookRepo.ListByAuthorIncludingExcluded(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 || all[0].ID != book.ID {
+		t.Fatalf("expected the existing row to be reused, got %+v", all)
+	}
+	linked, err := seriesRepo.ListBooksInSeries(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(linked) != 1 || linked[0].ID != book.ID {
+		t.Fatalf("expected the existing book linked into the series, got %+v", linked)
+	}
+}
+
 func TestSeriesFillSkipsExcludedHardcoverTitleMatch(t *testing.T) {
 	catalog := stormlightCatalog()
 	catalog.Books[0].ForeignID = "hc:the-way-of-kings-new"


### PR DESCRIPTION
Addresses the one concrete defect in #2524. **Stacked on #2528**, which is stacked on #2526. Merge in that order.

## What was wrong

`fillHardcoverCatalogBook` (`internal/api/series.go:1574`) resolved an existing book with `h.books.GetByForeignID`, which reads only the `books.foreign_id` column. A book the library already holds under a different provider's identity carries the catalogue's id in `book_identifiers` (#1705), and `GetByAnyForeignID` (`internal/db/book_identifiers.go:45`) exists to see exactly that. Matching only the primary column meant Fill treated the work as missing, created a second row and queued it for download.

magrhino raised this in #2524 from source inspection. It reproduces.

The title-similarity fallback further down (`:1627`) masked it whenever the two rows happened to share a title, which is why it went unnoticed. It does not help the case that actually matters: a translation or a foreign edition, where the saved identifier is the only evidence the two are one work.

## What changed

One call swapped to `GetByAnyForeignID`.

## Verification

`TestSeriesFillMatchesASavedAlternateForeignID`: the library holds "Der Weg der Koenige" under `ol:OL1W` with `hc:the-way-of-kings` recorded as an alternate identifier, and Fill is asked for `hc:the-way-of-kings`. The differing title is deliberate, so the title-similarity fallback cannot rescue it and the identifier is the only thing under test.

Fail-before, with `GetByForeignID` restored:

```
series_test.go:2116: an already-held book must not be queued, got map[queued:1]
```

Green: `go build ./...`, `go test ./internal/api/`, `golangci-lint run ./internal/api/...`.

## What this does not do

#2524 also proposes a work-identity check shared by series catalogue comparison, series fill and scheduled series discovery. That is a larger design question, its third consumer does not exist yet, and the issue is candid that its findings are source inspection rather than a reproduced duplicate download. I would want one real reproduction of a duplicate before building the shared abstraction, so I have left the issue open with only this piece taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
