### PR TITLE
fix(series): keep box sets out of the Hardcover missing list (#2524)

### DIFF
--- a/changelog.d/2524-diff-bundle-prune.md
+++ b/changelog.d/2524-diff-bundle-prune.md
@@ -1,0 +1,2 @@
+### Fixed
+- **A linked series no longer counts box sets among its missing books** (#2524) — the Hardcover comparison listed every catalogue entry the library did not already hold, including the box sets and collection sets that adding a book refuses outright. The Add button beside them did nothing, and they kept the missing count above zero on a series that was actually complete. The comparison now applies the same rule the add path does. Thanks magrhino for running a real catalogue against it.

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -1297,6 +1297,14 @@ func buildHardcoverDiff(ctx context.Context, books *db.BookRepo, userID int64, s
 		if _, ok := matchedCatalog[i]; ok {
 			continue
 		}
+		// The same unconditional bundle prune the add path applies (#2239).
+		// Without it the diff offered an Add button on a box set that
+		// fillHardcoverCatalogBook then silently refused, and counted it in
+		// "N missing" so a complete series never read as complete. Reported
+		// by magrhino in #2524 against a real Stormlight catalogue.
+		if title := firstNonEmpty(book.Book.Title, book.Title); metadata.IsUnambiguousBundleTitle(title) {
+			continue
+		}
 		item := catalogDiffBook(book, catalog.AuthorName)
 		enrichMissingDiffBook(ctx, books, userID, book, &item)
 		diff.Missing = append(diff.Missing, item)

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -1189,6 +1189,82 @@ func TestBuildHardcoverDiffEnrichesMissingWithOwnedLibraryBook(t *testing.T) {
 	}
 }
 
+// TestSeriesHardcoverDiffPrunesBundleTitles covers the display half of #2524:
+// the diff listed every unclaimed catalogue entry as missing, including the
+// box sets that fillHardcoverCatalogBook refuses (#2239). The result was an
+// Add button that silently did nothing and a "N missing" count a complete
+// series could never clear.
+func TestSeriesHardcoverDiffPrunesBundleTitles(t *testing.T) {
+	catalog := stormlightCatalog()
+	catalog.Books = append(catalog.Books,
+		metadata.SeriesCatalogBook{
+			ForeignID:  "hc:stormlight-box-set",
+			ProviderID: "900",
+			Title:      "The Stormlight Archive 3 Books Collection Set",
+			Position:   "",
+			Book: models.Book{
+				ForeignID: "hc:stormlight-box-set",
+				Title:     "The Stormlight Archive 3 Books Collection Set",
+				Author:    catalog.Books[0].Book.Author,
+			},
+		},
+		metadata.SeriesCatalogBook{
+			ForeignID:  "hc:oathbringer",
+			ProviderID: "103",
+			Title:      "Oathbringer",
+			Position:   "3",
+			Book: models.Book{
+				ForeignID: "hc:oathbringer",
+				Title:     "Oathbringer",
+				Author:    catalog.Books[0].Book.Author,
+			},
+		},
+	)
+	catalog.BookCount = len(catalog.Books)
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, nil)
+	ctx := context.Background()
+	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.HardcoverDiff(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/1/hardcover-diff", nil), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got seriesHardcoverDiffResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range got.Missing {
+		if item.ForeignBookID == "hc:stormlight-box-set" {
+			t.Fatalf("the box set the add path refuses must not be offered as missing: %+v", got.Missing)
+		}
+	}
+	if got.MissingCount != len(got.Missing) {
+		t.Fatalf("missingCount %d disagrees with the list length %d", got.MissingCount, len(got.Missing))
+	}
+	// The real books are untouched.
+	if len(got.Missing) != 2 {
+		t.Fatalf("missing = %+v, want The Way of Kings and Oathbringer", got.Missing)
+	}
+}
+
 func TestSeriesHardcoverDiffEndpointErrors(t *testing.T) {
 	catalog := stormlightCatalog()
 	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{


### PR DESCRIPTION
Second piece of #2524, from magrhino's catalogue run against the #2530 build. **Stacked on #2530.**

## What was wrong

`buildHardcoverDiff` (`internal/api/series.go:1236-1243`) listed every unclaimed catalogue entry as missing, with no filtering at all. `fillHardcoverCatalogBook` (`:1504`) prunes unambiguous bundle titles before adding anything, per #2239 and #1780.

So the two layers disagreed. The diff offered an Add button on a box set, the add path refused it and returned `queued: 0`, and the entry stayed in the missing count permanently. A series the user actually holds in full could never read as complete.

## What changed

The same `metadata.IsUnambiguousBundleTitle` call moves into the diff loop. One keyword list, two call sites, same answer.

## Verification

Fail-before, with the prune removed, `TestSeriesHardcoverDiffPrunesBundleTitles` reports "The Stormlight Archive 3 Books Collection Set" among the missing entries. The test also pins that `missingCount` agrees with the list length and that the real books are untouched.

Green: `go test ./internal/api/`, `golangci-lint run ./internal/api/...`.

## What this does not fix

magrhino's stronger case is split editions: "The Way of Kings, Part 1" and "Part 2" alongside a held "The Way of Kings". I checked both bundle tiers against his exact titles and neither matches any of them:

```
"The Way of Kings, Part 1"                                unambiguous=false full=false
"The Way of Kings, Part 2"                                unambiguous=false full=false
"Words of Radiance, Part 1"                               unambiguous=false full=false
"The Great Hunt, Part 2 of 2: New Threads in the Pattern" unambiguous=false full=false
"The Dragon Reborn, Part 2 of 2"                          unambiguous=false full=false
"The Stormlight Archive 3 Books Collection Set"           unambiguous=true  full=true
```

`SkipPartBooks` is named for exactly the shape it does not detect: it is a bundle detector (`internal/metadata/bundle_titles.go`), matching box sets, omnibuses and "Books N-M", not "Title, Part 1". That naming is its own trap and worth fixing separately.

A split edition is the inverse of a bundle: several catalogue rows that together make one work, rather than one row covering several. It needs its own rule and its own decision, and magrhino's own Wheel of Time example shows why it cannot just be a prune, because that catalogue *is* the split editions and pruning them would empty the series. Left for #2524 to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
