### PR TITLE
feat(importer): write an opt-in metadata.opf sidecar per book

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Clean-room Go rewrite, modern React UI, MIT-licensed, actively developed.
 - Calibre integration in three modes: `calibredb` CLI hook on import, [Bindery Bridge plugin](https://github.com/vavallee/bindery-plugins) (cross-container), or direct read of an existing Calibre library's `metadata.db` as Bindery's catalogue.
 - **Audiobookshelf import** — pull an existing ABS server's book libraries in as Bindery's catalogue (metadata-first, dry-run, review queue for ambiguous matches, rollback), with an ABS library-scan trigger after every audiobook import. See [docs/ABS-Import-Wiki.md](docs/ABS-Import-Wiki.md).
 - **Grimmory push** (preview) — imported ebooks are sent to a self-hosted [Grimmory](https://grimmory.org) library via its BookDrop inbox, with a bulk **Push all** for existing files.
+- **`metadata.opf` sidecar** (opt-in) — write a Calibre-style `metadata.opf` next to each imported book, carrying Bindery's own canonical title/author/series/identifiers/etc. so a library app that reads sidecar metadata sees consistent data regardless of which source the file came from. Refreshed on Reorganize.
 
 **Metadata sources** — all stable, documented, public APIs. No Goodreads scraping.
 

--- a/changelog.d/opf-sidecar-metadata.md
+++ b/changelog.d/opf-sidecar-metadata.md
@@ -1,0 +1,2 @@
+### Added
+- **Optional `metadata.opf` sidecar per book** — when `import.write_opf_sidecar` is enabled (off by default), Bindery writes a Calibre-style `metadata.opf` next to each imported ebook/audiobook, carrying Bindery's own canonical title, author, series, identifiers, language, publisher, narrator, description, and genres — regardless of what the downloaded file's own embedded tags say. Refreshed by Reorganize too, so a later author rename or metadata edit doesn't leave it stale. Never touches the book file itself, only adds this extra file alongside it.

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -886,6 +886,12 @@ func removeBookPathScoped(p, format string, ownedByOther func(string) bool) erro
 		}
 	}
 
+	// A book file's metadata.opf sidecar (import.write_opf_sidecar) is not a
+	// book file itself, so it survives the sweep above and would otherwise
+	// strand this folder the same way it used to strand a Reorganize move —
+	// reclaim it first so the empty check below actually sees empty.
+	importer.RemoveOrphanedSidecar(parent)
+
 	// Clean up parent directory if it is now empty.
 	remaining, err := os.ReadDir(parent)
 	if err == nil && len(remaining) == 0 {

--- a/internal/api/path_safety_test.go
+++ b/internal/api/path_safety_test.go
@@ -345,6 +345,34 @@ func TestSafeRemoveBookPath_OwnershipErrorFailsSafe(t *testing.T) {
 	}
 }
 
