### PR TITLE
fix(importer): strip "NNN-TOTAL - " track counters from scanned titles (#2547)

### DIFF
--- a/changelog.d/2547-track-counter-prefix.md
+++ b/changelog.d/2547-track-counter-prefix.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Library Scan now matches audiobooks whose tracks are named "001-190 - Title"** (#2547). The track counter was read as the title and the real title as the author, so every file in a numbered rip came back unmatched. A leading "track of total" counter is now stripped before the title is read, and a tag title that is only a counter no longer overrides the folder name. Titles that merely start with a number, like 1984 or 11-22-63, are unaffected. Thanks ReynoldsProductions for the report.

--- a/internal/importer/chaptertitle_test.go
+++ b/internal/importer/chaptertitle_test.go
@@ -47,3 +47,19 @@ func TestLooksLikeChapterTitle(t *testing.T) {
 		}
 	}
 }
+
+// TestLooksLikeChapterTitleBareTrackCounter covers the tag side of #2547:
+// some rips tag each track's title as just its counter, "001-190", and that
+// tag used to override a real folder-derived book title.
+func TestLooksLikeChapterTitleBareTrackCounter(t *testing.T) {
+	for _, title := range []string{"001-190", "07 of 12", "3/10", "190-190"} {
+		if !looksLikeChapterTitle(title) {
+			t.Errorf("looksLikeChapterTitle(%q) = false, want true", title)
+		}
+	}
+	for _, title := range []string{"1984", "11-22-63", "The Girl with All the Gifts", "Catch-22"} {
+		if looksLikeChapterTitle(title) {
+			t.Errorf("looksLikeChapterTitle(%q) = true, want false", title)
+		}
+	}
+}

--- a/internal/importer/parser.go
+++ b/internal/importer/parser.go
@@ -54,6 +54,11 @@ var (
 	seriesParenRe = regexp.MustCompile(`(?i)\(([A-Za-z][^)]*?),?\s*(?:book|vol(?:ume)?|part)?\.?\s*#?(\d+(?:\.\d+)?)\)`)
 	// Leading position number at start of base name: "01 - Title" or "1. Title"
 	leadingNumRe = regexp.MustCompile(`^(\d+(?:\.\d+)?)\s*[-–.]\s+`)
+	// trackCounterPrefixRe matches a leading "track of total" counter and the
+	// separator after it: "001-190 - ", "07 of 12 - ", "3/10 - ". Both numbers
+	// are required, so a real title that merely starts with a number ("1984 -
+	// George Orwell", "11-22-63 - Stephen King" has three) is left alone.
+	trackCounterPrefixRe = regexp.MustCompile(`^\d{1,4}\s*(?:-|/|of)\s*\d{1,4}\s+-\s+`)
 	// "Series Book N - Title" or "Series Book N: Title" inline pattern (after dot/underscore expansion).
 	// Captures: series name, book number, title (and optional author after another " - ").
 	seriesBookInlineRe = regexp.MustCompile(`(?i)^(.+?)\s+(?:book|vol(?:ume)?|part)\.?\s*(\d+(?:\.\d+)?)\s*[-–:]\s*(.+)$`)
@@ -119,6 +124,14 @@ func ParseFilename(path string) ParsedFile {
 	// dash-based separator below (Title - Author, Author - [Series] - Title,
 	// leading position number, ...) matches an em dash the same as a hyphen.
 	name = dashNormalizer.Replace(name)
+
+	// Numbered audiobook rips prefix every track with "NNN-TOTAL - " (or
+	// "NNN of TOTAL - "), then repeat the book title: "001-190 - The Girl with
+	// All the Gifts". The Title - Author split below would otherwise take the
+	// track counter as the title and the real title as the author, so every
+	// file in the folder parsed as a different non-title and none matched
+	// (#2547). A counter pair followed by the separator is never a title.
+	name = trackCounterPrefixRe.ReplaceAllString(name, "")
 
 	// Extract ASIN if present and strip it so it doesn't pollute the title
 	if asin := asinRe.FindString(name); asin != "" {

--- a/internal/importer/parser_test.go
+++ b/internal/importer/parser_test.go
@@ -250,3 +250,29 @@ func TestParseFilenameSeriesExtraction(t *testing.T) {
 		})
 	}
 }
+
+// TestParseFilenameStripsTrackCounterPrefix covers #2547: numbered audiobook
+// rips name every file "NNN-TOTAL - Title", and the Title - Author split took
+// the counter as the title and the real title as the author, so none of the
+// 193 files matched the catalogued book.
+func TestParseFilenameStripsTrackCounterPrefix(t *testing.T) {
+	cases := []struct {
+		path, wantTitle, wantAuthor string
+	}{
+		{"/lib/girl_with_all_the_gifts/001-190 - The Girl with All the Gifts.mp3", "The Girl with All the Gifts", ""},
+		{"/lib/x/190-190 - The Girl with All the Gifts.mp3", "The Girl with All the Gifts", ""},
+		{"/lib/x/07 of 12 - Dune.m4b", "Dune", ""},
+		{"/lib/x/001-190 - The Girl with All the Gifts - M R Carey.mp3", "The Girl with All the Gifts", "M R Carey"},
+		// Titles that start with numbers are not counters.
+		{"/lib/x/1984 - George Orwell.epub", "1984", "George Orwell"},
+		{"/lib/x/11-22-63 - Stephen King.epub", "11-22-63", "Stephen King"},
+	}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			got := ParseFilename(c.path)
+			if got.Title != c.wantTitle || got.Author != c.wantAuthor {
+				t.Fatalf("ParseFilename(%q) = title %q author %q, want %q / %q", c.path, got.Title, got.Author, c.wantTitle, c.wantAuthor)
+			}
+		})
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -3463,7 +3463,10 @@ func (s *Scanner) refreshStaleRenderedPaths(ctx context.Context) {
 // this only suppresses the tag title when the folder hierarchy already resolved
 // a title to fall back to (see the caller), so the worst case is using the
 // folder's title for such a book rather than the tag's.
-var chapterTitleRe = regexp.MustCompile(`(?i)^(\d{1,3}\s*[-._]\s*\D|(chapter|track|part|disc|cd)\b\s*\.?\s*\d)`)
+// The last branch is a bare track counter with nothing else, "001-190" or
+// "07 of 12": some rips tag every track's title that way, and letting it win
+// over a folder-derived book title left every file unmatched (#2547).
+var chapterTitleRe = regexp.MustCompile(`(?i)^(\d{1,3}\s*[-._]\s*\D|(chapter|track|part|disc|cd)\b\s*\.?\s*\d|\d{1,4}\s*(?:-|/|of)\s*\d{1,4}$)`)
 
 // looksLikeChapterTitle reports whether an embedded-tag title looks like a
 // per-track chapter name rather than a book title (#1239).


### PR DESCRIPTION
Closes #2547.

`ParseFilename` split `001-190 - The Girl with All the Gifts` as title `001-190`, author `The Girl with All the Gifts`, so every track in a numbered rip was `no_title_match`.

- `trackCounterPrefixRe` strips a leading `NNN-TOTAL - ` / `NNN of TOTAL - ` before the split. Both numbers required, so `1984 - George Orwell` and `11-22-63 - Stephen King` are untouched (both pinned in the test).
- `chapterTitleRe` treats a bare counter as a chapter title, so a track tag of just `001-190` can't override the folder-derived title.

Fail-before: the parser test returns title `001-190`; the chapter-title test rejects all four counters. `go test ./internal/importer/` and `golangci-lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUzQ8XBez4cD68eS2FWsXP
