### PR TITLE
fix(web): stop the series toggle promising checks nothing performs

### DIFF
--- a/changelog.d/series-monitor-honest-label.md
+++ b/changelog.d/series-monitor-honest-label.md
@@ -1,0 +1,2 @@
+### Changed
+- **The series monitor toggle now says what it actually does** (#2523) — it was labelled "Monitor series" and "Monitored", which reads as a promise that Bindery watches the series and adds new books as they appear. Nothing did that: the flag was stored, shown back, and read by nothing else, and Fill gaps ignored it. It is now "Add to shortlist" and "Shortlisted", with a tooltip saying Bindery does not yet check a shortlisted series on its own. The control and everything it stores are unchanged, so nothing you have set is lost. Real series tracking is #2523.

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -95,6 +95,29 @@ describe('SeriesPage', () => {
     expect(api.getSeriesHardcoverDiff).not.toHaveBeenCalled()
   })
 
+  it('does not promise automatic checks the code never runs', async () => {
+    // series.monitored is written by this toggle and read back for display,
+    // and nothing else consumes it: no scheduled job checks a series for new
+    // books and Fill gaps ignores the flag. The label used to say "Monitor
+    // series" / "Monitored", which is what led to #2523. It must not claim
+    // recurring attention until something actually schedules it.
+    renderSeriesPage([{
+      id: 13,
+      foreignSeriesId: 'series-13',
+      title: 'Mistborn',
+      description: '',
+      monitored: true,
+      books: [],
+    }])
+
+    await screen.findByRole('heading', { name: 'Mistborn' })
+    expect(screen.getByText('Shortlisted')).toBeInTheDocument()
+    expect(screen.queryByText('Monitored')).toBeNull()
+    expect(screen.queryByRole('switch', { name: /monitor/i })).toBeNull()
+    const toggle = screen.getByRole('switch', { name: /shortlist/i })
+    expect(toggle).toHaveAttribute('title', expect.stringContaining('does not yet check'))
+  })
+
   it('offers a genre override before a series has books', async () => {
     vi.mocked(api.applySeriesGenres).mockResolvedValue({ updated: 0 })
     const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Fantasy, Epic')

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -319,12 +319,19 @@ export default function SeriesPage() {
 
                 {/* Actions row */}
                 <div className="px-4 pb-3 flex items-center gap-3 flex-wrap" onClick={e => e.stopPropagation()}>
+                  {/* This flag is a shortlist marker, not a schedule. Nothing
+                      reads series.monitored except this page: no job checks a
+                      monitored series for new books, and Fill gaps ignores it.
+                      Labelling it "Monitor series" promised recurring attention
+                      the code never gave, which is what #2523 was filed about.
+                      The control stays, the wording no longer overstates it. */}
                   <Switch
                     checked={series.monitored}
                     onChange={() => toggleMonitor(series)}
-                    label={series.monitored ? 'Stop monitoring' : 'Monitor series'}
+                    label={series.monitored ? 'Remove from shortlist' : 'Add to shortlist'}
+                    title="Marks the series so you can find it again. Bindery does not yet check a shortlisted series for new books on its own; use Fill gaps."
                   >
-                    {series.monitored ? 'Monitored' : 'Not monitored'}
+                    {series.monitored ? 'Shortlisted' : 'Not shortlisted'}
                   </Switch>
                   {enhancedHardcoverApi && (
                     <button


### PR DESCRIPTION
Independent of the #2525 stack; branches off `main` and touches only `web/`.

## What was wrong

`series.monitored` is written by `PATCH /series/{id}` (`internal/api/series.go:460`) and read back for display. Nothing else consumes it. I grepped every reader: no scheduled job looks at a monitored series, `Fill` ignores the flag, and the only series monitoring that gates anything is the per-author pin from #810 (`ListMonitoredSeriesIDs`, consumed at `internal/api/authors.go:2025` during author refresh), which is a different column in a different table.

The series page nevertheless rendered it as "Monitor series" and "Monitored" (`web/src/pages/SeriesPage.tsx:322-327`). That reads as a promise that Bindery watches the series and adds new books as they are announced. magrhino filed #2523 asking for exactly that, having reasonably concluded from the label that it already worked and was broken.

This is the repo's own "no silent no-ops" rule, one step removed: the control is not a no-op, it stores what you set, but what it stores does nothing and the wording says otherwise.

## What changed

Label only. "Add to shortlist" / "Shortlisted", plus a tooltip saying Bindery does not yet check a shortlisted series on its own and pointing at Fill gaps.

The control stays, the endpoint stays, the stored value is untouched. Nothing anyone has already set is lost, and #2523 can give the flag real meaning later without a migration.

## Why relabel rather than build the feature

Wiring the toggle to something real is most of #2523: a scheduled job, provider catalogue checks, an "upcoming" concept, and the duplicate-resolution work in #2524 underneath it. That is worth doing and it is not a week. A toggle that lies is worse in the meantime than one that is honestly narrow, so this ships now and the feature is sequenced separately.

If you would rather keep the word "monitored" and qualify it instead, say so and I will change the strings; the shape of the change is the same either way.

## Verification

`SeriesPage.test.tsx` gains "does not promise automatic checks the code never runs", asserting the new label renders, that no control matching /monitor/i survives, and that the tooltip carries the caveat.

Green: `npm run typecheck`, `npm run lint` (0 errors), `npm test` (842 tests), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