+// TestSafeRemoveBookPath_ReclaimsFolderWithOrphanedSidecar regression-tests a
+// PR review finding: import.write_opf_sidecar's metadata.opf is not a book
+// file, so it survived the old empty-folder check in removeBookPathScoped
+// and stranded every book's folder on delete, holding nothing but a stale
+// sidecar. removeBookPathScoped now reclaims an orphaned sidecar the same
+// way Reorganize already did (RemoveOrphanedSidecar), before checking empty.
+func TestSafeRemoveBookPath_ReclaimsFolderWithOrphanedSidecar(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "Book")
+	ebook := mustWrite(t, filepath.Join(dir, "Book.epub"))
+	if err := os.WriteFile(filepath.Join(dir, "metadata.opf"), []byte("<package/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skipped, err := safeRemoveBookPath(context.Background(), nil, stubOwner{}, 1, ebook, "ebook")
+	if err != nil {
+		t.Fatalf("safeRemoveBookPath: %v", err)
+	}
+	if skipped {
+		t.Fatal("expected the delete to proceed, not be skipped")
+	}
+	if exists(ebook) {
+		t.Error("ebook file should have been removed")
+	}
+	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+		t.Errorf("book folder should be gone once only the sidecar was left behind, stat err = %v", statErr)
+	}
+}
+
 // TestSafeRemoveBookPath_SiblingOwnedByAnotherBook is the file branch of the
 // same guard: the same-stem sweep must not take a sibling another book tracks.
 func TestSafeRemoveBookPath_SiblingOwnedByAnotherBook(t *testing.T) {

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -131,6 +131,15 @@ const (
 	// never-arriving second format would wedge the first forever. The importer
 	// reads this key as a string literal; keep the literal in sync.
 	SettingImportDropPairGatingTimeoutHours = "import.drop_pair_gating_timeout_hours"
+	// SettingImportWriteOPFSidecar opts imports (and Reorganize moves) into
+	// writing a Calibre-style metadata.opf sidecar next to each book, using
+	// Bindery's own canonical DB metadata rather than whatever the source
+	// file happened to carry. "true" enables it; unset/"false" (default)
+	// keeps the prior behaviour — Bindery only ever renames files, it never
+	// writes a new one into the library. The importer reads this key as a
+	// string literal to avoid an import cycle; keep the literal in sync with
+	// this constant.
+	SettingImportWriteOPFSidecar = "import.write_opf_sidecar"
 )
 
 // SettingLibraryLastScan is the KV key holding the JSON summary of the most
@@ -673,6 +682,13 @@ func validateSettingValue(key, value string) error {
 			return nil
 		}
 		return fmt.Errorf("import.drop_pair_gating %q is not one of: true, false", value)
+	case SettingImportWriteOPFSidecar:
+		// Boolean flag; empty or "false" = off (default). Only accept the two
+		// canonical values so a typo can't be silently misread as truthy.
+		if value == "" || value == "true" || value == "false" {
+			return nil
+		}
+		return fmt.Errorf("import.write_opf_sidecar %q is not one of: true, false", value)
 	case SettingImportDropPairGatingTimeoutHours:
 		// Empty falls back to the 72h default; a non-empty value must be a
 		// positive integer number of hours so a typo fails loudly here rather

--- a/internal/api/settings_registry.go
+++ b/internal/api/settings_registry.go
@@ -236,6 +236,11 @@ var settingDescriptors = []SettingDescriptor{
 		State:       SettingStateActive,
 	},
 	{
+		Key: SettingImportWriteOPFSidecar, Type: SettingTypeBool, Default: "false",
+		Description: "Write a Calibre style metadata.opf next to each imported book (and refresh it on Reorganize), carrying Bindery's own canonical metadata regardless of what the source file's embedded tags say.",
+		State:       SettingStateActive,
+	},
+	{
 		Key: "naming.bookTemplate", Type: SettingTypeString, Default: "",
 		Description: "Path template for imported ebooks. Empty uses the built in default.",
 		State:       SettingStateActive,

--- a/internal/api/settings_registry_test.go
+++ b/internal/api/settings_registry_test.go
@@ -357,6 +357,11 @@ func TestValidateSettingValue_KnownKeysUnchanged(t *testing.T) {
 		{"plugin url rejects a missing host", SettingCalibrePluginURL, "https://", true},
 		{"plugin url rejects cloud metadata", SettingCalibrePluginURL, "http://169.254.169.254/latest/meta-data", true},
 
+		{"opf sidecar accepts true", SettingImportWriteOPFSidecar, "true", false},
+		{"opf sidecar accepts false", SettingImportWriteOPFSidecar, "false", false},
+		{"opf sidecar accepts empty", SettingImportWriteOPFSidecar, "", false},
+		{"opf sidecar rejects other", SettingImportWriteOPFSidecar, "yes", true},
+
 		{"abs enabled accepts false", SettingABSEnabled, "false", false},
 		{"abs enabled accepts empty", SettingABSEnabled, "", false},
 		{"abs enabled rejects other", SettingABSEnabled, "on", true},

--- a/internal/api/settings_registry_test.go
+++ b/internal/api/settings_registry_test.go
@@ -431,6 +431,7 @@ var webSettingKeys = []string{
 	"import.drop_layout",
 	"import.drop_link_mode",
 	"import.mode",
+	"import.write_opf_sidecar",
 	"library.defaultRootFolderId",
 	"log.retention_days",
 	"metadata.primary_provider",

--- a/internal/importer/opfsidecar.go
+++ b/internal/importer/opfsidecar.go
@@ -69,10 +69,73 @@ func WriteOPFSidecarFile(dir string, book *models.Book, author *models.Author, e
 		return fmt.Errorf("opfsidecar: create dir %q: %w", dir, err)
 	}
 	dest := filepath.Join(dir, opfSidecarFileName)
-	if err := os.WriteFile(dest, xmlBytes, 0o644); err != nil {
-		return fmt.Errorf("opfsidecar: write %q: %w", dest, err)
+	// Staged write, not os.WriteFile: WriteFile truncates first, so a crash
+	// (or an unlucky reader) mid-write leaves a zero-length or half-written
+	// metadata.opf, which is strictly worse than no sidecar — a library app
+	// parses it as a corrupt book instead of falling back to the filename.
+	// This is also the overwrite path (Reorganize rewrites an existing
+	// sidecar), so the truncate window is not a one-off. Same temp+rename
+	// shape as calibre.MaterializeCover; the rename is atomic because the temp
+	// file is created in the destination directory.
+	tmp, err := os.CreateTemp(dir, ".metadata.opf-*")
+	if err != nil {
+		return fmt.Errorf("opfsidecar: create temp in %q: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(xmlBytes); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("opfsidecar: write %q: %w", tmpName, err)
+	}
+	// CreateTemp makes the file 0600; the sidecar wants the same 0644 the
+	// library files it sits beside get, so it is readable by whatever reads
+	// the book itself.
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("opfsidecar: chmod %q: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("opfsidecar: close %q: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, dest); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("opfsidecar: rename into %q: %w", dest, err)
 	}
 	return nil
+}
+
+// removeOrphanedSidecar deletes a metadata.opf left alone in oldDir after the
+// book file it described moved out (Reorganize). Without it a reorganize that
+// renames a book's folder strands the old folder permanently: the sidecar
+// keeps the folder non-empty, so pruneEmptyParents' os.Remove fails with
+// ENOTEMPTY, and the library accumulates one orphan folder per rename, each
+// holding an out-of-date copy of a book's metadata that a sidecar-reading
+// library app will happily index as a real book.
+//
+// Deliberately NOT gated on import.write_opf_sidecar: turning the setting off
+// does not retract the sidecars already on disk, and those strand folders just
+// the same. The guard is instead that the sidecar must be the SOLE remaining
+// entry. A folder still holding another format of the book — or anything else
+// at all — is left completely alone, sidecar included; a folder holding
+// nothing but a metadata.opf is one pruneEmptyParents was going to reclaim
+// anyway. Best-effort: a failure only leaves the folder behind, which is
+// exactly the prior behaviour.
+func removeOrphanedSidecar(oldDir, newDir string) {
+	if oldDir == "" || filepath.Clean(oldDir) == filepath.Clean(newDir) {
+		return
+	}
+	entries, err := os.ReadDir(oldDir)
+	if err != nil || len(entries) != 1 {
+		return
+	}
+	if entries[0].IsDir() || entries[0].Name() != opfSidecarFileName {
+		return
+	}
+	if err := os.Remove(filepath.Join(oldDir, opfSidecarFileName)); err != nil {
+		slog.Warn("opf sidecar: failed to remove the orphaned sidecar left by a move", "dir", oldDir, "error", err)
+	}
 }
 
 // BuildOPFXML renders book/author/edition metadata as a Calibre-style OPF

--- a/internal/importer/opfsidecar.go
+++ b/internal/importer/opfsidecar.go
@@ -1,0 +1,229 @@
+package importer
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/calibre"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// opfSidecarFileName is the Calibre convention this mirrors: one
+// metadata.opf per book folder. Unambiguous because Bindery gives every
+// book its own folder — multiple files of the SAME book (formats of one
+// edition, or a merged ebook+audiobook pair) can share a folder, but two
+// different books never do (see DestPath/AudiobookDestDir).
+const opfSidecarFileName = "metadata.opf"
+
+// opfSidecarEnabled reports whether the opt-in "write a metadata.opf
+// sidecar" feature is on (import.write_opf_sidecar). Off by default: unlike
+// renaming, this is the first time Bindery writes a *new* file into a
+// library folder rather than just moving/renaming the download, so it opts
+// in rather than opting out. Read as a string literal to avoid an import
+// cycle with the api package; keep in sync with
+// api.SettingImportWriteOPFSidecar.
+func (s *Scanner) opfSidecarEnabled(ctx context.Context) bool {
+	if s.settings == nil {
+		return false
+	}
+	setting, err := s.settings.Get(ctx, "import.write_opf_sidecar")
+	if err != nil || setting == nil {
+		return false
+	}
+	return setting.Value == "true"
+}
+
+// writeOPFSidecar writes (or overwrites) metadata.opf in dir when the
+// setting is on. Best-effort, mirroring pushToCWA/pushToCalibre: a sidecar
+// failure is logged and swallowed rather than failing an otherwise-good
+// import or reorganize move. dir is the book's folder — the caller passes
+// filepath.Dir(destPath) for a single ebook file or the audiobook
+// destination directory directly.
+func (s *Scanner) writeOPFSidecar(ctx context.Context, dir string, book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum string) {
+	if !s.opfSidecarEnabled(ctx) || book == nil || dir == "" {
+		return
+	}
+	if err := WriteOPFSidecarFile(dir, book, author, edition, seriesTitle, seriesNum); err != nil {
+		slog.Warn("opf sidecar: write failed, continuing", "bookID", book.ID, "dir", dir, "error", err)
+		return
+	}
+	slog.Info("opf sidecar: metadata.opf written", "bookID", book.ID, "dir", dir)
+}
+
+// WriteOPFSidecarFile renders book/author/edition metadata as a
+// Calibre-style OPF package document and writes it to
+// filepath.Join(dir, "metadata.opf"), creating dir if needed.
+func WriteOPFSidecarFile(dir string, book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum string) error {
+	xmlBytes, err := BuildOPFXML(book, author, edition, seriesTitle, seriesNum)
+	if err != nil {
+		return fmt.Errorf("opfsidecar: build xml: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("opfsidecar: create dir %q: %w", dir, err)
+	}
+	dest := filepath.Join(dir, opfSidecarFileName)
+	if err := os.WriteFile(dest, xmlBytes, 0o644); err != nil {
+		return fmt.Errorf("opfsidecar: write %q: %w", dest, err)
+	}
+	return nil
+}
+
+// BuildOPFXML renders book/author/edition metadata as a Calibre-style OPF
+// package document (the same "content.opf" schema an EPUB carries inside
+// its own zip, minus the file-manifest/spine sections that only make sense
+// for an actual archive — see ReadEpubMetadata's read-side counterpart).
+//
+// Deliberately built by hand rather than via encoding/xml struct tags:
+// namespaced attributes (opf:role, opf:file-as, opf:scheme) are awkward to
+// get byte-stable through Go's XML marshaller, and parseOPFMetadata already
+// established that this codebase treats OPF as "walk/write the tokens
+// directly" rather than "bind a fixed struct" for exactly that reason.
+//
+// Reuses the same field-resolution helpers as the Calibre push integration
+// (calibre.IdentifiersForBook, calibre.NormalizeLanguageForCalibre,
+// calibre.FormatPublishedDate) so a book's metadata.opf and its
+// calibredb-pushed metadata never disagree. One deliberate divergence:
+// Book.AverageRating is left out of calibre:rating here, unlike
+// calibreMetadata. Calibre's rating field is a personal 1-5 star rating;
+// AverageRating is a public/aggregate score pulled from a provider, and
+// writing it under a tag readers expect to mean "your rating" would be
+// misleading. The Calibre push integration made the opposite call for its
+// own (pre-existing, out of scope here) reasons — this does not change that.
+//
+// No cover reference is written: Bindery never places a cover image file in
+// the library folder (covers are proxied/cached separately), so there is
+// nothing on disk for a <meta name="cover"> to point at.
+func BuildOPFXML(book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum string) ([]byte, error) {
+	if book == nil {
+		return nil, fmt.Errorf("opfsidecar: nil book")
+	}
+
+	var uniqueID string
+	var meta bytes.Buffer
+
+	fmt.Fprintf(&meta, "    <dc:title>%s</dc:title>\n", opfEscape(book.Title))
+	if strings.TrimSpace(book.SortTitle) != "" {
+		fmt.Fprintf(&meta, "    <meta name=\"calibre:title_sort\" content=%s/>\n", opfAttr(book.SortTitle))
+	}
+
+	if author != nil && strings.TrimSpace(author.Name) != "" {
+		if fileAs := strings.TrimSpace(author.SortName); fileAs != "" {
+			fmt.Fprintf(&meta, "    <dc:creator opf:role=\"aut\" opf:file-as=%s>%s</dc:creator>\n", opfAttr(fileAs), opfEscape(author.Name))
+		} else {
+			fmt.Fprintf(&meta, "    <dc:creator opf:role=\"aut\">%s</dc:creator>\n", opfEscape(author.Name))
+		}
+	}
+
+	if narrator := strings.TrimSpace(book.Narrator); narrator != "" {
+		fmt.Fprintf(&meta, "    <dc:contributor opf:role=\"nrt\">%s</dc:contributor>\n", opfEscape(narrator))
+	}
+
+	identifiers := calibre.IdentifiersForBook(book, edition)
+	keys := make([]string, 0, len(identifiers))
+	for k := range identifiers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		scheme := opfIdentifierScheme(k)
+		if k == "bindery" {
+			uniqueID = "bindery-id"
+			fmt.Fprintf(&meta, "    <dc:identifier id=%s opf:scheme=%s>%s</dc:identifier>\n", opfAttr(uniqueID), opfAttr(scheme), opfEscape(identifiers[k]))
+			continue
+		}
+		fmt.Fprintf(&meta, "    <dc:identifier opf:scheme=%s>%s</dc:identifier>\n", opfAttr(scheme), opfEscape(identifiers[k]))
+	}
+
+	language := book.Language
+	if edition != nil && strings.TrimSpace(edition.Language) != "" {
+		language = edition.Language
+	}
+	if language = calibre.NormalizeLanguageForCalibre(language); language != "" {
+		fmt.Fprintf(&meta, "    <dc:language>%s</dc:language>\n", opfEscape(language))
+	}
+
+	if edition != nil && strings.TrimSpace(edition.Publisher) != "" {
+		fmt.Fprintf(&meta, "    <dc:publisher>%s</dc:publisher>\n", opfEscape(edition.Publisher))
+	}
+
+	date := ""
+	if edition != nil && edition.PublishDate != nil {
+		date = calibre.FormatPublishedDate(edition.PublishDate)
+	} else if book.ReleaseDate != nil {
+		date = calibre.FormatPublishedDate(book.ReleaseDate)
+	}
+	if date != "" {
+		fmt.Fprintf(&meta, "    <dc:date>%s</dc:date>\n", opfEscape(date))
+	}
+
+	if strings.TrimSpace(book.Description) != "" {
+		fmt.Fprintf(&meta, "    <dc:description>%s</dc:description>\n", opfEscape(book.Description))
+	}
+
+	for _, genre := range book.Genres {
+		if strings.TrimSpace(genre) == "" {
+			continue
+		}
+		fmt.Fprintf(&meta, "    <dc:subject>%s</dc:subject>\n", opfEscape(genre))
+	}
+
+	if strings.TrimSpace(seriesTitle) != "" {
+		fmt.Fprintf(&meta, "    <meta name=\"calibre:series\" content=%s/>\n", opfAttr(seriesTitle))
+		if strings.TrimSpace(seriesNum) != "" {
+			fmt.Fprintf(&meta, "    <meta name=\"calibre:series_index\" content=%s/>\n", opfAttr(seriesNum))
+		}
+	}
+
+	var doc bytes.Buffer
+	doc.WriteString(`<?xml version="1.0" encoding="utf-8"?>` + "\n")
+	if uniqueID != "" {
+		fmt.Fprintf(&doc, "<package xmlns=\"http://www.idpf.org/2007/opf\" unique-identifier=%s version=\"2.0\">\n", opfAttr(uniqueID))
+	} else {
+		doc.WriteString("<package xmlns=\"http://www.idpf.org/2007/opf\" version=\"2.0\">\n")
+	}
+	doc.WriteString("  <metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:opf=\"http://www.idpf.org/2007/opf\">\n")
+	doc.Write(meta.Bytes())
+	doc.WriteString("  </metadata>\n")
+	doc.WriteString("</package>\n")
+	return doc.Bytes(), nil
+}
+
+// opfIdentifierScheme maps a calibre.IdentifiersForBook key to the
+// opf:scheme value real Calibre metadata.opf files use for it, falling back
+// to an uppercased form of the key (underscores to hyphens, matching
+// Calibre's own multi-word scheme style like "MOBI-ASIN") for anything not
+// specifically known.
+func opfIdentifierScheme(key string) string {
+	switch key {
+	case "bindery":
+		return "BINDERY"
+	case "isbn":
+		return "ISBN"
+	case "asin":
+		return "MOBI-ASIN"
+	default:
+		return strings.ToUpper(strings.ReplaceAll(key, "_", "-"))
+	}
+}
+
+// opfEscape XML-escapes text content (dc:title, dc:description, …).
+func opfEscape(s string) string {
+	var buf bytes.Buffer
+	// xml.EscapeText cannot fail on a bytes.Buffer target.
+	_ = xml.EscapeText(&buf, []byte(s))
+	return buf.String()
+}
+
+// opfAttr renders s as a double-quoted, escaped XML attribute value
+// (including the quotes), so callers can drop it straight after "=" without
+// juggling quote characters themselves.
+func opfAttr(s string) string {
+	return "\"" + opfEscape(s) + "\""
+}

--- a/internal/importer/opfsidecar.go
+++ b/internal/importer/opfsidecar.go
@@ -157,15 +157,28 @@ func removeOrphanedSidecar(oldDir, newDir string) {
 	if oldDir == "" || filepath.Clean(oldDir) == filepath.Clean(newDir) {
 		return
 	}
-	entries, err := os.ReadDir(oldDir)
+	RemoveOrphanedSidecar(oldDir)
+}
+
+// RemoveOrphanedSidecar deletes metadata.opf from dir when it is the SOLE
+// remaining entry there, so a caller that just removed a book's last file
+// (a plain delete, not only Reorganize's move) can reclaim the folder
+// afterward instead of stranding it holding nothing but a stale sidecar — the
+// same failure shape as removeOrphanedSidecar's move case, reached from
+// internal/api/books.go's delete paths instead. A folder still holding
+// another format of the book, or anything else at all, is left completely
+// alone, sidecar included. Best-effort: a failure only leaves the folder
+// behind, which is no worse than before this existed.
+func RemoveOrphanedSidecar(dir string) {
+	entries, err := os.ReadDir(dir)
 	if err != nil || len(entries) != 1 {
 		return
 	}
 	if entries[0].IsDir() || entries[0].Name() != opfSidecarFileName {
 		return
 	}
-	if err := os.Remove(filepath.Join(oldDir, opfSidecarFileName)); err != nil {
-		slog.Warn("opf sidecar: failed to remove the orphaned sidecar left by a move", "dir", oldDir, "error", err)
+	if err := os.Remove(filepath.Join(dir, opfSidecarFileName)); err != nil {
+		slog.Warn("opf sidecar: failed to remove the orphaned sidecar", "dir", dir, "error", err)
 	}
 }
 

--- a/internal/importer/opfsidecar.go
+++ b/internal/importer/opfsidecar.go
@@ -45,22 +45,53 @@ func (s *Scanner) opfSidecarEnabled(ctx context.Context) bool {
 // failure is logged and swallowed rather than failing an otherwise-good
 // import or reorganize move. dir is the book's folder — the caller passes
 // filepath.Dir(destPath) for a single ebook file or the audiobook
-// destination directory directly.
-func (s *Scanner) writeOPFSidecar(ctx context.Context, dir string, book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum string) {
+// destination directory directly. roots is the set of configured library
+// roots dir must resolve inside (see dirWithinRoots) — every caller already
+// derives dir from Renamer.DestPath/AudiobookDestDir, which sanitize and
+// contain it before this is ever reached, but this function does not trust
+// that: it re-verifies independently rather than assuming every future
+// caller gets that right.
+func (s *Scanner) writeOPFSidecar(ctx context.Context, dir string, roots []string, book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum string) {
 	if !s.opfSidecarEnabled(ctx) || book == nil || dir == "" {
 		return
 	}
-	if err := WriteOPFSidecarFile(dir, book, author, edition, seriesTitle, seriesNum); err != nil {
+	if err := WriteOPFSidecarFile(dir, roots, book, author, edition, seriesTitle, seriesNum); err != nil {
 		slog.Warn("opf sidecar: write failed, continuing", "bookID", book.ID, "dir", dir, "error", err)
 		return
 	}
 	slog.Info("opf sidecar: metadata.opf written", "bookID", book.ID, "dir", dir)
 }
 
+// dirWithinRoots reports whether dir resolves inside at least one of roots,
+// reusing ensureContained's same prefix-after-Clean check that
+// Renamer.DestPath/AudiobookDestDir already apply. WriteOPFSidecarFile calls
+// this itself, independent of any sanitization its caller already did, so a
+// book/author string sourced from remote provider metadata can never steer
+// a library-folder-derived path outside the configured roots — this is the
+// direct guard for what a path-injection static analysis (rightly) cannot
+// verify by tracing through the renamer's own containment check several
+// calls upstream.
+func dirWithinRoots(dir string, roots []string) bool {
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		if _, err := ensureContained(dir, root); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // WriteOPFSidecarFile renders book/author/edition metadata as a
 // Calibre-style OPF package document and writes it to
-// filepath.Join(dir, "metadata.opf"), creating dir if needed.
-func WriteOPFSidecarFile(dir string, book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum string) error {
+// filepath.Join(dir, "metadata.opf"), creating dir if needed. roots is the
+// set of acceptable library roots dir must resolve inside (see
+// dirWithinRoots); a dir outside every root is refused rather than written.
+func WriteOPFSidecarFile(dir string, roots []string, book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum string) error {
+	if !dirWithinRoots(dir, roots) {
+		return fmt.Errorf("opfsidecar: refusing to write outside configured library roots: %q", dir)
+	}
 	xmlBytes, err := BuildOPFXML(book, author, edition, seriesTitle, seriesNum)
 	if err != nil {
 		return fmt.Errorf("opfsidecar: build xml: %w", err)

--- a/internal/importer/opfsidecar_test.go
+++ b/internal/importer/opfsidecar_test.go
@@ -262,4 +262,176 @@ func TestWriteOPFSidecarFile(t *testing.T) {
 	if p.Metadata.Title != book.Title {
 		t.Errorf("after overwrite, title = %q, want %q", p.Metadata.Title, book.Title)
 	}
+
+	// The write stages through a temp file and renames; neither the first
+	// write nor the overwrite may leave that temp file behind. A stray one
+	// would sit in the library folder forever and, worse, keep the folder
+	// non-empty so Reorganize's pruneEmptyParents could never reclaim it.
+	entries, err := os.ReadDir(bookDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "metadata.opf" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("book folder holds %v, want just [metadata.opf]", names)
+	}
+}
+
+// TestBuildOPFXML_EscapesEveryInterpolatedField widens the escaping guard past
+// title and author. Every value below arrives from provider metadata or a user
+// edit and can carry XML metacharacters, so each interpolation site is checked
+// on its own rather than trusting that one escaped field means the rest are —
+// a single unescaped "&" anywhere makes the whole document unparseable, taking
+// the correctly-escaped fields down with it.
+func TestBuildOPFXML_EscapesEveryInterpolatedField(t *testing.T) {
+	isbn13 := "9780345472199"
+	book := &models.Book{
+		ID:          5,
+		Title:       `Cats & Dogs <vol 1> "revised" 'ed'`,
+		SortTitle:   `Cats & Dogs, "revised"`,
+		Description: "Chapter 1 & <b>2</b>\nA \"quoted\" line — with ünïcode 😀 and an apostrophe's worth of trouble",
+		Genres:      []string{`Sci-Fi & Fantasy`, `<Horror>`, `"Literary"`},
+		Narrator:    `Reader & "Co"`,
+		Language:    "eng",
+	}
+	author := &models.Author{Name: `Ann & <Bob>`, SortName: `Bob, "Ann" & Co`}
+	edition := &models.Edition{Publisher: `Smith & <Sons> "Ltd"`, ISBN13: &isbn13}
+
+	xmlBytes, err := BuildOPFXML(book, author, edition, `Saga & <One> "Two"`, `1 & 2`)
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	p := parseOPFProbe(t, xmlBytes)
+
+	for _, tc := range []struct{ field, got, want string }{
+		{"title", p.Metadata.Title, book.Title},
+		{"creator", p.Metadata.Creator, author.Name},
+		{"contributor", p.Metadata.Contributor, book.Narrator},
+		{"publisher", p.Metadata.Publisher, edition.Publisher},
+		{"description", p.Metadata.Description, book.Description},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s round-tripped as %q, want %q", tc.field, tc.got, tc.want)
+		}
+	}
+	if len(p.Metadata.Subjects) != len(book.Genres) {
+		t.Fatalf("subjects = %v, want %d entries", p.Metadata.Subjects, len(book.Genres))
+	}
+	for i, want := range book.Genres {
+		if p.Metadata.Subjects[i] != want {
+			t.Errorf("subject[%d] = %q, want %q", i, p.Metadata.Subjects[i], want)
+		}
+	}
+	// Attribute sites (opf:file-as, calibre:*) escape separately from element
+	// text, so they get their own assertions.
+	for _, tc := range []struct{ name, want string }{
+		{"calibre:title_sort", book.SortTitle},
+		{"calibre:series", `Saga & <One> "Two"`},
+		{"calibre:series_index", `1 & 2`},
+	} {
+		got, ok := metaContent(p, tc.name)
+		if !ok || got != tc.want {
+			t.Errorf("%s = %q (found=%v), want %q", tc.name, got, ok, tc.want)
+		}
+	}
+	if len(p.Metadata.Identifiers) == 0 {
+		t.Error("expected at least the bindery identifier")
+	}
+}
+
+// Provider metadata occasionally carries raw control bytes or invalid UTF-8,
+// which are not representable in XML at all. They must be sanitised into a
+// still-parseable document rather than producing a file no reader can open.
+func TestBuildOPFXML_SanitisesUnrepresentableCharacters(t *testing.T) {
+	book := &models.Book{
+		ID:          9,
+		Title:       "Bad\x00Title\x08Here",
+		Description: "invalid utf-8: \xff\xfe tail",
+	}
+	xmlBytes, err := BuildOPFXML(book, nil, nil, "", "")
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	p := parseOPFProbe(t, xmlBytes)
+	if !strings.Contains(p.Metadata.Title, "Title") || !strings.Contains(p.Metadata.Title, "Here") {
+		t.Errorf("title lost its printable content: %q", p.Metadata.Title)
+	}
+	if strings.ContainsAny(string(xmlBytes), "\x00\x08") {
+		t.Error("raw control characters must not reach the file")
+	}
+}
+
+// A nil author, nil edition, nil dates, an empty description and an empty
+// genre must all be skipped rather than emitting an empty element a reader
+// would take as "this book has no title/publisher/date" data.
+func TestBuildOPFXML_SkipsEmptyFieldsEntirely(t *testing.T) {
+	book := &models.Book{
+		ID:          11,
+		Title:       "Only A Title",
+		SortTitle:   "   ",
+		Description: "  \n ",
+		Genres:      []string{"", "   ", "Fantasy"},
+		Narrator:    " ",
+		Language:    "",
+	}
+	author := &models.Author{Name: "   "}
+	edition := &models.Edition{Publisher: " ", Language: "  "}
+
+	xmlBytes, err := BuildOPFXML(book, author, edition, "  ", "3")
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	out := string(xmlBytes)
+	for _, tag := range []string{"dc:creator", "dc:contributor", "dc:publisher", "dc:date", "dc:description", "dc:language", "calibre:title_sort", "calibre:series", "calibre:series_index"} {
+		if strings.Contains(out, tag) {
+			t.Errorf("blank field still emitted %s:\n%s", tag, out)
+		}
+	}
+	p := parseOPFProbe(t, xmlBytes)
+	if len(p.Metadata.Subjects) != 1 || p.Metadata.Subjects[0] != "Fantasy" {
+		t.Errorf("subjects = %v, want only the non-blank genre", p.Metadata.Subjects)
+	}
+}
+
+// The edition wins over the book for language, publisher and date — the same
+// precedence calibreMetadata applies, which is the whole point of sharing the
+// calibre.* helpers. A divergence here means a book's sidecar and its
+// calibredb-pushed metadata disagree.
+func TestBuildOPFXML_EditionOverridesBookFields(t *testing.T) {
+	book, author, edition := fullBookFixture()
+	book.Language = "spa"
+	edition.Language = "fre"
+
+	p := parseOPFProbe(t, mustBuildOPF(t, book, author, edition))
+	if p.Metadata.Language != "fr" {
+		t.Errorf("language = %q, want the edition's normalized %q", p.Metadata.Language, "fr")
+	}
+	if p.Metadata.Date != "2021-06-01" {
+		t.Errorf("date = %q, want the edition's publish date", p.Metadata.Date)
+	}
+
+	// With no edition date, the book's release date is the fallback.
+	edition.PublishDate = nil
+	p = parseOPFProbe(t, mustBuildOPF(t, book, author, edition))
+	if p.Metadata.Date != "2020-03-15" {
+		t.Errorf("date = %q, want the book's release date fallback", p.Metadata.Date)
+	}
+
+	// With neither, no dc:date at all rather than an empty one.
+	book.ReleaseDate = nil
+	if out := string(mustBuildOPF(t, book, author, edition)); strings.Contains(out, "dc:date") {
+		t.Errorf("no date anywhere must emit no dc:date:\n%s", out)
+	}
+}
+
+func mustBuildOPF(t *testing.T, book *models.Book, author *models.Author, edition *models.Edition) []byte {
+	t.Helper()
+	out, err := BuildOPFXML(book, author, edition, "", "")
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	return out
 }

--- a/internal/importer/opfsidecar_test.go
+++ b/internal/importer/opfsidecar_test.go
@@ -1,0 +1,265 @@
+package importer
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// opfProbe is a namespace-agnostic parse-back of the fields BuildOPFXML
+// writes, mirroring the style parseOPFMetadata uses to read a real EPUB's
+// embedded OPF (epubmeta.go) — proving the output is not just
+// string-shaped but genuinely well-formed, parseable XML.
+type opfProbe struct {
+	XMLName  xml.Name `xml:"package"`
+	UniqueID string   `xml:"unique-identifier,attr"`
+	Metadata struct {
+		Title       string   `xml:"title"`
+		Creator     string   `xml:"creator"`
+		Contributor string   `xml:"contributor"`
+		Language    string   `xml:"language"`
+		Publisher   string   `xml:"publisher"`
+		Date        string   `xml:"date"`
+		Description string   `xml:"description"`
+		Subjects    []string `xml:"subject"`
+		Identifiers []struct {
+			ID     string `xml:"id,attr"`
+			Scheme string `xml:"scheme,attr"`
+			Value  string `xml:",chardata"`
+		} `xml:"identifier"`
+		Meta []struct {
+			Name    string `xml:"name,attr"`
+			Content string `xml:"content,attr"`
+		} `xml:"meta"`
+	} `xml:"metadata"`
+}
+
+func parseOPFProbe(t *testing.T, xmlBytes []byte) opfProbe {
+	t.Helper()
+	var p opfProbe
+	if err := xml.Unmarshal(xmlBytes, &p); err != nil {
+		t.Fatalf("BuildOPFXML output did not parse as XML: %v\n---\n%s", err, xmlBytes)
+	}
+	return p
+}
+
+func metaContent(p opfProbe, name string) (string, bool) {
+	for _, m := range p.Metadata.Meta {
+		if m.Name == name {
+			return m.Content, true
+		}
+	}
+	return "", false
+}
+
+func fullBookFixture() (*models.Book, *models.Author, *models.Edition) {
+	release := time.Date(2020, 3, 15, 0, 0, 0, 0, time.UTC)
+	pub := time.Date(2021, 6, 1, 0, 0, 0, 0, time.UTC)
+	isbn13 := "9780345472199"
+	book := &models.Book{
+		ID:               42,
+		Title:            "The Way of Kings",
+		SortTitle:        "Way of Kings, The",
+		Description:      "A stormlight epic.",
+		Genres:           []string{"Fantasy", "Epic"},
+		ReleaseDate:      &release,
+		Language:         "eng",
+		Narrator:         "Michael Kramer",
+		ASIN:             "B0031RS9YE",
+		ForeignID:        "12345",
+		MetadataProvider: "hardcover",
+		AverageRating:    4.7,
+		RatingsCount:     9001,
+	}
+	author := &models.Author{
+		Name:     "Brandon Sanderson",
+		SortName: "Sanderson, Brandon",
+	}
+	edition := &models.Edition{
+		BookID:      42,
+		ISBN13:      &isbn13,
+		Publisher:   "Tor Books",
+		PublishDate: &pub,
+		Language:    "eng",
+	}
+	return book, author, edition
+}
+
+func TestBuildOPFXML_FullFields(t *testing.T) {
+	book, author, edition := fullBookFixture()
+
+	xmlBytes, err := BuildOPFXML(book, author, edition, "The Stormlight Archive", "1")
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	p := parseOPFProbe(t, xmlBytes)
+
+	if p.Metadata.Title != book.Title {
+		t.Errorf("title = %q, want %q", p.Metadata.Title, book.Title)
+	}
+	if p.Metadata.Creator != author.Name {
+		t.Errorf("creator = %q, want %q", p.Metadata.Creator, author.Name)
+	}
+	if p.Metadata.Contributor != book.Narrator {
+		t.Errorf("contributor (narrator) = %q, want %q", p.Metadata.Contributor, book.Narrator)
+	}
+	if p.Metadata.Language != "en" {
+		t.Errorf("language = %q, want normalized %q", p.Metadata.Language, "en")
+	}
+	if p.Metadata.Publisher != "Tor Books" {
+		t.Errorf("publisher = %q, want %q", p.Metadata.Publisher, "Tor Books")
+	}
+	if p.Metadata.Date != "2021-06-01" {
+		t.Errorf("date = %q, want edition.PublishDate %q", p.Metadata.Date, "2021-06-01")
+	}
+	if p.Metadata.Description != book.Description {
+		t.Errorf("description = %q, want %q", p.Metadata.Description, book.Description)
+	}
+	if len(p.Metadata.Subjects) != 2 || p.Metadata.Subjects[0] != "Fantasy" || p.Metadata.Subjects[1] != "Epic" {
+		t.Errorf("subjects = %v, want [Fantasy Epic]", p.Metadata.Subjects)
+	}
+	if series, ok := metaContent(p, "calibre:series"); !ok || series != "The Stormlight Archive" {
+		t.Errorf("calibre:series = %q (found=%v), want %q", series, ok, "The Stormlight Archive")
+	}
+	if idx, ok := metaContent(p, "calibre:series_index"); !ok || idx != "1" {
+		t.Errorf("calibre:series_index = %q (found=%v), want %q", idx, ok, "1")
+	}
+	if sortTitle, ok := metaContent(p, "calibre:title_sort"); !ok || sortTitle != book.SortTitle {
+		t.Errorf("calibre:title_sort = %q (found=%v), want %q", sortTitle, ok, book.SortTitle)
+	}
+
+	// Identifiers: bindery id is the unique-identifier target; ISBN and ASIN
+	// use their special-cased Calibre scheme names.
+	found := map[string]struct{ scheme, id string }{}
+	for _, ident := range p.Metadata.Identifiers {
+		found[ident.Value] = struct{ scheme, id string }{ident.Scheme, ident.ID}
+	}
+	if got := found["42"]; got.scheme != "BINDERY" || got.id != "bindery-id" {
+		t.Errorf("bindery identifier = %+v, want scheme BINDERY id bindery-id", got)
+	}
+	if p.UniqueID != "bindery-id" {
+		t.Errorf("package unique-identifier = %q, want %q", p.UniqueID, "bindery-id")
+	}
+	if got := found["9780345472199"]; got.scheme != "ISBN" {
+		t.Errorf("isbn identifier scheme = %q, want ISBN", got.scheme)
+	}
+	if got := found["B0031RS9YE"]; got.scheme != "MOBI-ASIN" {
+		t.Errorf("asin identifier scheme = %q, want MOBI-ASIN", got.scheme)
+	}
+}
+
+// TestBuildOPFXML_ExcludesRatings is the field-scope assertion this feature
+// hinges on: docs/third-party-data.md draws the exact same line for
+// commercial-use compliance ("Title, author, series, edition, publisher,
+// narrator, description, and cover are facts and are fine" vs.
+// "average_rating and ratings_count ... [s]trip them"). The sidecar must
+// never carry AverageRating/RatingsCount so a deployment that already
+// excludes them from the API/UI per that doc doesn't have them leak back
+// out through this file instead.
+func TestBuildOPFXML_ExcludesRatings(t *testing.T) {
+	book, author, edition := fullBookFixture()
+	xmlBytes, err := BuildOPFXML(book, author, edition, "", "")
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	out := string(xmlBytes)
+	for _, needle := range []string{"4.7", "9001", "rating"} {
+		if strings.Contains(strings.ToLower(out), strings.ToLower(needle)) {
+			t.Errorf("output must not reference AverageRating/RatingsCount, found %q in:\n%s", needle, out)
+		}
+	}
+}
+
+func TestBuildOPFXML_NoCoverReference(t *testing.T) {
+	book, author, edition := fullBookFixture()
+	book.ImageURL = "https://example.com/cover.jpg"
+	xmlBytes, err := BuildOPFXML(book, author, edition, "", "")
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	if strings.Contains(string(xmlBytes), "cover") {
+		t.Errorf("output must not reference a cover (none is ever written to the library folder), got:\n%s", xmlBytes)
+	}
+}
+
+func TestBuildOPFXML_MinimalBook(t *testing.T) {
+	book := &models.Book{ID: 7, Title: "Bare Book"}
+	xmlBytes, err := BuildOPFXML(book, nil, nil, "", "")
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	p := parseOPFProbe(t, xmlBytes)
+	if p.Metadata.Title != "Bare Book" {
+		t.Errorf("title = %q, want %q", p.Metadata.Title, "Bare Book")
+	}
+	if p.Metadata.Creator != "" {
+		t.Errorf("creator = %q, want empty (nil author)", p.Metadata.Creator)
+	}
+	if len(p.Metadata.Identifiers) != 1 || p.Metadata.Identifiers[0].Value != "7" {
+		t.Errorf("identifiers = %+v, want just the bindery id", p.Metadata.Identifiers)
+	}
+}
+
+func TestBuildOPFXML_NilBook(t *testing.T) {
+	if _, err := BuildOPFXML(nil, nil, nil, "", ""); err == nil {
+		t.Fatal("expected an error for a nil book, got nil")
+	}
+}
+
+// TestBuildOPFXML_EscapesSpecialCharacters guards against a title/author
+// containing XML metacharacters (an ampersand is routine — "Fantasy &
+// Science Fiction") producing malformed output a reader can't parse.
+func TestBuildOPFXML_EscapesSpecialCharacters(t *testing.T) {
+	book := &models.Book{ID: 1, Title: `<Weird> & "Title"`}
+	author := &models.Author{Name: "A & B", SortName: `B, "A"`}
+	xmlBytes, err := BuildOPFXML(book, author, nil, "", "")
+	if err != nil {
+		t.Fatalf("BuildOPFXML: %v", err)
+	}
+	p := parseOPFProbe(t, xmlBytes)
+	if p.Metadata.Title != book.Title {
+		t.Errorf("round-tripped title = %q, want %q", p.Metadata.Title, book.Title)
+	}
+	if p.Metadata.Creator != author.Name {
+		t.Errorf("round-tripped creator = %q, want %q", p.Metadata.Creator, author.Name)
+	}
+}
+
+func TestWriteOPFSidecarFile(t *testing.T) {
+	dir := t.TempDir()
+	bookDir := filepath.Join(dir, "Brandon Sanderson", "The Way of Kings (2020)")
+	book, author, edition := fullBookFixture()
+
+	if err := WriteOPFSidecarFile(bookDir, book, author, edition, "", ""); err != nil {
+		t.Fatalf("WriteOPFSidecarFile: %v", err)
+	}
+	dest := filepath.Join(bookDir, "metadata.opf")
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("expected %s to exist: %v", dest, err)
+	}
+	p := parseOPFProbe(t, data)
+	if p.Metadata.Title != book.Title {
+		t.Errorf("written file title = %q, want %q", p.Metadata.Title, book.Title)
+	}
+
+	// Re-writing (e.g. via Reorganize) must overwrite cleanly, not append or
+	// fail because the file and directory already exist.
+	book.Title = "The Way of Kings: Author's Definitive Edition"
+	if err := WriteOPFSidecarFile(bookDir, book, author, edition, "", ""); err != nil {
+		t.Fatalf("WriteOPFSidecarFile (overwrite): %v", err)
+	}
+	data, err = os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("re-read after overwrite: %v", err)
+	}
+	p = parseOPFProbe(t, data)
+	if p.Metadata.Title != book.Title {
+		t.Errorf("after overwrite, title = %q, want %q", p.Metadata.Title, book.Title)
+	}
+}

--- a/internal/importer/opfsidecar_test.go
+++ b/internal/importer/opfsidecar_test.go
@@ -232,10 +232,11 @@ func TestBuildOPFXML_EscapesSpecialCharacters(t *testing.T) {
 
 func TestWriteOPFSidecarFile(t *testing.T) {
 	dir := t.TempDir()
+	roots := []string{dir}
 	bookDir := filepath.Join(dir, "Brandon Sanderson", "The Way of Kings (2020)")
 	book, author, edition := fullBookFixture()
 
-	if err := WriteOPFSidecarFile(bookDir, book, author, edition, "", ""); err != nil {
+	if err := WriteOPFSidecarFile(bookDir, roots, book, author, edition, "", ""); err != nil {
 		t.Fatalf("WriteOPFSidecarFile: %v", err)
 	}
 	dest := filepath.Join(bookDir, "metadata.opf")
@@ -251,7 +252,7 @@ func TestWriteOPFSidecarFile(t *testing.T) {
 	// Re-writing (e.g. via Reorganize) must overwrite cleanly, not append or
 	// fail because the file and directory already exist.
 	book.Title = "The Way of Kings: Author's Definitive Edition"
-	if err := WriteOPFSidecarFile(bookDir, book, author, edition, "", ""); err != nil {
+	if err := WriteOPFSidecarFile(bookDir, roots, book, author, edition, "", ""); err != nil {
 		t.Fatalf("WriteOPFSidecarFile (overwrite): %v", err)
 	}
 	data, err = os.ReadFile(dest)
@@ -277,6 +278,42 @@ func TestWriteOPFSidecarFile(t *testing.T) {
 			names = append(names, e.Name())
 		}
 		t.Errorf("book folder holds %v, want just [metadata.opf]", names)
+	}
+}
+
+// TestWriteOPFSidecarFile_RefusesOutsideRoots is the direct regression test
+// for dirWithinRoots: WriteOPFSidecarFile must refuse to write when dir does
+// not resolve inside any given root, rather than trusting that a caller
+// already sanitized it. Every real caller derives dir from
+// Renamer.DestPath/AudiobookDestDir, which already apply this exact
+// containment check — this test exercises the independent guard
+// WriteOPFSidecarFile itself applies regardless of what the caller did.
+func TestWriteOPFSidecarFile_RefusesOutsideRoots(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir() // a sibling temp dir, not under root
+	book, author, edition := fullBookFixture()
+
+	err := WriteOPFSidecarFile(outside, []string{root}, book, author, edition, "", "")
+	if err == nil {
+		t.Fatal("want an error writing outside the given roots, got nil")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "metadata.opf")); !os.IsNotExist(statErr) {
+		t.Errorf("metadata.opf should not have been written to %s", outside)
+	}
+
+	// A traversal attempt through a root-relative-looking path must not
+	// escape either: filepath.Join(root, "..", "escaped") resolves outside
+	// root once Cleaned, same as ensureContained already checks for
+	// Renamer.DestPath.
+	traversal := filepath.Join(root, "..", "escaped")
+	if err := WriteOPFSidecarFile(traversal, []string{root}, book, author, edition, "", ""); err == nil {
+		t.Fatal("want an error for a path that traverses outside root, got nil")
+	}
+
+	// Sanity: the same call with the correct root still succeeds.
+	inside := filepath.Join(root, "Some Author", "Some Book (2020)")
+	if err := WriteOPFSidecarFile(inside, []string{root}, book, author, edition, "", ""); err != nil {
+		t.Fatalf("WriteOPFSidecarFile inside root: %v", err)
 	}
 }
 

--- a/internal/importer/reorganize.go
+++ b/internal/importer/reorganize.go
@@ -296,6 +296,20 @@ func (s *Scanner) applyOne(ctx context.Context, fileID int64) ReorganizeMove {
 		"format": file.Format,
 	})
 
+	// Regenerate the metadata.opf sidecar (when the feature is on) so it
+	// reflects the current metadata — this is Reorganize's normal job for
+	// folder names, and the sidecar is exactly the same kind of "derived from
+	// the DB, stale until something re-derives it" artifact (#1970-adjacent
+	// design note: nothing else in the importer auto-refreshes on a plain
+	// metadata edit either; Reorganize is the one place that already
+	// re-touches disk with current metadata, so it's the natural hook).
+	sidecarDir := proposed
+	if file.Format != models.MediaTypeAudiobook {
+		sidecarDir = filepath.Dir(proposed)
+	}
+	edition := s.resolveCalibreEdition(ctx, nil, book)
+	s.writeOPFSidecar(ctx, sidecarDir, book, author, edition, seriesTitle, seriesNum)
+
 	m.Status = ReorgStatusMoved
 	return m
 }

--- a/internal/importer/reorganize.go
+++ b/internal/importer/reorganize.go
@@ -319,7 +319,7 @@ func (s *Scanner) applyOne(ctx context.Context, fileID int64) ReorganizeMove {
 			sidecarDir = filepath.Dir(proposed)
 		}
 		edition := s.resolveCalibreEdition(ctx, nil, book)
-		s.writeOPFSidecar(ctx, sidecarDir, book, author, edition, seriesTitle, seriesNum)
+		s.writeOPFSidecar(ctx, sidecarDir, s.rootsForFormat(ctx, author, file.Format), book, author, edition, seriesTitle, seriesNum)
 	}
 
 	m.Status = ReorgStatusMoved

--- a/internal/importer/reorganize.go
+++ b/internal/importer/reorganize.go
@@ -288,6 +288,13 @@ func (s *Scanner) applyOne(ctx context.Context, fileID int64) ReorganizeMove {
 		return m
 	}
 
+	// A single-file ebook leaves its metadata.opf behind when it moves out of a
+	// folder, which both strands a stale sidecar and blocks the prune below
+	// from reclaiming the now-empty folder. An audiobook moves as a whole
+	// directory, so its sidecar travels with it and there is nothing to clean.
+	if file.Format != models.MediaTypeAudiobook {
+		removeOrphanedSidecar(filepath.Dir(file.Path), filepath.Dir(proposed))
+	}
 	pruneEmptyParents(filepath.Dir(file.Path), s.rootsForFormat(ctx, author, file.Format))
 	bookID := book.ID
 	s.createHistoryEvent(ctx, models.HistoryEventBookRenamed, book.Title, &bookID, map[string]string{
@@ -303,12 +310,17 @@ func (s *Scanner) applyOne(ctx context.Context, fileID int64) ReorganizeMove {
 	// design note: nothing else in the importer auto-refreshes on a plain
 	// metadata edit either; Reorganize is the one place that already
 	// re-touches disk with current metadata, so it's the natural hook).
-	sidecarDir := proposed
-	if file.Format != models.MediaTypeAudiobook {
-		sidecarDir = filepath.Dir(proposed)
+	// Gated here as well as inside writeOPFSidecar so resolveCalibreEdition —
+	// a per-file editions query — is not paid on every reorganized file for a
+	// feature that is off by default.
+	if s.opfSidecarEnabled(ctx) {
+		sidecarDir := proposed
+		if file.Format != models.MediaTypeAudiobook {
+			sidecarDir = filepath.Dir(proposed)
+		}
+		edition := s.resolveCalibreEdition(ctx, nil, book)
+		s.writeOPFSidecar(ctx, sidecarDir, book, author, edition, seriesTitle, seriesNum)
 	}
-	edition := s.resolveCalibreEdition(ctx, nil, book)
-	s.writeOPFSidecar(ctx, sidecarDir, book, author, edition, seriesTitle, seriesNum)
 
 	m.Status = ReorgStatusMoved
 	return m

--- a/internal/importer/reorganize_test.go
+++ b/internal/importer/reorganize_test.go
@@ -449,3 +449,149 @@ func TestReorganize_DestinationInsideSourceIsRefused(t *testing.T) {
 		t.Fatalf("source folder was modified: %v", entries)
 	}
 }
+
+// enableOPFSidecar turns on import.write_opf_sidecar for a reorganize fixture.
+func (env reorgEnv) enableOPFSidecar(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if err := env.s.settings.Set(ctx, "import.write_opf_sidecar", "true"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReorganize_EbookSidecarFollowsTheMove is the regression test for a
+// sidecar stranding its old folder. An ebook is a single file: when it moves
+// out, its metadata.opf does not follow, which both leaves a stale copy of the
+// book's metadata on disk for a sidecar-reading library app to index and keeps
+// the folder non-empty, so pruneEmptyParents can never reclaim it. Renaming a
+// book (or its author) would then leave one orphan folder behind per rename.
+func TestReorganize_EbookSidecarFollowsTheMove(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	env.enableOPFSidecar(t, ctx)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	// The book sits at its previous title's templated location, with the
+	// sidecar a previous import wrote there.
+	oldDir := filepath.Join(libraryDir, "Jane Doe", "Old Title (2020)")
+	oldPath := filepath.Join(oldDir, "Old Title - Jane Doe.epub")
+	writeFileAt(t, oldPath)
+	if err := os.WriteFile(filepath.Join(oldDir, "metadata.opf"), []byte("<stale/>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, oldPath); err != nil {
+		t.Fatal(err)
+	}
+
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results := env.s.ApplyReorganize(ctx, []int64{moves[0].FileID}); results[0].Status != ReorgStatusMoved {
+		t.Fatalf("apply = %+v, want moved", results[0])
+	}
+
+	// The sidecar is rewritten beside the book at its new location, carrying
+	// the current title rather than the one it was imported under.
+	newDir := filepath.Join(libraryDir, "Jane Doe", "My Book (2020)")
+	data, err := os.ReadFile(filepath.Join(newDir, "metadata.opf"))
+	if err != nil {
+		t.Fatalf("sidecar missing at the new location: %v", err)
+	}
+	if p := parseOPFProbe(t, data); p.Metadata.Title != "My Book" {
+		t.Errorf("refreshed sidecar title = %q, want the current %q", p.Metadata.Title, "My Book")
+	}
+
+	// And the old folder is gone entirely — not left behind holding the stale
+	// sidecar.
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		entries, _ := os.ReadDir(oldDir)
+		t.Errorf("old folder should have been pruned, still holds %v (stat err = %v)", entries, err)
+	}
+}
+
+// A folder the moved file shared with something else keeps everything it has,
+// sidecar included: the leftover may well describe whatever is still there.
+func TestReorganize_SidecarKeptWhenTheOldFolderIsNotEmpty(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	env.enableOPFSidecar(t, ctx)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	oldDir := filepath.Join(libraryDir, "Jane Doe", "Old Title (2020)")
+	oldPath := filepath.Join(oldDir, "Old Title - Jane Doe.epub")
+	writeFileAt(t, oldPath)
+	writeFileAt(t, filepath.Join(oldDir, "Old Title - Jane Doe.mobi"))
+	if err := os.WriteFile(filepath.Join(oldDir, "metadata.opf"), []byte("<stale/>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, oldPath); err != nil {
+		t.Fatal(err)
+	}
+
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results := env.s.ApplyReorganize(ctx, []int64{moves[0].FileID}); results[0].Status != ReorgStatusMoved {
+		t.Fatalf("apply = %+v, want moved", results[0])
+	}
+	if _, err := os.Stat(filepath.Join(oldDir, "metadata.opf")); err != nil {
+		t.Errorf("sidecar in a still-occupied folder must be left alone: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(oldDir, "Old Title - Jane Doe.mobi")); err != nil {
+		t.Errorf("untracked sibling file must be left alone: %v", err)
+	}
+}
+
+// An audiobook is a whole directory, so its sidecar belongs INSIDE the moved
+// folder (and travels with it) rather than beside it in the author folder.
+func TestReorganize_AudiobookSidecarGoesInsideTheFolder(t *testing.T) {
+	env, _, audiobookDir, ctx := reorgFixture(t)
+	env.enableOPFSidecar(t, ctx)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	oldDir := filepath.Join(audiobookDir, "unsorted", "My Book audio")
+	writeFileAt(t, filepath.Join(oldDir, "part1.mp3"))
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, oldDir); err != nil {
+		t.Fatal(err)
+	}
+
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results := env.s.ApplyReorganize(ctx, []int64{moves[0].FileID}); results[0].Status != ReorgStatusMoved {
+		t.Fatalf("apply = %+v, want moved", results[0])
+	}
+
+	want := filepath.Join(audiobookDir, "Jane Doe", "My Book (2020)")
+	if _, err := os.Stat(filepath.Join(want, "metadata.opf")); err != nil {
+		t.Errorf("sidecar should be inside the audiobook folder: %v", err)
+	}
+	// Not in the author folder alongside it.
+	if _, err := os.Stat(filepath.Join(audiobookDir, "Jane Doe", "metadata.opf")); !os.IsNotExist(err) {
+		t.Errorf("sidecar must not be written beside the audiobook folder, stat err = %v", err)
+	}
+}
+
+// With the setting off (the default) Reorganize must not start writing new
+// files into the library.
+func TestReorganize_NoSidecarWhenDisabled(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	oldPath := filepath.Join(libraryDir, "misc", "randomname.epub")
+	writeFileAt(t, oldPath)
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, oldPath); err != nil {
+		t.Fatal(err)
+	}
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results := env.s.ApplyReorganize(ctx, []int64{moves[0].FileID}); results[0].Status != ReorgStatusMoved {
+		t.Fatalf("apply = %+v, want moved", results[0])
+	}
+	newDir := filepath.Join(libraryDir, "Jane Doe", "My Book (2020)")
+	if _, err := os.Stat(filepath.Join(newDir, "metadata.opf")); !os.IsNotExist(err) {
+		t.Errorf("no sidecar may be written while the setting is off, stat err = %v", err)
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1912,6 +1912,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 
 		s.pushToCalibre(ctx, book, author, edition, seriesTitle, seriesNum, destDir)
 		s.pushToABS(ctx)
+		s.writeOPFSidecar(ctx, destDir, book, author, edition, seriesTitle, seriesNum)
 
 		historyMeta := map[string]string{"path": destDir, "format": models.MediaTypeAudiobook}
 		if len(mergeSkippedFiles) > 0 {
@@ -2065,6 +2066,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		s.pushToCalibre(ctx, book, author, edition, seriesTitle, seriesNum, destPath)
 		s.pushToCWA(ctx, destPath)
 		s.pushToGrimmory(ctx, book, destPath)
+		s.writeOPFSidecar(ctx, filepath.Dir(destPath), book, author, edition, seriesTitle, seriesNum)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath, "format": models.MediaTypeEbook})
 	}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1946,6 +1946,15 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// edit outranks it, and that locks the field — in which case the EPUB is
 	// not opened at all.
 	var detectedLang string
+	// sidecarDir records the folder a successfully imported ebook file landed
+	// in, so the OPF sidecar can be written once after the loop rather than
+	// once per file — and, critically, after applyEmbeddedLanguage below has
+	// had a chance to backfill book.Language, so a first-time import of a
+	// book with no catalogue language doesn't write a sidecar missing
+	// dc:language moments before the DB gains one. All files of one book
+	// share a destination directory (only the extension varies), so any
+	// imported file's directory is the right one.
+	var sidecarDir string
 	readLanguage := book != nil && !book.IsFieldLocked(models.BookFieldLanguage)
 	// Resolve the ebook destination root and (auto) placement mode once: the
 	// root is stable for this author across the loop, and choosing hardlink-vs-
@@ -2055,6 +2064,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		}
 		imported++
 		importedSrcFiles = append(importedSrcFiles, srcFile)
+		sidecarDir = filepath.Dir(destPath)
 		// NOTE: StateImported is intentionally NOT set here (issue #705 finding 1).
 		// Writing the terminal "imported" state after the first successful file
 		// would mark an incomplete multi-file download as fully imported; a later
@@ -2066,7 +2076,6 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		s.pushToCalibre(ctx, book, author, edition, seriesTitle, seriesNum, destPath)
 		s.pushToCWA(ctx, destPath)
 		s.pushToGrimmory(ctx, book, destPath)
-		s.writeOPFSidecar(ctx, filepath.Dir(destPath), book, author, edition, seriesTitle, seriesNum)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath, "format": models.MediaTypeEbook})
 	}
@@ -2076,6 +2085,16 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// rewrite the catalogue from a file that is not in the library.
 	if readLanguage && imported > 0 && detectedLang != "" {
 		s.applyEmbeddedLanguage(ctx, book, detectedLang, dl.Title)
+	}
+
+	// Written once here, after applyEmbeddedLanguage above, rather than once
+	// per file inside the loop: a sidecar written mid-loop could carry a
+	// blank dc:language that the backfill above fills in moments later, and
+	// a multi-file download (epub + mobi + pdf sharing one folder) would
+	// otherwise regenerate the identical sidecar once per format.
+	if imported > 0 && sidecarDir != "" {
+		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
+		s.writeOPFSidecar(ctx, sidecarDir, book, author, edition, seriesTitle, seriesNum)
 	}
 
 	// If every file failed to copy/move, the destination is likely not writable —

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1912,7 +1912,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 
 		s.pushToCalibre(ctx, book, author, edition, seriesTitle, seriesNum, destDir)
 		s.pushToABS(ctx)
-		s.writeOPFSidecar(ctx, destDir, book, author, edition, seriesTitle, seriesNum)
+		s.writeOPFSidecar(ctx, destDir, []string{audiobookRoot}, book, author, edition, seriesTitle, seriesNum)
 
 		historyMeta := map[string]string{"path": destDir, "format": models.MediaTypeAudiobook}
 		if len(mergeSkippedFiles) > 0 {
@@ -2094,7 +2094,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// otherwise regenerate the identical sidecar once per format.
 	if imported > 0 && sidecarDir != "" {
 		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
-		s.writeOPFSidecar(ctx, sidecarDir, book, author, edition, seriesTitle, seriesNum)
+		s.writeOPFSidecar(ctx, sidecarDir, []string{ebookRoot}, book, author, edition, seriesTitle, seriesNum)
 	}
 
 	// If every file failed to copy/move, the destination is likely not writable —

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -465,6 +466,99 @@ func TestImportInternal_ThreeFileBundle_TracksAllInBookFiles(t *testing.T) {
 	}
 	if len(files) != 3 {
 		t.Errorf("want 3 book_files rows for epub+mobi+pdf bundle, got %d", len(files))
+	}
+}
+
+// TestImportInternal_OPFSidecarSeesBackfilledLanguage regression-tests the
+// ordering fix: the OPF sidecar is written after applyEmbeddedLanguage's
+// #1160 backfill, not before it, so a first-time import of a book with no
+// catalogue language produces a sidecar that already carries the language
+// read from the EPUB rather than a blank dc:language moments before the DB
+// catches up.
+func TestImportInternal_OPFSidecarSeesBackfilledLanguage(t *testing.T) {
+	dlDir := t.TempDir()
+
+	opf := `<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Cien Años de Soledad</dc:title>
+    <dc:creator opf:role="aut">Gabriel García Márquez</dc:creator>
+    <dc:language>es</dc:language>
+  </metadata>
+</package>`
+	epubSrc := writeTestEpub(t, "OEBPS/content.opf", opf)
+	epubBytes, err := os.ReadFile(epubSrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dlDir, "book.epub"), epubBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	libDir := t.TempDir()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	if err := settingsRepo.Set(ctx, "import.write_opf_sidecar", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{ForeignID: "OLA-LANG", Name: "Author", SortName: "Author", Monitored: true, MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OLB-LANG", AuthorID: author.ID, Title: "Cien Años de Soledad",
+		SortTitle: "Cien Años de Soledad", Status: models.BookStatusWanted,
+		Monitored: true, AnyEditionOK: true, MetadataProvider: "openlibrary",
+		Language: "", // no catalogue language — triggers the #1160 backfill path
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	dl := &models.Download{
+		GUID: "lang-guid", Title: "Cien Años de Soledad", BookID: &book.ID,
+		Status: models.StateCompleted,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, db.NewHistoryRepo(database), libDir, "", "", "", "").WithSettings(settingsRepo)
+	s.tryImportInternal(ctx, dl, dlDir, "", "", "", nil, nil)
+
+	updated, err := bookRepo.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if updated.Language != "spa" {
+		t.Fatalf("book language after import = %q, want backfilled %q", updated.Language, "spa")
+	}
+
+	bookFiles, err := bookRepo.ListFiles(ctx, book.ID)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(bookFiles) != 1 {
+		t.Fatalf("want 1 book_files row, got %d", len(bookFiles))
+	}
+	sidecarPath := filepath.Join(filepath.Dir(bookFiles[0].Path), "metadata.opf")
+	sidecar, err := os.ReadFile(sidecarPath)
+	if err != nil {
+		t.Fatalf("reading metadata.opf: %v", err)
+	}
+	if !strings.Contains(string(sidecar), "<dc:language>es</dc:language>") {
+		t.Errorf("metadata.opf missing backfilled language (want normalized <dc:language>es</dc:language>), got:\n%s", sidecar)
 	}
 }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -801,6 +801,8 @@
       "dropLinkMode": "Placement",
       "dropLinkCopy": "Copy",
       "dropLinkHardlink": "Hardlink (same filesystem)",
+      "writeOPFSidecar": "Write a metadata.opf sidecar",
+      "writeOPFSidecarHint": "Write a Calibre-style metadata.opf file next to each imported book, carrying Bindery's own title, author, series, identifiers, and other catalogue metadata — regardless of what the downloaded file's own embedded tags say. Also refreshed when you run Reorganize. Never modifies the book file itself, only adds this extra file. Off by default.",
       "bookTemplate": "Book Naming Template",
       "audiobookTemplate": "Audiobook Folder Template",
       "audiobookTemplateHint": "Audiobooks are imported as whole directories (multi-part m4b/mp3 + cover stay together). Template produces the destination folder; original filenames inside are preserved.",

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -320,6 +320,28 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
               </div>
             </div>
           )}
+          <div className="border-t border-slate-200 dark:border-zinc-800 pt-3">
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                className="mt-0.5"
+                checked={settings['import.write_opf_sidecar'] === 'true'}
+                onChange={async e => {
+                  const v = e.target.checked ? 'true' : 'false'
+                  setSettings(s => ({ ...s, 'import.write_opf_sidecar': v }))
+                  await api.setSetting('import.write_opf_sidecar', v).catch(console.error)
+                }}
+              />
+              <span>
+                <span className="text-xs font-medium text-slate-700 dark:text-zinc-300">
+                  {t('settings.general.writeOPFSidecar', 'Write a metadata.opf sidecar')}
+                </span>
+                <span className="block text-xs text-slate-600 dark:text-zinc-500">
+                  {t('settings.general.writeOPFSidecarHint', "Write a Calibre-style metadata.opf file next to each imported book, carrying Bindery's own title, author, series, identifiers, and other catalogue metadata — regardless of what the downloaded file's own embedded tags say. Also refreshed when you run Reorganize. Never modifies the book file itself, only adds this extra file. Off by default.")}
+                </span>
+              </span>
+            </label>
+          </div>
           <NamingTemplateField
             label={t('settings.general.bookTemplate')}
             kind="book"


### PR DESCRIPTION
## Summary

Ebooks and audiobooks pulled from different sources can carry differently-spelled author names in their embedded metadata — punctuation, initials, diacritics ("J.R.R. Tolkien" vs "JRR Tolkien" vs an ASCII-transliterated "Joerg Mueller"). `textutil.MatchAuthorName` already reconciles this correctly for Bindery's own catalogue and folder naming, but that reconciled truth never goes anywhere else: `epubmeta.go` and `audiotag.go` are read-only (confirmed — no ID3/OPF/M4B writer exists anywhere in the codebase), and Bindery only ever renames files, never writes into or beside one. A downstream library app that trusts embedded (or sidecar) metadata over folder structure — this came up specifically with BookOrbit and Grimmory — still sees the inconsistency even though Bindery's own view looks perfectly clean.

This is genuinely open territory, not a declined request: `docs/ROADMAP.md`'s "Won't do" / "Explicitly out of scope" sections don't mention it either way.

This PR adds **Phase 1** of a two-phase plan and lays out **Phase 2** below for you to weigh in on — I'd rather you see the whole shape than have it trickle in as surprise follow-ups.

## Phase 1 (this PR): a `metadata.opf` sidecar

New opt-in setting `import.write_opf_sidecar` (off by default). When on:

- Every imported ebook/audiobook folder gets a Calibre-style `metadata.opf` — the same OPF package-document `<metadata>` schema and Dublin Core vocabulary an EPUB carries inside its own zip (`internal/importer/epubmeta.go`'s `ReadEpubMetadata` is the read-side counterpart of the same format), written standalone instead of unzipped from inside a book file.
- Carries Bindery's own canonical DB metadata — title, sort-title, author (name + file-as sort form), narrator, series + series-index, identifiers (ISBN/ASIN/provider IDs), language, publisher, publish date, description, genres — regardless of what the downloaded file's own tags said.
- Refreshed by Reorganize too (`internal/importer/reorganize.go`'s `applyOne`), so a later author rename or alias merge doesn't leave the sidecar stale.
- **Zero risk to the book file's own bytes** — this is a new file only, never a modification to the file it sits beside. That's deliberately the whole reason this is Phase 1 and not Phase 2: it sidesteps hardlink import mode entirely, where the "imported" file and the original download share an inode and any embedded-tag write would mutate the seed file too.

### Field scope

Title, sort-title, author, narrator, series, identifiers, language, publisher, date, description, and genres are written. **`Book.AverageRating` and `Book.RatingsCount` are deliberately excluded**, and so is any cover reference (no cover file is ever placed in the library folder to reference — covers are proxied/cached separately at `/api/v1/images`).

This isn't a new policy call — it's the same line `docs/third-party-data.md` already draws for Hardcover-sourced data: *"Title, author, series, edition, publisher, narrator, description, and cover are facts and are fine"* vs. *"`books.average_rating` and `books.ratings_count`... are aggregates of other users' ratings, not facts about the book. Strip them..."* A `metadata.opf` sidecar is exactly the kind of new surface that line exists to keep closed, so this PR keeps to it rather than opening a new gap. `TestBuildOPFXML_ExcludesRatings` pins this as a regression test, citing the doc directly.

### Implementation notes

- `internal/importer/opfsidecar.go` is new, sibling to `epubmeta.go`. `BuildOPFXML` is hand-built XML (not `encoding/xml` struct tags) — namespaced attributes (`opf:role`, `opf:file-as`, `opf:scheme`) are awkward to get byte-stable through Go's marshaller, and `parseOPFMetadata` already established this codebase's precedent of walking/writing OPF tokens directly rather than binding a fixed struct.
- Reuses `calibre.IdentifiersForBook`, `calibre.NormalizeLanguageForCalibre`, and `calibre.FormatPublishedDate` from the existing Calibre-push integration (`internal/calibre`) rather than reimplementing identifier/language/date resolution. A book's `metadata.opf` and its `calibredb`-pushed metadata are guaranteed to agree by construction, not by two implementations happening to match.
- Hook points mirror the existing best-effort push pattern exactly (`pushToCalibre`/`pushToCWA`/`pushToGrimmory` in `scanner.go`, `pushToCalibre`/`pushToABS` on the audiobook side) — logged and swallowed on failure, never rolling back an otherwise-good import.
- Sidecar writes are atomic (temp file + rename, matching `calibre.MaterializeCover`'s existing pattern), and for the ebook path happen once per book after the whole file loop completes — not once per file — so a multi-format download (epub+mobi+pdf sharing one folder) doesn't regenerate the identical sidecar three times, and so the write happens *after* the `#1160` embedded-language backfill rather than before it (a first import with no catalogue language previously risked a sidecar with a blank `dc:language` for the seconds before the backfill landed).
- Reorganize removes an orphaned `metadata.opf` when it's the last thing left in a folder being pruned, so a rename never strands an empty folder that `os.Remove` can't clear.

### Where it's mounted

- Settings → General, next to the drop-folder/flatten-multi-disc import toggles (`import.write_opf_sidecar`).
- `internal/importer/scanner.go`: ebook hook after the per-file loop (once per book), audiobook hook after `pushToABS`.
- `internal/importer/reorganize.go`: `applyOne`, after the history event, gated the same way.

## Phase 2 (proposed, not built here): embed metadata into the file itself

Phase 1 doesn't close the loop for every downstream app — I checked both concretely:

- **BookOrbit** supports OPF-sidecar-as-a-metadata-source with a configurable precedence order, but there's a [currently open upstream bug](https://github.com/bookorbit/bookorbit/issues/200) where the sidecar is ignored even when ranked first.
- **Grimmory** uses its own `.sidecar.json` convention and doesn't consume `.opf` sidecars at all (though it does have its own manual "write metadata into the EPUB" feature, and Bindery already has a direct `pushToGrimmory`/BookDrop integration that's a separate mechanism from this).

The real fix for both is embedding metadata directly into the file:

- **EPUB is a near-trivial follow-on.** It's the exact same OPF `<metadata>` schema/vocabulary this PR already generates — Phase 2 would splice `BuildOPFXML`'s `<metadata>` block into the EPUB's *internal* package document (found via `META-INF/container.xml`, same as `ReadEpubMetadata` does today) instead of writing it standalone, and rewrite the zip. No new format to learn, same generation function, different write target.
- **Audio formats need real work.** ID3 (mp3) and MP4 atoms (m4b/m4a) are different binary container formats with no shared vocabulary — this needs an actual tag-writing dependency (checked: `dhowden/tag`, the only tagging dep currently in `go.mod`, is read-only) and a license check per the project's MIT-vs-copyleft conventions.
- **The one real risk, stated plainly:** under `hardlink` import mode, the "imported" file and the original download share an inode. Writing tags into one mutates the other's bytes too. Phase 2 would need to detect hardlink mode and either skip the write or force a copy first — this is exactly the risk Phase 1 was scoped to avoid entirely, and it doesn't go away for Phase 2, it just becomes a solvable, scoped problem instead of an unscoped one.

I'm not asking for a decision under time pressure — Phase 1 stands on its own regardless of which way you land on Phase 2. But I'd rather you see the full shape now than have "embed into EPUB" show up as a surprise follow-up PR with no warning it was coming.

## Suggested review order

1. `internal/importer/opfsidecar.go` + `opfsidecar_test.go` — the core logic and its test contract (especially `TestBuildOPFXML_ExcludesRatings`).
2. `internal/importer/scanner.go` + `reorganize.go` — the hook wiring, including the orphaned-sidecar cleanup and the post-loop write ordering.
3. `internal/api/settings_handler.go` + `settings_registry.go` (+ `settings_registry_test.go`) — the setting plumbing.
4. `web/src/pages/settings/GeneralTab.tsx` + `en.json` — the UI.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — `README.md` (Import & organize feature list), godoc on every new exported symbol, `changelog.d/opf-sidecar-metadata.md`. Not touched: `docs/DEPLOYMENT.md` — happy to add a line there too if you'd like one (its closest analogue, `cwa.ingest_path`, gets a topology mention; the closer sibling toggles `drop_pair_gating`/`flatten_multi_disc` don't).
- [ ] Wiki pages updated — n/a, no existing wiki page covers this surface

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`
- [x] `golangci-lint run` (`internal/importer/...`, `internal/api/...`)
- [x] `govulncheck ./...`
- [x] `go test ./internal/importer/...`, `./internal/api/...`, `./internal/calibre/...`
- [x] `go test -race ./internal/importer/...`, `go test -race -run TestSetting ./internal/api/...`
- [x] `cd web && npm run typecheck && npm run lint && npm run build && npm test` (861/861)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A3uW6ZH6m56q1SLVg7Ky
