### PR TITLE
Add Previous/Next navigation across authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Cover images are fetched and cached server-side under `<dataDir>/image-cache/` (
 - Modern React 19 + TypeScript + Tailwind CSS SPA with search-first author acquisition and deep-linkable routed `/book/:id` and `/author/:id` pages.
 - Light / dark themes (respecting `prefers-color-scheme` first paint), grid / table view toggles, mobile-friendly responsive layout, hamburger nav, agenda-style mobile Calendar.
 - Full pagination, search, filter, and sort on every list page; preferences persist to `localStorage`.
+- Previous/Next navigation between authors on the author detail page, stepping through the list page you came from.
 - 8 languages — English, French, German, Dutch, Spanish, Filipino (Tagalog), Indonesian, Korean — auto-detected from the browser, override in Settings.
 - **OPDS 1.2 catalogue** at `/opds/` for KOReader, Moon+ Reader, and other reading apps. HTTP Basic auth with the API key as the password.
 

--- a/changelog.d/2548-author-nav-frontend.md
+++ b/changelog.d/2548-author-nav-frontend.md
@@ -1,0 +1,2 @@
+### Added
+- **Previous/Next navigation on the author detail page** (#2548) — step through the authors on the list page you came from, with no server round trip. Frontend-only: works within the currently loaded list page and doesn't survive a hard refresh or a direct link.

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -228,6 +228,12 @@
     "refreshMetadata": "Refresh metadata"
   },
   "authorDetail": {
+    "nav": {
+      "previous": "‹ Previous",
+      "next": "Next ›",
+      "previousAriaLabel": "Previous author",
+      "nextAriaLabel": "Next author"
+    },
     "description": {
       "showMore": "Show more",
       "showLess": "Show less"

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -94,7 +94,13 @@ function LocationProbe({ onLocation }: { onLocation?: (location: string) => void
   return null
 }
 
-function renderAuthorDetailPage(books: Book[], view: 'grid' | 'table' = 'grid', authorOverride: Partial<Author> = {}, initialPath = '/author/42', onLocation?: (location: string) => void) {
+function renderAuthorDetailPage(
+  books: Book[],
+  view: 'grid' | 'table' = 'grid',
+  authorOverride: Partial<Author> = {},
+  initialPath: string | { pathname: string; state?: unknown } = '/author/42',
+  onLocation?: (location: string) => void,
+) {
   localStorage.setItem('bindery.view.author-detail', view)
   vi.mocked(api.getAuthor).mockResolvedValue({ ...author, ...authorOverride })
   vi.mocked(api.listAllBooks).mockResolvedValue(books)
@@ -944,5 +950,68 @@ describe('AuthorDetailPage — last sync outcome', () => {
     renderAuthorDetailPage([makeBook({ id: 1, title: 'Only Book', status: 'imported' })])
     await screen.findByRole('heading', { name: 'Only Book' })
     expect(screen.queryByTestId('author-sync-notice')).toBeNull()
+  })
+})
+
+describe('AuthorDetailPage — Previous/Next navigation (#2548, frontend-only)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    installLocalStorageMock()
+    vi.mocked(api.listAuthorSeries).mockResolvedValue([])
+  })
+
+  it('hides the controls when there is no router state at all (opened from a Series tab, a bookmark, or after a refresh)', async () => {
+    renderAuthorDetailPage([])
+    await screen.findByText('Brandon Sanderson')
+    expect(screen.queryByLabelText('Previous author')).toBeNull()
+    expect(screen.queryByLabelText('Next author')).toBeNull()
+  })
+
+  it('renders Previous/Next from router state and follows Next to the right id, carrying the chain state', async () => {
+    let lastLocation = ''
+    renderAuthorDetailPage(
+      [], 'grid', {},
+      { pathname: '/author/42', state: { ids: [40, 42, 43, 44, 45], index: 1 } },
+      loc => { lastLocation = loc },
+    )
+    await screen.findByText('Brandon Sanderson')
+
+    fireEvent.click(screen.getByLabelText('Next author'))
+
+    await waitFor(() => expect(lastLocation).toBe('/author/43'))
+  })
+
+  it('hides Previous at the first position and shows only Next', async () => {
+    renderAuthorDetailPage([], 'grid', {}, { pathname: '/author/42', state: { ids: [42, 43], index: 0 } })
+    await screen.findByText('Brandon Sanderson')
+
+    expect(screen.queryByLabelText('Previous author')).toBeNull()
+    expect(screen.getByLabelText('Next author')).toBeInTheDocument()
+  })
+
+  it('hides the controls for a single-author list (both ends null)', async () => {
+    renderAuthorDetailPage([], 'grid', {}, { pathname: '/author/42', state: { ids: [42], index: 0 } })
+    await screen.findByText('Brandon Sanderson')
+    expect(screen.queryByLabelText('Previous author')).toBeNull()
+    expect(screen.queryByLabelText('Next author')).toBeNull()
+  })
+
+  it('ignores state that does not match this author (stale browser back/forward state)', async () => {
+    // ids[index] is 99, not 42 — a mismatch that must be treated as no
+    // navigation info rather than pointing at the wrong neighbour.
+    renderAuthorDetailPage([], 'grid', {}, { pathname: '/author/42', state: { ids: [98, 99, 100], index: 1 } })
+    await screen.findByText('Brandon Sanderson')
+    expect(screen.queryByLabelText('Previous author')).toBeNull()
+    expect(screen.queryByLabelText('Next author')).toBeNull()
+  })
+
+  it('Back always goes to the Authors list, not browser history', async () => {
+    let lastLocation = ''
+    renderAuthorDetailPage([], 'grid', {}, '/author/42', loc => { lastLocation = loc })
+    await screen.findByText('Brandon Sanderson')
+
+    fireEvent.click(screen.getByText('← Back'))
+
+    await waitFor(() => expect(lastLocation).toBe('/'))
   })
 })

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -63,6 +63,20 @@ function mediaLabel(mediaType?: Book['mediaType']): string {
   return '📖 Ebook'
 }
 
+// Previous/Next navigation (#2548), entirely client-side: AuthorsPage already
+// has its current page loaded and ordered, so it hands that over as router
+// `state` instead of this page re-fetching it. Not shared as an exported
+// type — AuthorsPage builds the same shape independently, same as the
+// seriesId router state between AuthorsPage and SeriesPage.
+//
+// Trade-off: only reaches as far as the loaded list page, and doesn't
+// survive a refresh or a direct link (router state is gone either way) —
+// Previous/Next just don't render then.
+interface AuthorNavState {
+  ids: number[]
+  index: number
+}
+
 export default function AuthorDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
@@ -195,6 +209,19 @@ export default function AuthorDetailPage() {
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [authorId, showExcluded])
+
+  // Validated against authorId: stale state (browser back/forward) or no
+  // state at all (opened from elsewhere) must read as "no nav info", not
+  // point at the wrong neighbour.
+  const navState = (() => {
+    const s = location.state as AuthorNavState | null
+    if (s && Array.isArray(s.ids) && typeof s.index === 'number' && s.ids[s.index] === authorId) {
+      return s
+    }
+    return null
+  })()
+  const prevId = navState && navState.index > 0 ? navState.ids[navState.index - 1] : null
+  const nextId = navState && navState.index < navState.ids.length - 1 ? navState.ids[navState.index + 1] : null
 
   useEffect(() => {
     const params = new URLSearchParams(location.search)
@@ -680,8 +707,25 @@ export default function AuthorDetailPage() {
     // One width shared with BookDetailPage — see the note there.
     <div className={`max-w-7xl ${selected.size > 0 ? 'pb-20' : ''}`}>
       {confirmDialog}
-      <div className="mb-4 flex items-center gap-3 text-sm">
-        <button onClick={() => navigate(-1)} className="text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">← Back</button>
+      <div className="mb-4 flex items-center justify-between gap-3 text-sm">
+        {/* Always the Authors list, not browser history, which can land
+            elsewhere (a Series tab, a search result, or, after following
+            Previous/Next a few times, one page short of the list). */}
+        <Link to="/" className="text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">← Back</Link>
+        {navState && (prevId !== null || nextId !== null) && (
+          <div className="flex items-center gap-2">
+            {prevId !== null && (
+              <Link to={`/author/${prevId}`} state={{ ids: navState.ids, index: navState.index - 1 }} aria-label={t('authorDetail.nav.previousAriaLabel', 'Previous author')} className={`${btn.ghost} ${btnSize.sm}`}>
+                {t('authorDetail.nav.previous', '‹ Previous')}
+              </Link>
+            )}
+            {nextId !== null && (
+              <Link to={`/author/${nextId}`} state={{ ids: navState.ids, index: navState.index + 1 }} aria-label={t('authorDetail.nav.nextAriaLabel', 'Next author')} className={`${btn.ghost} ${btnSize.sm}`}>
+                {t('authorDetail.nav.next', 'Next ›')}
+              </Link>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="flex flex-col sm:flex-row gap-6 mb-8">

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import AuthorsPage from './AuthorsPage'
 import { api } from '../api/client'
 import type { Series } from '../api/client'
@@ -668,5 +668,42 @@ describe('AuthorsPage — sortable column headers', () => {
     // always "—", because the field is `json:"statistics,omitempty"` and no
     // code ever set it on a row read back from SQLite.
     expect(await screen.findByText('12')).toBeInTheDocument()
+  })
+})
+
+describe('AuthorsPage — Previous/Next router state (#2548)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.listAuthors).mockResolvedValue({
+      items: [
+        { id: 7, authorName: 'Ursula K. Le Guin', foreignAuthorId: 'OL_U', monitored: true, averageRating: 0, imageUrl: '' },
+        { id: 8, authorName: 'Vernor Vinge', foreignAuthorId: 'OL_V', monitored: true, averageRating: 0, imageUrl: '' },
+      ] as never,
+      total: 2, limit: 50, offset: 0,
+    })
+  })
+
+  it('hands the whole loaded page as router state, so the detail page can step Previous/Next with no server round trip', async () => {
+    let capturedState: unknown = null
+    function StateProbe() {
+      capturedState = useLocation().state
+      return null
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<AuthorsPage />} />
+          <Route path="/author/:id" element={<StateProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    // Vernor Vinge is index 1 of the two-author fixture page — the state
+    // must carry both ids (for a further Next once there) and this row's
+    // own index (for AuthorDetailPage's ids[index] === authorId sanity check).
+    fireEvent.click(await screen.findByText('Vernor Vinge'))
+
+    await waitFor(() => expect(capturedState).toEqual({ ids: [7, 8], index: 1 }))
   })
 })

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -341,6 +341,11 @@ export default function AuthorsPage() {
   // outright and costing OpenLibrary users a real sort key.
   const anyRating = authors.some(a => a.averageRating > 0)
 
+  // This page's loaded ids, in order — handed to AuthorDetailPage as router
+  // state (#2548) for Previous/Next; see AuthorNavState there.
+  const authorIds = authors.map(a => a.id)
+  const authorNavState = (index: number) => ({ ids: authorIds, index })
+
   return (
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       {confirmDialog}
@@ -502,7 +507,7 @@ export default function AuthorsPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
-                {authors.map(author => (
+                {authors.map((author, i) => (
                   <tr
                     key={author.id}
                     className={`hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 ${selectedIds.has(author.id) ? 'bg-emerald-500/10 dark:bg-emerald-500/10' : 'bg-slate-100/50 dark:bg-zinc-900/50'}`}
@@ -517,7 +522,7 @@ export default function AuthorsPage() {
                       />
                     </td>
                     <td className="px-3 py-2">
-                      <Link to={`/author/${author.id}`} className="flex items-center gap-2">
+                      <Link to={`/author/${author.id}`} state={authorNavState(i)} className="flex items-center gap-2">
                         {author.imageUrl ? (
                           <img src={author.imageUrl} alt="" className="w-7 h-7 rounded-full object-cover flex-shrink-0" />
                         ) : (
@@ -560,7 +565,7 @@ export default function AuthorsPage() {
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {authors.map(author => (
+          {authors.map((author, i) => (
             <div
               key={author.id}
               className={`border rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden hover:border-emerald-500 transition-colors ${selectedIds.has(author.id) ? 'border-emerald-500' : 'border-slate-200 dark:border-zinc-800'}`}
@@ -573,7 +578,7 @@ export default function AuthorsPage() {
                   className={`absolute top-2 left-2 z-10 rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 ${selectedIds.has(author.id) ? '' : 'bg-white/80 dark:bg-zinc-900/80'}`}
                   title={`Select ${author.authorName}`}
                 />
-                <Link to={`/author/${author.id}`} className="flex gap-3 p-4 hover:bg-slate-200/40 dark:hover:bg-zinc-800/40 transition-colors">
+                <Link to={`/author/${author.id}`} state={authorNavState(i)} className="flex gap-3 p-4 hover:bg-slate-200/40 dark:hover:bg-zinc-800/40 transition-colors">
                   {author.imageUrl ? (
                     <img src={author.imageUrl} alt={author.authorName} className="w-16 h-16 rounded-full object-cover flex-shrink-0" />
                   ) : (


### PR DESCRIPTION
## Summary

Adds Previous/Next navigation on the author detail page, stepping through the authors on the list page you came from — no round trip back to the list to find your place. Frontend-only, per your comment on the issue. Part of #2548 (book side not included — see scope note below).

## Implementation notes

- `AuthorsPage` already loads its current page (in whatever search/sort/monitored order) into React state before a row is ever clicked, so no backend endpoint is needed: each author `Link` now carries `{ ids, index }` as router `state`, and `AuthorDetailPage` reads it back to render Previous/Next and step the chain (`index - 1` / `index + 1`) client-side.
- Not shared as an exported type between the two pages — each side builds/reads the same `{ ids, index }` shape independently, the same idiom already used for the series picker's `{ seriesId }` router state between `AuthorsPage` and `SeriesPage`.
- Kept deliberately minimal: no position counter, no disabled-button state at either end (a direction with nowhere to go simply isn't rendered), no client-side whitelist on the sort value — none of those were asked for, and the backend's `authorSortOrder()` already falls back safely on an unrecognized sort value.
- "← Back" goes to the Authors list only when there's Previous/Next nav state (i.e. you arrived via a list row or a chain hop) — a few hops through Next/Previous land one page short of where the list actually was, so history alone isn't enough there. With no nav state (Wanted, the Books list, a book page, a direct link) it falls back to `navigate(-1)`, so those flows land back where they came from instead of always on the Authors list.

## Review fixes

- The page stays mounted across Next/Previous (only the `:id` param changes), which leaked two bits of state between authors:
  - **Group-by-series data**: the lazy-load effect skipped refetching once `authorSeries` held *any* data, so hopping to a new author kept grouping its books against the previous author's series. Now tracked by a ref recording which author's series are loaded, so a new `authorId` always triggers a refetch.
  - **Error banner**: an error from the previous author (e.g. a failed load) stayed visible after hopping to the next one. The load effect now clears it before each fetch.

## Why minimal / scope decisions

- **Trade-off, accepted deliberately:** this only reaches as far as the currently loaded list page (its own page size), and does not survive a hard refresh or a direct link — router state is gone in both cases, and the controls simply don't render then, same as when opened from somewhere that never set the state.
- **Filter preservation on Back is a separate PR** (not included here): carrying the list's search/sort/monitored filter across Back and the Previous/Next chain is a related-but-distinct fix with its own code path, kept out to match "one branch, one change."
- **Book side of #2548 is out of scope for this PR** (per review) — not marking this as closing the issue since only the author half is done here.

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` — n/a, no env vars/config/upgrade-path changes
- [x] Added a changelog fragment under `changelog.d/`
- [x] Wiki pages — n/a, no wiki page covers per-page list-navigation UX

## Test plan

- [x] `cd web && npx tsc --noEmit`
- [x] `cd web && npm run lint`
- [x] `cd web && npm test` (871 tests)
- [x] `cd web && npm run build`

No Go files changed in this PR.
